### PR TITLE
fix: replace hardcoded greeting with dynamic displayName from SessionContext

### DIFF
--- a/software_side/walkbuddy_reactNative/frontend_reactNative/app/(tabs)/index.tsx
+++ b/software_side/walkbuddy_reactNative/frontend_reactNative/app/(tabs)/index.tsx
@@ -17,10 +17,19 @@ import Icon from "react-native-vector-icons/FontAwesome";
 import HomeHeader from "../HomeHeader";
 import ModelWebView from "../../src/components/ModelWebView";
 import { API_BASE } from "../../src/config";
+import { useSession } from "../SessionContext";
 
 export default function HomePage() {
   const router = useRouter();
   const { width } = useWindowDimensions();
+  const { auth } = useSession();
+
+  const displayName = useMemo(() => {
+    if (auth.status === "loggedInWithProfile" && auth.profile.displayName) {
+      return auth.profile.displayName;
+    }
+    return "there";
+  }, [auth]);
 
   const [visionEnabled, setVisionEnabled] = useState(true);
   const [visionPreviewOn, setVisionPreviewOn] = useState(false);
@@ -91,7 +100,7 @@ export default function HomePage() {
     <SafeAreaView style={styles.screen}>
       <View style={[styles.content, { width: contentWidth }]}>
         <HomeHeader
-          greeting="Hi Daniel"
+          greeting={`Hi ${displayName}`}
           appTitle="WalkBuddy"
           onPressProfile={goToAccount}
           showDivider


### PR DESCRIPTION
## Description

The Home page had a hardcoded greeting "Hi Daniel" in the HomeHeader component. This PR replaces the hardcoded greeting with a dynamic greeting that uses the displayName from SessionContext.

- If the user is logged in with a profile (status: "loggedInWithProfile"), the greeting shows "Hi {displayName}"
- Otherwise, it defaults to "Hi there"

## Changes

- Modified: software_side/walkbuddy_reactNative/frontend_reactNative/app/(tabs)/index.tsx
  - Added import for useSession from SessionContext
  - Added useSession() hook call in HomePage component
  - Added displayName computation using useMemo
  - Replaced hardcoded greeting="Hi Daniel" with dynamic greeting={\Hi \\}

## Testing

- Verified TypeScript types are correct
- The change is minimal and follows the existing patterns in the codebase
- Component will render "Hi there" when user is not logged in or has no profile
- Component will render "Hi {displayName}" when user is logged in with profile

---

Checklist:

- [x] I have read and followed the contribution guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

Closes #51