### PR TITLE
feat(ml): extract depth proxy module from notebook for #66

### DIFF
--- a/ML_side/depth/__init__.py
+++ b/ML_side/depth/__init__.py
@@ -1,0 +1,13 @@
+"""Depth proxy helpers extracted from the cohort-2 notebook."""
+
+from .depth_estimator import (
+    baseline_depth_score,
+    estimate_depth,
+    improved_depth_score,
+)
+
+__all__ = [
+    "baseline_depth_score",
+    "estimate_depth",
+    "improved_depth_score",
+]

--- a/ML_side/depth/demo_depth_estimator.py
+++ b/ML_side/depth/demo_depth_estimator.py
@@ -1,0 +1,32 @@
+"""Simple demo for the extracted depth proxy module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+
+ML_SIDE_ROOT = Path(__file__).resolve().parents[1]
+if str(ML_SIDE_ROOT) not in sys.path:
+    sys.path.insert(0, str(ML_SIDE_ROOT))
+
+from depth.depth_estimator import estimate_depth
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    sample_image = repo_root / "ML_side" / "testing_pipeline" / "test_assets" / "test.png"
+
+    result = estimate_depth(
+        sample_image,
+        bounding_boxes=[
+            {"x_min": 40, "y_min": 50, "x_max": 180, "y_max": 310},
+            {"x_min": 250, "y_min": 110, "x_max": 370, "y_max": 240},
+        ],
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/ML_side/depth/depth_estimator.py
+++ b/ML_side/depth/depth_estimator.py
@@ -1,0 +1,239 @@
+"""Notebook-free depth proxy utilities for ML-side integration.
+
+This module extracts the relative depth proxy logic from
+`ML_side/notebooks/cohort-2/04_training_and_depth_estimation.ipynb` into a
+plain Python module that can be imported by scripts or backend code.
+
+Public API:
+    estimate_depth(image, bounding_boxes=None, alpha=0.7, beta=0.3)
+
+Args:
+    image:
+        Either a NumPy array with shape `(H, W)` or `(H, W, C)`, or a file path
+        to a PNG or JPEG image.
+    bounding_boxes:
+        Optional iterable of pixel-coordinate boxes. Each box may be either a
+        mapping with keys `x_min`, `y_min`, `x_max`, `y_max`, or a 4-item
+        sequence in that order.
+    alpha:
+        Weight for box-height contribution in the improved score.
+    beta:
+        Weight for vertical-position contribution in the improved score.
+
+Returns:
+    A dictionary with image dimensions, the relative unit name, and one depth
+    proxy record per bounding box. Each box record contains the original bbox,
+    `baseline_depth_score`, and `improved_depth_score`.
+
+Notes:
+    - Scores are relative proxy values, not metric distances in metres.
+    - This module does not produce a full depth map.
+    - No model weights are required for this v1 implementation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import struct
+from typing import Any, Iterable, Mapping, Sequence
+
+import numpy as np
+
+
+BoundingBoxInput = Mapping[str, Any] | Sequence[float]
+
+
+def baseline_depth_score(box_height_px: float, img_height_px: int) -> float:
+    """Baseline depth proxy: larger boxes are assumed closer."""
+    _validate_positive_image_height(img_height_px)
+    return float(box_height_px) / float(img_height_px)
+
+
+def improved_depth_score(
+    box_height_px: float,
+    box_center_y_px: float,
+    img_height_px: int,
+    alpha: float = 0.7,
+    beta: float = 0.3,
+) -> float:
+    """Improved proxy: combine size and vertical position cues."""
+    _validate_positive_image_height(img_height_px)
+    size_score = float(box_height_px) / float(img_height_px)
+    position_score = float(box_center_y_px) / float(img_height_px)
+    return alpha * size_score + beta * position_score
+
+
+def estimate_depth(
+    image: np.ndarray | str | Path,
+    bounding_boxes: Iterable[BoundingBoxInput] | None = None,
+    *,
+    alpha: float = 0.7,
+    beta: float = 0.3,
+) -> dict[str, Any]:
+    """Estimate relative depth proxy scores for bounding boxes in an image.
+
+    The function accepts an image array or image file path and returns relative
+    depth proxy scores for each supplied box. If no boxes are supplied, the
+    function still returns image metadata with an empty `boxes` list.
+    """
+    image_height, image_width = _image_dimensions(image)
+    results = []
+
+    for index, raw_box in enumerate(bounding_boxes or ()):
+        box = _normalize_bounding_box(raw_box)
+        box_height_px = box["y_max"] - box["y_min"]
+        box_center_y_px = (box["y_min"] + box["y_max"]) / 2.0
+        results.append(
+            {
+                "index": index,
+                "bbox": box,
+                "baseline_depth_score": baseline_depth_score(
+                    box_height_px,
+                    image_height,
+                ),
+                "improved_depth_score": improved_depth_score(
+                    box_height_px,
+                    box_center_y_px,
+                    image_height,
+                    alpha=alpha,
+                    beta=beta,
+                ),
+            }
+        )
+
+    return {
+        "image_width": image_width,
+        "image_height": image_height,
+        "unit": "relative_depth_score",
+        "depth_map": None,
+        "boxes": results,
+    }
+
+
+def _validate_positive_image_height(img_height_px: int) -> None:
+    if img_height_px <= 0:
+        raise ValueError("img_height_px must be greater than zero")
+
+
+def _image_dimensions(image: np.ndarray | str | Path) -> tuple[int, int]:
+    if isinstance(image, np.ndarray):
+        if image.ndim < 2:
+            raise ValueError("image array must have at least 2 dimensions")
+        return int(image.shape[0]), int(image.shape[1])
+
+    image_path = Path(image)
+    if not image_path.exists():
+        raise FileNotFoundError(f"Image not found: {image_path}")
+
+    image_type = _detect_image_type(image_path)
+    if image_type == "png":
+        return _png_dimensions(image_path)
+    if image_type == "jpeg":
+        return _jpeg_dimensions(image_path)
+
+    raise ValueError(
+        f"Unsupported image format for {image_path}. Only PNG and JPEG are supported."
+    )
+
+
+def _detect_image_type(image_path: Path) -> str | None:
+    with image_path.open("rb") as file_obj:
+        header = file_obj.read(16)
+
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    if header.startswith(b"\xff\xd8"):
+        return "jpeg"
+    return None
+
+
+def _png_dimensions(image_path: Path) -> tuple[int, int]:
+    with image_path.open("rb") as file_obj:
+        signature = file_obj.read(24)
+    if len(signature) < 24 or signature[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError(f"Invalid PNG file: {image_path}")
+    width, height = struct.unpack(">II", signature[16:24])
+    return int(height), int(width)
+
+
+def _jpeg_dimensions(image_path: Path) -> tuple[int, int]:
+    with image_path.open("rb") as file_obj:
+        if file_obj.read(2) != b"\xff\xd8":
+            raise ValueError(f"Invalid JPEG file: {image_path}")
+
+        while True:
+            marker_prefix = file_obj.read(1)
+            if not marker_prefix:
+                break
+            if marker_prefix != b"\xff":
+                continue
+
+            marker_type = file_obj.read(1)
+            while marker_type == b"\xff":
+                marker_type = file_obj.read(1)
+            if not marker_type:
+                break
+
+            if marker_type in {b"\xd8", b"\xd9"}:
+                continue
+
+            segment_length_bytes = file_obj.read(2)
+            if len(segment_length_bytes) != 2:
+                break
+            segment_length = struct.unpack(">H", segment_length_bytes)[0]
+            if segment_length < 2:
+                raise ValueError(f"Corrupt JPEG segment in {image_path}")
+
+            if marker_type in {
+                b"\xc0",
+                b"\xc1",
+                b"\xc2",
+                b"\xc3",
+                b"\xc5",
+                b"\xc6",
+                b"\xc7",
+                b"\xc9",
+                b"\xca",
+                b"\xcb",
+                b"\xcd",
+                b"\xce",
+                b"\xcf",
+            }:
+                data = file_obj.read(5)
+                if len(data) != 5:
+                    break
+                _, height, width = struct.unpack(">BHH", data)
+                return int(height), int(width)
+
+            file_obj.seek(segment_length - 2, 1)
+
+    raise ValueError(f"Could not determine JPEG dimensions for {image_path}")
+
+
+def _normalize_bounding_box(raw_box: BoundingBoxInput) -> dict[str, int]:
+    if isinstance(raw_box, Mapping):
+        try:
+            x_min = raw_box["x_min"]
+            y_min = raw_box["y_min"]
+            x_max = raw_box["x_max"]
+            y_max = raw_box["y_max"]
+        except KeyError as exc:
+            raise ValueError(
+                "Bounding box mapping must contain x_min, y_min, x_max, y_max"
+            ) from exc
+    else:
+        if len(raw_box) != 4:
+            raise ValueError("Bounding box sequence must contain four values")
+        x_min, y_min, x_max, y_max = raw_box
+
+    box = {
+        "x_min": int(round(float(x_min))),
+        "y_min": int(round(float(y_min))),
+        "x_max": int(round(float(x_max))),
+        "y_max": int(round(float(y_max))),
+    }
+
+    if box["x_max"] <= box["x_min"] or box["y_max"] <= box["y_min"]:
+        raise ValueError("Bounding box must have positive width and height")
+
+    return box

--- a/ML_side/tests/conftest.py
+++ b/ML_side/tests/conftest.py
@@ -1,5 +1,8 @@
 import sys
 import os
 
+# Add ML_side root to path so tests can import local packages such as depth.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 # Add deployment folder to path so test_api.py can import api.py
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "deployment")))

