### PR TITLE
docs: add Teams setup asset location

### DIFF
--- a/BASELINE.md
+++ b/BASELINE.md
@@ -40,6 +40,12 @@ Information is labelled as:
 
 Some runtime files are not stored in GitHub and must be downloaded from Teams or SharePoint.
 
+For easier team access, copies of the required runtime files are shared in the project Teams folder:
+
+`T2 2026 Setup Assets`
+
+The original `AIAND_REPO` location remains the archive source. Do not place the private Teams sharing link inside this public repository.
+
 Known SharePoint location:
 
 `AIAND_REPO/ML_side/2026 Trimester 1/models/v1`

--- a/docs/LOCAL_SETUP.md
+++ b/docs/LOCAL_SETUP.md
@@ -67,15 +67,21 @@ The following runtime files are not stored in GitHub:
 
 Known SharePoint location:
 
-```text
-AIAND_REPO/ML_side/2026 Trimester 1/models/v1
-```
+### Where to download the model files
+
+For easier access, the required files are shared in the project Teams chat inside:
+
+`T2 2026 Setup Assets`
+
+The folder link is shared or pinned in Teams.
+
+The original archive location remains:
+
+`AIAND_REPO/ML_side/2026 Trimester 1/models/v1`
 
 Download both files and place them in:
 
-```text
-ML_side/models/
-```
+`ML_side/models/`
 
 Do not rename or commit them.
 


### PR DESCRIPTION
## Summary

- documents the new `T2 2026 Setup Assets` Teams folder
- keeps AIAND_REPO recorded as the original archive location
- directs members to place both runtime files in `ML_side/models`
- avoids exposing the private Teams sharing link in the public repository