### PR TITLE
fix: write computed direction into navigation memory (fixes #59)

### DIFF
--- a/software_side/walkbuddy_reactNative/backend/adapters/vision_adapter.py
+++ b/software_side/walkbuddy_reactNative/backend/adapters/vision_adapter.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from ultralytics import YOLO
 from opentelemetry import trace
+from tts_service.message_reasoning import calculate_spatial_position # reuse existing direction logic
 
 tracer = trace.get_tracer("vision.adapter")
 
@@ -16,6 +17,9 @@ def vision_adapter(model: YOLO, image_path: str) -> dict:
 
     result = results[0]
     detections = []
+    
+    # get image width for direction calculation
+    image_height, image_width = result.orig_shape[:2]
 
     if result.boxes:
         for box in result.boxes:
@@ -24,15 +28,21 @@ def vision_adapter(model: YOLO, image_path: str) -> dict:
             cls_id = int(box.cls[0])
             label = result.names[cls_id]
 
+            bbox = {
+                "x_min": int(coords[0]),
+                "y_min": int(coords[1]),
+                "x_max": int(coords[2]),
+                "y_max": int(coords[3]),
+            }
+
+            # compute left/right/ahead
+            direction = calculate_spatial_position(bbox, image_width) 
+
             detections.append({
                 "category": label,
                 "confidence": round(conf, 3),
-                "bbox": {
-                    "x_min": int(coords[0]),
-                    "y_min": int(coords[1]),
-                    "x_max": int(coords[2]),
-                    "y_max": int(coords[3]),
-                },
+                "bbox": bbox,
+                "direction": direction, # store computed direction instead of hardcoded value
             })
 
     detections.sort(key=lambda x: x["confidence"], reverse=True)

--- a/software_side/walkbuddy_reactNative/backend/routers/ai_service.py
+++ b/software_side/walkbuddy_reactNative/backend/routers/ai_service.py
@@ -36,7 +36,7 @@ async def vision_endpoint(request: Request, file: UploadFile = File(...)):
         for d in result["detections"]:
             state.memory.add_event(
                 label=d["category"],
-                direction="ahead",
+                direction = d.get("direction", "ahead"), # using computed direction instead of ahead
                 distance_m=None,
                 confidence=d["confidence"],
             )


### PR DESCRIPTION
Write computed direction into NavigationMemory.

- Compute direction from bounding box position
- Replace hardcoded "ahead" in memory storage
- Keep existing TTS guidance unchanged

fixes #59