### PR TITLE
feat(ml): add active model metadata inspector

### DIFF
--- a/ML_side/models/README.md
+++ b/ML_side/models/README.md
@@ -12,4 +12,68 @@ This directory uses the **v1** models stored in SharePoint at:
 
 These files are not tracked in git. Download them from the SharePoint path above and place them in this directory before running inference.
 
+## Verified Active Model Artifact
+
+The following record applies only to the local artifact whose SHA-256 checksum
+matches this value:
+
+- File: `ML_side/models/best.pt`
+- File size: 6,244,458 bytes
+- SHA-256:
+  `198df54da4f6aa071b342bee77b100e78f243df785b325ec364036e106572238`
+- Verified class count: 7
+- Verified `model.names` mapping:
+  - 0: `book`
+  - 1: `books`
+  - 2: `monitor`
+  - 3: `office-chair`
+  - 4: `whiteboard`
+  - 5: `table`
+  - 6: `tv`
+
+The repository configuration lists an eighth class, `couch`, but `couch` is not
+present in this specific `best.pt` artifact. This suggests that the active model
+artifact and repository training configuration may come from different versions
+or training runs; the cause has not yet been confirmed. Members must compare
+the SHA-256 checksum before assuming their local `best.pt` is the same artifact.
+
+Do not modify or replace the model as part of this task. Resolving the
+model/configuration lineage mismatch is separate follow-up work.
+
+## Inspecting Active Model Metadata
+
+`ML_side/tools/inspect_active_model.py` is a read-only utility for verifying the
+local `best.pt` file's resolved path, file size, SHA-256 checksum, and
+`model.names` class mapping. It does not download, train, export, replace, or
+otherwise modify a model.
+
+Run it from the repository root after creating the backend virtual environment
+by following `docs/LOCAL_SETUP.md`:
+
+```powershell
+& ".\software_side\walkbuddy_reactNative\backend\.venv\Scripts\python.exe" ".\ML_side\tools\inspect_active_model.py"
+```
+
+On macOS or Linux, use a backend virtual environment with Ultralytics installed:
+
+```bash
+software_side/walkbuddy_reactNative/backend/.venv/bin/python ML_side/tools/inspect_active_model.py
+```
+
+Pass a local model path to inspect a different file:
+
+```text
+python ML_side/tools/inspect_active_model.py /path/to/model.pt
+```
+
+The repository training configuration does not prove that a locally supplied
+`best.pt` has the same class mapping. Inspect metadata locally before relying on
+the model's labels in ML, deployment, or safety work.
+
+> **Warning:** Never commit model weights, including `.pt`, `.tflite`, or
+> `.gguf` files.
+>
+> **Security warning:** Inspect `.pt` files only when they come from a trusted
+> project source, because loading model weights involves model deserialization.
+
 Maintenance: Update this README whenever the active model changes — include the new version, SharePoint path, and file list.