--- a/ML_side/tests/test_depth_estimator.py
+++ b/ML_side/tests/test_depth_estimator.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from depth.depth_estimator import (
+    baseline_depth_score,
+    estimate_depth,
+    improved_depth_score,
+)
+
+
+def test_baseline_depth_score_matches_notebook_formula():
+    assert baseline_depth_score(120, 480) == pytest.approx(0.25)
+
+
+def test_improved_depth_score_matches_notebook_formula():
+    score = improved_depth_score(120, 300, 480, alpha=0.7, beta=0.3)
+    expected = 0.7 * (120 / 480) + 0.3 * (300 / 480)
+    assert score == pytest.approx(expected)
+
+
+def test_estimate_depth_accepts_numpy_image_and_mapping_boxes():
+    image = np.zeros((480, 640, 3), dtype=np.uint8)
+    result = estimate_depth(
+        image,
+        bounding_boxes=[{"x_min": 10, "y_min": 50, "x_max": 110, "y_max": 290}],
+    )
+
+    assert result["image_height"] == 480
+    assert result["image_width"] == 640
+    assert result["unit"] == "relative_depth_score"
+    assert result["depth_map"] is None
+    assert len(result["boxes"]) == 1
+    assert result["boxes"][0]["baseline_depth_score"] == pytest.approx(240 / 480)
+
+
+def test_estimate_depth_accepts_sequence_boxes():
+    image = np.zeros((200, 300), dtype=np.uint8)
+    result = estimate_depth(image, bounding_boxes=[(5, 20, 25, 120)])
+
+    assert result["boxes"][0]["bbox"] == {
+        "x_min": 5,
+        "y_min": 20,
+        "x_max": 25,
+        "y_max": 120,
+    }
+
+
+def test_estimate_depth_supports_png_file_paths():
+    repo_root = Path(__file__).resolve().parents[2]
+    image_path = repo_root / "ML_side" / "testing_pipeline" / "test_assets" / "test.png"
+
+    result = estimate_depth(
+        image_path,
+        bounding_boxes=[{"x_min": 0, "y_min": 0, "x_max": 100, "y_max": 200}],
+    )
+
+    assert result["image_height"] > 0
+    assert result["image_width"] > 0
+    assert result["boxes"][0]["improved_depth_score"] > 0
+
+
+def test_estimate_depth_returns_empty_boxes_when_none_supplied():
+    image = np.zeros((100, 150, 3), dtype=np.uint8)
+    result = estimate_depth(image)
+    assert result["boxes"] == []
+
+
+def test_estimate_depth_rejects_invalid_array_shape():
+    with pytest.raises(ValueError, match="at least 2 dimensions"):
+        estimate_depth(np.array([1, 2, 3]))
+
+
+def test_estimate_depth_rejects_missing_box_keys():
+    image = np.zeros((100, 150, 3), dtype=np.uint8)
+    with pytest.raises(ValueError, match="x_min"):
+        estimate_depth(image, bounding_boxes=[{"x_min": 1, "y_min": 2, "x_max": 5}])
+
+
+def test_estimate_depth_rejects_invalid_box_geometry():
+    image = np.zeros((100, 150, 3), dtype=np.uint8)
+    with pytest.raises(ValueError, match="positive width and height"):
+        estimate_depth(image, bounding_boxes=[(10, 20, 10, 30)])


