### PR TITLE
fix: Set EasyOCR gpu=False for CPU compatibility (fixes #54)

### DIFF
--- a/software_side/walkbuddy_reactNative/backend/main.py
+++ b/software_side/walkbuddy_reactNative/backend/main.py
@@ -110,8 +110,8 @@ async def lifespan(app: FastAPI):
     # --- load EasyOCR ---
     try:
         logger.info("Loading EasyOCR reader")
-        app.state.ocr_reader = easyocr.Reader(["en"], gpu=True)
-        logger.info("✅ EasyOCR ready")
+        app.state.ocr_reader = easyocr.Reader(["en"], gpu=False)
+        logger.info("✅ EasyOCR ready (CPU mode)")
     except Exception as e:
         logger.error(f"❌ EasyOCR load failed: {e}")
         app.state.ocr_reader = None


### PR DESCRIPTION
## Fix Summary

**Issue:** #54 - easyocr.Reader is initialized with gpu=True hardcoded, causing the backend to crash on CPU-only systems.

**Root Cause:** The easyocr.Reader(['en'], gpu=True) call fails on systems without a compatible GPU, since CUDA is not available.

**Fix:**
- Changed gpu=True to gpu=False in software_side/walkbuddy_reactNative/backend/main.py
- Updated the log message to indicate EasyOCR is running in CPU mode

This allows the app to run on any system regardless of GPU availability.

---
Fixes #54