--- a/ML_side/tests/test_inspect_active_model.py
+++ b/ML_side/tests/test_inspect_active_model.py
@@ -1,0 +1,117 @@
+"""Tests for the read-only active-model metadata inspector."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import inspect_active_model as inspector
+
+
+class FakeModel:
+    def __init__(self, names: object) -> None:
+        self.names = names
+
+
+def test_calculate_sha256_and_format_class_map(tmp_path: Path) -> None:
+    model_path = tmp_path / "sample.pt"
+    model_path.write_bytes(b"walkbuddy")
+
+    assert inspector.calculate_sha256(model_path) == hashlib.sha256(
+        b"walkbuddy"
+    ).hexdigest()
+    assert (
+        inspector.format_class_map({0: "book", 2: "couch"})
+        == "  0: book\n  2: couch"
+    )
+
+
+def test_inspect_model_reports_metadata_with_mocked_loader(tmp_path: Path) -> None:
+    model_path = tmp_path / "sample.pt"
+    model_path.write_bytes(b"walkbuddy")
+
+    metadata = inspector.inspect_model(
+        model_path,
+        yolo_loader=lambda path: FakeModel({2: "couch", 0: "book"}),
+    )
+
+    assert metadata.path == model_path.resolve()
+    assert metadata.size_bytes == len(b"walkbuddy")
+    assert metadata.class_names == {0: "book", 2: "couch"}
+    assert inspector.format_metadata(metadata).splitlines() == [
+        f"Resolved model path: {model_path.resolve()}",
+        "File size in bytes: 9",
+        f"SHA-256 checksum: {hashlib.sha256(b'walkbuddy').hexdigest()}",
+        "Number of classes: 2",
+        "Class ID-to-name mapping:",
+        "  0: book",
+        "  2: couch",
+    ]
+
+
+def test_main_reports_a_missing_model_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = inspector.main([str(tmp_path / "missing.pt")])
+
+    assert result == 1
+    assert "Model file is missing:" in capsys.readouterr().err
+
+
+def test_main_reports_a_path_that_is_not_a_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = inspector.main([str(tmp_path)])
+
+    assert result == 1
+    assert "Model path is not a file:" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "names",
+    (
+        None,
+        {},
+        {"not-an-id": "book"},
+        {0: ""},
+    ),
+)
+def test_malformed_model_names_are_rejected(tmp_path: Path, names: object) -> None:
+    model_path = tmp_path / "sample.pt"
+    model_path.write_bytes(b"walkbuddy")
+
+    with pytest.raises(inspector.InspectionError, match="malformed model.names"):
+        inspector.inspect_model(model_path, yolo_loader=lambda path: FakeModel(names))
+
+
+def test_model_loading_failure_is_reported(tmp_path: Path) -> None:
+    model_path = tmp_path / "sample.pt"
+    model_path.write_bytes(b"walkbuddy")
+
+    def failing_loader(path: str) -> FakeModel:
+        raise RuntimeError("invalid model")
+
+    with pytest.raises(inspector.InspectionError, match="Model loading failed"):
+        inspector.inspect_model(model_path, yolo_loader=failing_loader)
+
+
+def test_unavailable_ultralytics_is_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    model_path = tmp_path / "sample.pt"
+    model_path.write_bytes(b"walkbuddy")
+
+    def unavailable_loader() -> object:
+        raise inspector.InspectionError("Ultralytics dependency is unavailable.")
+
+    monkeypatch.setattr(inspector, "_get_yolo_loader", unavailable_loader)
+
+    with pytest.raises(inspector.InspectionError, match="Ultralytics dependency"):
+        inspector.inspect_model(model_path)

--- a/ML_side/tools/inspect_active_model.py
+++ b/ML_side/tools/inspect_active_model.py
@@ -1,0 +1,169 @@
+"""Read-only inspector for locally supplied WalkBuddy YOLO model metadata."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_MODEL_PATH = Path(__file__).resolve().parents[1] / "models" / "best.pt"
+CHECKSUM_CHUNK_SIZE = 1024 * 1024
+
+
+class InspectionError(Exception):
+    """Raised when local model metadata cannot be safely inspected."""
+
+
+@dataclass(frozen=True)
+class ModelMetadata:
+    """The limited metadata reported by this read-only utility."""
+
+    path: Path
+    size_bytes: int
+    sha256: str
+    class_names: dict[int, str]
+
+
+def calculate_sha256(path: Path) -> str:
+    """Return the SHA-256 checksum of a local file without modifying it."""
+    digest = hashlib.sha256()
+    with path.open("rb") as model_file:
+        for chunk in iter(lambda: model_file.read(CHECKSUM_CHUNK_SIZE), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def normalise_class_names(names: object) -> dict[int, str]:
+    """Validate and normalise the Ultralytics model.names ID/name mapping."""
+    if isinstance(names, Mapping):
+        raw_items = names.items()
+    elif isinstance(names, Sequence) and not isinstance(names, (str, bytes)):
+        raw_items = enumerate(names)
+    else:
+        raise InspectionError("Model metadata is missing or has malformed model.names.")
+
+    class_names: dict[int, str] = {}
+    for raw_id, raw_name in raw_items:
+        if isinstance(raw_id, bool):
+            raise InspectionError("Model metadata is missing or has malformed model.names.")
+        try:
+            class_id = int(raw_id)
+        except (TypeError, ValueError) as exc:
+            raise InspectionError(
+                "Model metadata is missing or has malformed model.names."
+            ) from exc
+
+        if class_id < 0 or class_id in class_names:
+            raise InspectionError("Model metadata is missing or has malformed model.names.")
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise InspectionError("Model metadata is missing or has malformed model.names.")
+
+        class_names[class_id] = raw_name.strip()
+
+    if not class_names:
+        raise InspectionError("Model metadata is missing or has malformed model.names.")
+
+    return dict(sorted(class_names.items()))
+
+
+def format_class_map(class_names: Mapping[int, str]) -> str:
+    """Format a validated class map without exposing unrelated model internals."""
+    return "\n".join(
+        f"  {class_id}: {name}" for class_id, name in sorted(class_names.items())
+    )
+
+
+def _get_yolo_loader() -> Callable[[str], Any]:
+    try:
+        from ultralytics import YOLO
+    except ImportError as exc:
+        raise InspectionError(
+            "Ultralytics dependency is unavailable. Use a backend environment "
+            "with ultralytics installed."
+        ) from exc
+    return YOLO
+
+
+def load_class_names(
+    model_path: Path, yolo_loader: Callable[[str], Any] | None = None
+) -> dict[int, str]:
+    """Load and validate only the class metadata from a local model file."""
+    loader = yolo_loader or _get_yolo_loader()
+    try:
+        model = loader(str(model_path))
+    except Exception as exc:
+        raise InspectionError("Model loading failed.") from exc
+
+    try:
+        names = model.names
+    except Exception as exc:
+        raise InspectionError("Model metadata is missing or has malformed model.names.") from exc
+
+    return normalise_class_names(names)
+
+
+def inspect_model(
+    model_path: str | Path, yolo_loader: Callable[[str], Any] | None = None
+) -> ModelMetadata:
+    """Inspect a local model path without downloading, changing, or exporting it."""
+    path = Path(model_path).expanduser().resolve()
+    if not path.exists():
+        raise InspectionError(f"Model file is missing: {path}")
+    if not path.is_file():
+        raise InspectionError(f"Model path is not a file: {path}")
+
+    return ModelMetadata(
+        path=path,
+        size_bytes=path.stat().st_size,
+        sha256=calculate_sha256(path),
+        class_names=load_class_names(path, yolo_loader),
+    )
+
+
+def format_metadata(metadata: ModelMetadata) -> str:
+    """Return the complete, intentionally limited inspection report."""
+    return "\n".join(
+        (
+            f"Resolved model path: {metadata.path}",
+            f"File size in bytes: {metadata.size_bytes}",
+            f"SHA-256 checksum: {metadata.sha256}",
+            f"Number of classes: {len(metadata.class_names)}",
+            "Class ID-to-name mapping:",
+            format_class_map(metadata.class_names),
+        )
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read-only inspection of a local WalkBuddy YOLO model."
+    )
+    parser.add_argument(
+        "model_path",
+        nargs="?",
+        default=DEFAULT_MODEL_PATH,
+        help=f"Local model to inspect (default: {DEFAULT_MODEL_PATH})",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the inspector and return a non-zero code when inspection fails."""
+    args = parse_args(argv)
+    try:
+        metadata = inspect_model(args.model_path)
+    except InspectionError as exc:
+        print(f"Inspection failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(format_metadata(metadata))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a read-only utility for verifying the metadata of a locally supplied YOLO model artifact.

## Changes

- Adds `ML_side/tools/inspect_active_model.py`.
- Reports the resolved path, file size, SHA-256 checksum, class count and `model.names` mapping.
- Supports the default `ML_side/models/best.pt` path or an optional local model path.
- Handles missing files, invalid paths, unavailable dependencies, model-loading failures and malformed metadata.
- Adds automated tests that do not require real model weights.
- Documents local inspection commands and model-deserialization safety guidance.

## Verified artifact finding

The local `best.pt` artifact with SHA-256:

`198df54da4f6aa071b342bee77b100e78f243df785b325ec364036e106572238`

contains 7 classes:

- book
- books
- monitor
- office-chair
- whiteboard
- table
- tv

The repository training configuration also lists `couch`, but that class is not present in this specific model artifact. The cause of the model/configuration lineage mismatch remains unresolved.

## Verification

- `10 passed`
- `git diff --check` passed.
- No model files were tracked, staged or modified.
- `best.pt` remains ignored.
- Temporary verification environments were outside the repository.

## Risk

Low. The utility is read-only and does not modify runtime or production code.