### PR TITLE
fix: replace hardcoded IP with localhost in config.ts

### DIFF
--- a/software_side/walkbuddy_reactNative/frontend_reactNative/src/config.ts
+++ b/software_side/walkbuddy_reactNative/frontend_reactNative/src/config.ts
@@ -14,4 +14,4 @@ export const API_BASE =
     ? "http://localhost:8000"
     : isIp(lanHost)
       ? `http://${lanHost}:8000`
-      : "http://172.20.10.2:8000");
+      : "http://localhost:8000");


### PR DESCRIPTION
## Description

Fixes #53 - config.ts contains hardcoded developer IP 172.20.10.2:8000 which causes connection issues for other users.

**Problem:**
- Line 17 in config.ts has hardcoded IP 172.20.10.2:8000
- This prevents other users from connecting

**Solution:**
- Changed hardcoded IP to localhost:8000
- Environment variable EXPO_PUBLIC_API_BASE takes precedence if set

## Changes

- Modified: software_side/walkbuddy_reactNative/frontend_reactNative/src/config.ts

## Testing

- Verified build passes after change

---

Checklist:

- [x] I have read and followed the contribution guidelines
- [x] I have tested these changes locally
- [x] My PR targets the main branch

Closes #53