### PR TITLE
fix: store OCR detections in navigation memory (fixes #57)

### DIFF
--- a/software_side/walkbuddy_reactNative/backend/routers/ai_service.py
+++ b/software_side/walkbuddy_reactNative/backend/routers/ai_service.py
@@ -74,6 +74,14 @@ async def ocr_endpoint(request: Request, file: UploadFile = File(...)):
                 temp_path,
             )
 
+        for d in result["detections"]:
+            state.memory.add_event(
+                label=f"text: {d['category']}",
+                direction="ahead",
+                distance_m=None,
+                confidence=d["confidence"],
+            )
+
         texts = [d["category"] for d in result["detections"]]
         return {
             "detections": result["detections"],


### PR DESCRIPTION
- Added storage of OCR detections to NavigationMemory in /ocr endpoint.
- Previously OCR results were not available to the LLM during /chat.
- Now each detected text is stored following the same structure as vision detections.

fixes #57