### PR TITLE
fix: restrict CORS origins using env variable (fixes #56)

### DIFF
--- a/software_side/walkbuddy_reactNative/backend/README.md
+++ b/software_side/walkbuddy_reactNative/backend/README.md
@@ -590,3 +590,4 @@ Model weights are mounted from `ML_side/models/` — ensure both `best.pt` and t
 | `PYTTSX3_DRIVER`              | (system default)             | TTS backend (`espeak` in Docker)                               |
 | `TTS_RATE`                    | (pyttsx3 default)            | Speech rate (`170` in Docker)                                  |
 | `LIBRIVOX_VERIFY_SSL`         | `1`                          | Set to `0` to disable SSL verification for LibriVox (dev only) |
+| `WALKBUDDY_ALLOWED_ORIGINS`   | `http://localhost:8081,http://localhost:8000` | Comma-separated list of allowed origins for CORS |

--- a/software_side/walkbuddy_reactNative/backend/main.py
+++ b/software_side/walkbuddy_reactNative/backend/main.py
@@ -152,9 +152,19 @@ app = FastAPI(
 # =========================
 # 7. MIDDLEWARE
 # =========================
+origins_env = os.getenv("WALKBUDDY_ALLOWED_ORIGINS")
+
+if origins_env:
+    allow_origins = [origin.strip() for origin in origins_env.split(",")]
+else:
+    allow_origins = [
+        "http://localhost:8081",
+        "http://localhost:8000"
+    ]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins = allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
Fix insecure CORS configuration.

- Replace allow_origins=["*"] with environment variable
- Add default localhost origins for development
- Update README with WALKBUDDY_ALLOWED_ORIGINS

Fixes #56