### PR DESCRIPTION
## Summary

  This PR extracts the cohort-2 depth estimation notebook logic into a
  standalone Python module that can be imported outside Jupyter and reused by
  downstream backend work.

  ## What is implemented

  - Added a reusable depth package under ML_side/depth/
  - Added estimate_depth(...) as the public API
  - Extracted the notebook’s relative depth proxy heuristics into code:
      - baseline_depth_score(...)
      - improved_depth_score(...)
  - Supported image input as:
      - NumPy array
      - PNG/JPEG file path
  - Supported bounding box input as:
      - dicts with x_min, y_min, x_max, y_max
      - 4-value sequences in that order
  - Added module-level docstrings describing:
      - inputs
      - outputs
      - limitations
      - model-weight requirements
  - Added a simple demo script using the existing sample image asset

  ## What is tested

  - Importability without Jupyter
  - Baseline depth score formula
  - Improved depth score formula
  - NumPy image input handling
  - PNG file path input handling
  - Bounding box normalization from dict and sequence inputs
  - Empty bounding box list handling
  - Invalid image input rejection
  - Invalid bounding box rejection

  Verification run:

  - pytest ML_side/tests -q
  - Result: 77 passed

  ## What is not implemented

  - No metric distance estimation in metres
  - No full depth map generation
  - No monocular depth model inference
  - No backend /vision integration yet
  - No replacement of the current backend proximity heuristic yet
  - No external model weights added, because this implementation is based on the
    notebook’s existing proxy logic rather than a learned depth model

  ## Notes

  The source notebook currently implements a depth proxy heuristic, not true
  depth estimation. This PR preserves that behavior in a reusable module so
  issue #73 can integrate it cleanly afterward.
