### PR TITLE
Fix broken API endpoint URLs in client.ts

### DIFF
--- a/software_side/walkbuddy_reactNative/frontend_reactNative/src/api/client.ts
+++ b/software_side/walkbuddy_reactNative/frontend_reactNative/src/api/client.ts
@@ -31,7 +31,7 @@ export async function detectObject(imageBlob: Blob): Promise<{ events: Detection
   // React Native's FormData handling needs explicit type for file
   formData.append("file", imageBlob as any, "frame.jpg");
 
-  const res = await fetch(`${API_BASE}/detect`, {
+  const res = await fetch(`${API_BASE}/vision`, {
     method: "POST",
     body: formData,
     headers: {
@@ -54,7 +54,7 @@ export async function askTwoBrain(
   formData.append("file", imageBlob as any, "frame.jpg");
   formData.append("question", question);
 
-  const res = await fetch(`${API_BASE}/two_brain`, {
+  const res = await fetch(`${API_BASE}/chat`, {
     method: "POST",
     body: formData,
     headers: {


### PR DESCRIPTION
## Summary

This PR fixes the API endpoint URLs in the frontend API client to match the backend API contract.

## Changes

- Replace `/detect` with `/vision` in `client.ts` (line 29)
- Replace `/two_brain` with `/chat` in `client.ts` (line 45)

## Background

According to the backend README API Reference section:
- The backend exposes `/vision` for YOLO object detection (not `/detect`)
- The backend exposes `/chat` for LLM queries (not `/two_brain`)

The frontend `client.ts` was calling routes that do not exist, causing 404 errors at runtime.

## Acceptance Criteria

- ✅ `/detect` is replaced with `/vision` in `client.ts`
- ✅ `/two_brain` is replaced with `/chat` in `client.ts`
- ✅ No other phantom endpoint URLs remain in `client.ts`
- ✅ The backend README was checked before making changes

Fixes #49