### PR TITLE
fix: replace hardcoded developer IP fallback with localhost (#53)

### DIFF
--- a/ONBOARDING_CHECK.txt
+++ b/ONBOARDING_CHECK.txt
@@ -9,3 +9,4 @@ Add your details on a new line below in this format:
 Name | Student ID | GitHub Username
 ------------------------------------------------------------
 Auritro Sami | s226219941 | AuritroS
+Zehong Li | s223926313 | ZeL1218

--- a/software_side/walkbuddy_reactNative/frontend_reactNative/src/config.ts
+++ b/software_side/walkbuddy_reactNative/frontend_reactNative/src/config.ts
@@ -3,6 +3,7 @@ import { Platform } from "react-native";
 
 // If EXPO_PUBLIC_API_BASE is set (e.g. a Cloudflare tunnel URL for hotspot use),
 // use it. Otherwise derive the backend host from Metro's LAN IP automatically.
+//Now can override API base URL using EXPO_PUBLIC_API_BASE
 const tunnelOverride = process.env.EXPO_PUBLIC_API_BASE;
 
 const lanHost = Constants.expoConfig?.hostUri?.split(":")[0];
@@ -14,4 +15,4 @@ export const API_BASE =
     ? "http://localhost:8000"
     : isIp(lanHost)
       ? `http://${lanHost}:8000`
-      : "http://172.20.10.2:8000");
+      : "http://localhost:8000");


### PR DESCRIPTION
Replaced hardcoded developer IP with localhost:8000 and kept EXPO_PUBLIC_API_BASE override.
fixes #53  