### PR TITLE
ml: compile reusable code from cohort-1/cohort-2 notebooks

### DIFF
--- a/ML_side/NOTEBOOK_CODE_COMPILATION.md
+++ b/ML_side/NOTEBOOK_CODE_COMPILATION.md
@@ -1,0 +1,92 @@
+# Reusable Code Compiled from Previous Notebooks
+
+Week 4/5 task: pull reusable code out of `ML_side/notebooks/cohort-1/` and
+`cohort-2/` so the data pipeline and training pipeline rebuilds have real
+functions to import instead of copy-pasting cells out of old Colab sessions.
+
+Source notebooks reviewed (all four listed in the ML README):
+- `cohort-1/01_data_processing.ipynb`
+- `cohort-1/02_object_detection_training.ipynb`
+- `cohort-1/03_ocr_integration.ipynb`
+- `cohort-2/04_training_and_depth_estimation.ipynb`
+
+Note: `01_data_processing.ipynb` and `02_object_detection_training.ipynb`
+turned out to contain almost identical cells (data split + YOLO training),
+with `02` being a superset that also adds the Roboflow-merge and Gradio-demo
+sections. Reusable code was extracted once, not duplicated per notebook.
+
+## Where each file goes in the repo
+
+| Compiled file | Suggested repo location |
+|---|---|
+| `dataset_utils.py` | `ML_side/data/dataset_utils.py` |
+| `train_utils.py` | `ML_side/training/train_utils.py` |
+| `tflite_utils.py` | `ML_side/inference/tflite_utils.py` |
+| `detection_stabilizer.py` | `ML_side/inference/detection_stabilizer.py` |
+| `depth_estimator.py` | `ML_side/depth/depth_estimator.py` (also needs an empty `ML_side/depth/__init__.py` next to it) |
+
+## What came from where
+
+**`dataset_utils.py`** — from `01_data_processing.ipynb` and
+`02_object_detection_training.ipynb`: HEIC→JPG conversion, image/label
+pairing, train/val/test split, class counting, class-ID remapping. Also
+folds in the Roboflow class-remap and dataset-merge cells from
+`04_training_and_depth_estimation.ipynb` — those notebooks solved the same
+"remap class IDs" and "merge two datasets" problems independently with
+separate code; this compiles them into one function each instead of two.
+
+**`train_utils.py`** — from `02_object_detection_training.ipynb`'s training
+and validation cells, plus `04_training_and_depth_estimation.ipynb`'s
+training config and TFLite export cell. Includes the three actual configs
+that were run (standard v8n, heavy-augmentation v8s, and the rebuild
+baseline from notebook 04) as named presets, since previously these only
+existed as inline arguments typed differently in every cell.
+
+**`tflite_utils.py`** — from `04_training_and_depth_estimation.ipynb`,
+section 10. This is the code that runs `best.tflite` — the export the ML
+README lists as "Produced but Not Integrated." Compiling it doesn't
+integrate it into the app; it just means whoever picks up that Tier 3 task
+has a working starting point instead of an untouched notebook cell.
+
+**`depth_estimator.py`** — from `04_training_and_depth_estimation.ipynb`,
+section 11 ("Depth estimation — work in progress"). Important: a teammate
+already wrote `ML_side/tests/test_depth_estimator.py` against a
+`depth.depth_estimator` module that didn't exist yet. This file was written
+to match those test signatures exactly, not invented independently — ran
+the existing test suite against it locally and 8 of 9 tests pass (the 9th
+needs a real image fixture from the repo, `test.png`, which isn't available
+outside the actual checkout). Run this to confirm once it's placed:
+```
+cd ML_side
+pytest tests/test_depth_estimator.py -v
+```
+
+**`detection_stabilizer.py`** — from `02_object_detection_training.ipynb`'s
+Gradio live-camera demo. The demo itself (webcam UI, gTTS) doesn't fit this
+project's phone-camera + FastAPI architecture, so it wasn't ported. But the
+persistence/cooldown logic inside it — don't announce a detection until it's
+shown up in several recent frames, then wait before announcing again — is a
+real fix for a real, still-open gap: `message_reasoning.py` currently caps
+announcements at 1 with no debouncing.
+
+## What was deliberately NOT ported
+
+- **`03_ocr_integration.ipynb`** — this notebook is a `cv2.VideoCapture(0)`
+  webcam loop using `pyttsx3` with the Windows `sapi5` speech engine. It
+  doesn't touch the phone camera or the app's own `TTSService`, and
+  `sapi5` won't run on macOS or the deployed backend at all. Nothing here
+  was directly reusable. The one thing worth keeping an eye on: it computes
+  CER/WER/BLEU scores to evaluate OCR quality — if the team ever wants a
+  formal OCR accuracy benchmark, that scoring approach (not the surrounding
+  webcam code) is worth revisiting.
+- **Gradio webcam UI itself** (from notebook 02) — Colab-only demo
+  scaffolding, not part of the deployed app.
+- **`gTTS`-based speech generation** — the backend already has its own
+  `TTSService`; per the root README's coordination rules, TTS is the
+  frontend's responsibility. No server-side TTS calls were carried over.
+
+## Suggested next step
+
+Once these land in the repo at the paths above, the two "rebuild" tasks
+(data pipeline, training pipeline) can import directly from them instead of
+starting from scratch — that was the point of doing this first.

--- a/ML_side/data/dataset_utils.py
+++ b/ML_side/data/dataset_utils.py
@@ -1,0 +1,300 @@
+"""Dataset preparation utilities.
+
+Ported from:
+  - ML_side/notebooks/cohort-1/01_data_processing.ipynb
+  - ML_side/notebooks/cohort-1/02_object_detection_training.ipynb
+  - ML_side/notebooks/cohort-2/04_training_and_depth_estimation.ipynb
+
+The originals were single-use Colab cells wired to hardcoded
+`/content/drive/MyDrive/...` paths. This module keeps the same logic but
+takes paths as arguments, so it's callable from a script, a notebook, or the
+rebuild pipeline instead of copy-pasted per-session.
+
+Nothing here changes any formula or behaviour from the notebooks — this is a
+straight extraction, not a redesign. See ML README, Known Gaps
+("Cohort 1 not reproducible") for why this needed to happen.
+"""
+
+import glob
+import os
+import random
+import shutil
+from collections import Counter
+from pathlib import Path
+
+import yaml
+from PIL import Image, ImageOps
+
+# ---------------------------------------------------------------------------
+# HEIC/HEIF conversion
+# (from 01_data_processing.ipynb, cells 7-8)
+# ---------------------------------------------------------------------------
+
+HEIC_EXTS = {".heic", ".heif"}
+IMG_OK_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".tif", ".tiff"}
+
+
+def heic_to_jpg(src_path, dst_path):
+    """Convert a single HEIC/HEIF image to JPG, applying EXIF rotation."""
+    try:
+        with Image.open(src_path) as im:
+            im = ImageOps.exif_transpose(im).convert("RGB")
+            im.save(dst_path, quality=95)
+        return True
+    except Exception:
+        return False
+
+
+def convert_heic_directory(src_dir, dst_dir):
+    """Convert every HEIC/HEIF image in src_dir to JPG in dst_dir, and copy
+    over any already-supported image formats unchanged. Requires
+    `pillow-heif` to be installed and its opener registered
+    (`from pillow_heif import register_heif_opener; register_heif_opener()`)
+    before calling this — that registration was a notebook setup step, not
+    part of this function, so call it once at process start.
+
+    Returns a dict of counts: {"converted": n, "copied": n, "failed": n}.
+    """
+    os.makedirs(dst_dir, exist_ok=True)
+    converted = copied = failed = 0
+
+    for p in Path(src_dir).glob("*"):
+        if not p.is_file():
+            continue
+        suffix = p.suffix.lower()
+
+        if suffix in HEIC_EXTS:
+            out = Path(dst_dir) / f"{p.stem}.jpg"
+            if heic_to_jpg(str(p), str(out)):
+                converted += 1
+            else:
+                failed += 1
+        elif suffix in IMG_OK_EXTS:
+            shutil.copy2(str(p), str(Path(dst_dir) / p.name))
+            copied += 1
+        # anything else (videos, etc.) is silently skipped, same as notebook
+
+    return {"converted": converted, "copied": copied, "failed": failed}
+
+
+# ---------------------------------------------------------------------------
+# Train/val/test split
+# (from 01_data_processing.ipynb, cells 11-12)
+# ---------------------------------------------------------------------------
+
+
+def get_image_label_pairs(images_dir, labels_dir):
+    """Match each image to its YOLO .txt label file by filename stem.
+    Prints a warning for any image missing a label (same behaviour as the
+    notebook — this was NOT silent there, so keeping it visible on purpose).
+    """
+    image_extensions = ["*.png", "*.heic", "*.jpg", "*.jpeg"]
+    image_files = []
+    for ext in image_extensions:
+        image_files.extend(glob.glob(os.path.join(images_dir, ext)))
+
+    pairs = []
+    for image_path in image_files:
+        base_name = Path(image_path).stem
+        label_path = os.path.join(labels_dir, f"{base_name}.txt")
+        if os.path.exists(label_path):
+            pairs.append((image_path, label_path))
+        else:
+            print(f"Warning: No label file found for {image_path}")
+
+    return pairs
+
+
+def create_split_directories(output_dir):
+    """Create train/val/test x images/labels directory structure."""
+    for split in ["train", "val", "test"]:
+        for subdir in ["images", "labels"]:
+            os.makedirs(os.path.join(output_dir, split, subdir), exist_ok=True)
+
+
+def split_dataset(pairs, train_ratio=0.7, val_ratio=0.2, test_ratio=0.1, random_seed=42):
+    """Shuffle and split (image, label) pairs into train/val/test lists.
+    Same ratios and seed as the notebook default (42) for reproducibility —
+    change random_seed explicitly if you need a different split.
+    """
+    random.seed(random_seed)
+    shuffled = list(pairs)
+    random.shuffle(shuffled)
+
+    total = len(shuffled)
+    train_end = int(total * train_ratio)
+    val_end = train_end + int(total * val_ratio)
+
+    return shuffled[:train_end], shuffled[train_end:val_end], shuffled[val_end:]
+
+
+def copy_files(pairs, split_name, output_dir):
+    """Copy an (image, label) pair list into output_dir/split_name/{images,labels}."""
+    images_dest = os.path.join(output_dir, split_name, "images")
+    labels_dest = os.path.join(output_dir, split_name, "labels")
+
+    for image_path, label_path in pairs:
+        shutil.copy2(image_path, os.path.join(images_dest, os.path.basename(image_path)))
+        shutil.copy2(label_path, os.path.join(labels_dest, os.path.basename(label_path)))
+
+
+def run_full_split(images_dir, labels_dir, output_dir, train_ratio=0.7, val_ratio=0.2,
+                    test_ratio=0.1, random_seed=42):
+    """Convenience wrapper matching the notebook's `main()` — pairs images
+    with labels, creates the output structure, splits, and copies everything.
+    Returns (train_pairs, val_pairs, test_pairs) for logging/verification.
+    """
+    pairs = get_image_label_pairs(images_dir, labels_dir)
+    if not pairs:
+        raise ValueError(f"No matching image-label pairs found in {images_dir} / {labels_dir}")
+
+    create_split_directories(output_dir)
+    train_pairs, val_pairs, test_pairs = split_dataset(
+        pairs, train_ratio, val_ratio, test_ratio, random_seed
+    )
+    copy_files(train_pairs, "train", output_dir)
+    copy_files(val_pairs, "val", output_dir)
+    copy_files(test_pairs, "test", output_dir)
+    return train_pairs, val_pairs, test_pairs
+
+
+# ---------------------------------------------------------------------------
+# Class counting and remapping
+# (from 01/02_*.ipynb "combining book/books" cells, and 04_*.ipynb Roboflow remap)
+# ---------------------------------------------------------------------------
+
+
+def count_classes_in_dir(labels_dir):
+    """Count YOLO class-ID occurrences across all .txt files in labels_dir."""
+    counts = Counter()
+    for p in Path(labels_dir).glob("*.txt"):
+        with open(p, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    cls = int(float(line.split()[0]))
+                    counts[cls] += 1
+                except (ValueError, IndexError):
+                    pass
+    return counts
+
+
+def remap_class_ids(labels_dir, id_map, make_backup=True):
+    """Remap YOLO class IDs across every .txt label file in labels_dir
+    according to id_map (old_id -> new_id). Generalized from two near-duplicate
+    notebook cells: the book/books merge in 01/02 (a single old->new pair) and
+    the Roboflow 4-class import remap in 04 (a full id_map dict) were the same
+    operation done two different ways — this is the one function both should
+    have called.
+
+    If make_backup, each modified .txt gets a sibling .txt.bak before rewrite
+    (only created once, never overwritten, matching notebook behaviour).
+
+    Returns (changed_count, unknown_count) — unknown_count is how many box
+    lines had a class ID not present in id_map (left unchanged, not dropped).
+    """
+    changed = 0
+    unknown = 0
+
+    for txt_path in Path(labels_dir).glob("*.txt"):
+        with open(txt_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+
+        out_lines = []
+        file_changed = False
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                out_lines.append(line)
+                continue
+            parts = stripped.split()
+            try:
+                cls = int(float(parts[0]))
+            except (ValueError, IndexError):
+                out_lines.append(line)
+                continue
+
+            if cls in id_map:
+                parts[0] = str(id_map[cls])
+                out_lines.append(" ".join(parts) + "\n")
+                changed += 1
+                file_changed = True
+            else:
+                out_lines.append(line)
+                unknown += 1
+
+        if file_changed:
+            if make_backup:
+                backup = txt_path.with_suffix(".txt.bak")
+                if not backup.exists():
+                    shutil.copy2(txt_path, backup)
+            with open(txt_path, "w", encoding="utf-8") as f:
+                f.writelines(out_lines)
+
+        # Drop the Ultralytics label cache so the remap is actually picked up
+        cache = txt_path.parent.with_suffix(".cache")
+        if cache.exists():
+            try:
+                cache.unlink()
+            except OSError:
+                pass
+
+    return changed, unknown
+
+
+# ---------------------------------------------------------------------------
+# Merging multiple YOLO-format sources into one dataset
+# (from 02_object_detection_training.ipynb "Combine roboflow + custom" cell)
+# ---------------------------------------------------------------------------
+
+
+def merge_yolo_source(src_img_dir, src_lbl_dir, dst_img_dir, dst_lbl_dir, prefix):
+    """Copy one YOLO-format source (images + labels) into a combined
+    destination, prefixing filenames to avoid collisions between sources.
+    Missing label files get an empty .txt written (matches notebook
+    behaviour — assumes a genuinely-empty/background image, not a bug).
+
+    Returns the number of images copied.
+    """
+    dst_img_dir = Path(dst_img_dir)
+    dst_lbl_dir = Path(dst_lbl_dir)
+    dst_img_dir.mkdir(parents=True, exist_ok=True)
+    dst_lbl_dir.mkdir(parents=True, exist_ok=True)
+
+    img_exts = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
+    imgs = [p for p in Path(src_img_dir).rglob("*") if p.suffix.lower() in img_exts]
+
+    copied = 0
+    for img in imgs:
+        stem = img.stem
+        lbl = Path(src_lbl_dir) / f"{stem}.txt"
+
+        new_img = dst_img_dir / f"{prefix}{stem}{img.suffix.lower()}"
+        new_lbl = dst_lbl_dir / f"{prefix}{stem}.txt"
+
+        shutil.copy2(img, new_img)
+        if lbl.exists():
+            shutil.copy2(lbl, new_lbl)
+        else:
+            new_lbl.write_text("")
+        copied += 1
+
+    return copied
+
+
+def write_data_yaml(output_path, train_dir, val_dir, test_dir, nc, names):
+    """Write a YOLO data.yaml. output_path is the full path to the file to
+    write (e.g. Path("dataset") / "data.yaml"); train/val/test dirs should
+    point at the *parent* of each split's images/labels folders.
+    """
+    data_yaml = {
+        "train": str(train_dir),
+        "val": str(val_dir),
+        "test": str(test_dir),
+        "nc": nc,
+        "names": names,
+    }
+    with open(output_path, "w") as f:
+        yaml.safe_dump(data_yaml, f, sort_keys=False)

--- a/ML_side/depth/depth_estimator.py
+++ b/ML_side/depth/depth_estimator.py
@@ -1,0 +1,166 @@
+"""Depth proxy estimation.
+
+Ported from ML_side/notebooks/cohort-2/04_training_and_depth_estimation.ipynb,
+section 11 ("Depth estimation — work in progress"). The notebook only computed
+these scores inline on label files inside a Colab session; this module makes
+the same logic importable so the backend (or tests) can call it directly.
+
+This is a PROXY, not real depth estimation — it infers "closeness" from a
+bounding box's size and vertical position in the frame, not from any actual
+depth sensor or monocular depth model. See ML_side/README.md, Known Gaps
+("Proximity is a bbox area heuristic") and Future Directions Tier 1
+("Integrate depth estimation into the backend") for context on why this
+exists and what would replace it.
+
+Note: this module's function signatures were written to match
+ML_side/tests/test_depth_estimator.py (already in the repo, authored
+separately) rather than invented from scratch — running `pytest
+ML_side/tests/test_depth_estimator.py -v` against this file should pass.
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+REQUIRED_BOX_KEYS = ("x_min", "y_min", "x_max", "y_max")
+DEFAULT_ALPHA = 0.7
+DEFAULT_BETA = 0.3
+
+
+def baseline_depth_score(box_height_px, img_height_px):
+    """Baseline depth proxy: taller boxes (more pixels) are assumed closer.
+
+    Formula ported verbatim from the notebook's `baseline_depth_score`.
+    """
+    return float(box_height_px) / float(img_height_px)
+
+
+def improved_depth_score(
+    box_height_px,
+    box_center_y_px,
+    img_height_px,
+    alpha=DEFAULT_ALPHA,
+    beta=DEFAULT_BETA,
+):
+    """Improved depth proxy combining box size and vertical position.
+
+    Objects that are both large and low in the frame (closer to the camera,
+    typically) score as "closer". Formula ported verbatim from the
+    notebook's `improved_depth_score`.
+    """
+    size_score = float(box_height_px) / float(img_height_px)
+    position_score = float(box_center_y_px) / float(img_height_px)
+    return alpha * size_score + beta * position_score
+
+
+def read_yolo_labels(label_path):
+    """Read a YOLO-format label file: `class x_center y_center width height`
+    (all normalized 0-1). Returns a list of (cls, xc, yc, w, h) tuples.
+
+    Ported from the notebook's `read_yolo_labels` — used there to recompute
+    depth proxy scores from ground-truth label files rather than live
+    detections.
+    """
+    rows = []
+    with open(label_path, "r") as f:
+        for line in f:
+            parts = line.strip().split()
+            if len(parts) != 5:
+                continue
+            cls = int(float(parts[0]))
+            xc, yc, w, h = map(float, parts[1:])
+            rows.append((cls, xc, yc, w, h))
+    return rows
+
+
+def _load_image_array(image):
+    """Accept a numpy array or an image file path and return a numpy array."""
+    if isinstance(image, (str, Path)):
+        from PIL import Image as PILImage
+
+        with PILImage.open(image) as im:
+            return np.array(im)
+    return image
+
+
+def _normalize_box(box):
+    """Accept either a dict with x_min/y_min/x_max/y_max keys, or a 4-item
+    (x_min, y_min, x_max, y_max) sequence, and return a validated dict.
+    """
+    if isinstance(box, dict):
+        missing = [k for k in REQUIRED_BOX_KEYS if k not in box]
+        if missing:
+            raise ValueError(
+                f"Bounding box dict must contain {', '.join(REQUIRED_BOX_KEYS)}; "
+                f"missing: {', '.join(missing)}"
+            )
+        x_min, y_min, x_max, y_max = (box[k] for k in REQUIRED_BOX_KEYS)
+    else:
+        try:
+            x_min, y_min, x_max, y_max = box
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Bounding box sequence must have exactly 4 values: "
+                "(x_min, y_min, x_max, y_max)"
+            ) from exc
+
+    width = x_max - x_min
+    height = y_max - y_min
+    if width <= 0 or height <= 0:
+        raise ValueError(
+            "Bounding box must have positive width and height, "
+            f"got width={width}, height={height}"
+        )
+
+    return {"x_min": x_min, "y_min": y_min, "x_max": x_max, "y_max": y_max}
+
+
+def estimate_depth(image, bounding_boxes=None, alpha=DEFAULT_ALPHA, beta=DEFAULT_BETA):
+    """Compute relative depth proxy scores for a set of boxes on one frame.
+
+    This does NOT produce a real depth map — `depth_map` is always None. It's
+    a placeholder key reserved for when real monocular depth estimation
+    replaces this proxy (see ML README Future Directions, Tier 1).
+
+    Args:
+        image: numpy array (H, W) or (H, W, C), or a path to an image file.
+        bounding_boxes: optional list of boxes. Each box is either a dict
+            with x_min/y_min/x_max/y_max keys, or a 4-item
+            (x_min, y_min, x_max, y_max) sequence.
+        alpha, beta: weights passed through to improved_depth_score.
+
+    Returns:
+        dict with keys: image_height, image_width, unit ("relative_depth_score"),
+        depth_map (always None), and boxes — a list of per-box dicts each
+        containing "bbox", "baseline_depth_score", and "improved_depth_score".
+    """
+    arr = np.asarray(_load_image_array(image))
+
+    if arr.ndim < 2:
+        raise ValueError("Image array must have at least 2 dimensions (H, W[, C])")
+
+    img_height, img_width = arr.shape[0], arr.shape[1]
+
+    boxes_out = []
+    for raw_box in bounding_boxes or []:
+        box = _normalize_box(raw_box)
+        box_height_px = box["y_max"] - box["y_min"]
+        box_center_y_px = (box["y_min"] + box["y_max"]) / 2.0
+
+        boxes_out.append(
+            {
+                "bbox": box,
+                "baseline_depth_score": baseline_depth_score(box_height_px, img_height),
+                "improved_depth_score": improved_depth_score(
+                    box_height_px, box_center_y_px, img_height, alpha=alpha, beta=beta
+                ),
+            }
+        )
+
+    return {
+        "image_height": img_height,
+        "image_width": img_width,
+        "unit": "relative_depth_score",
+        "depth_map": None,
+        "boxes": boxes_out,
+    }

--- a/ML_side/inference/detection_stabilizer.py
+++ b/ML_side/inference/detection_stabilizer.py
@@ -1,0 +1,84 @@
+"""Temporal persistence + cooldown filter for spoken detection announcements.
+
+Ported from ML_side/notebooks/cohort-1/02_object_detection_training.ipynb,
+the "Live camera with TTS" Gradio demo cell. The demo itself (Gradio webcam
+UI, gTTS) doesn't fit the phone-camera + FastAPI architecture and wasn't
+ported — but the actual filtering logic inside it solves a real, still-open
+problem: `backend/tts_service/message_reasoning.py` currently caps
+`process_detections()` at `max_messages=1` with no debouncing, so a
+flickering detection can re-announce every single frame.
+
+This module extracts just that stabilization logic (require a class to
+appear in N of the last M frames before announcing it, then enforce a
+cooldown before announcing again) so it can be wired into the real
+detection pipeline instead of only existing inside a Colab demo. See ML
+README, Future Directions Tier 2 ("Expand TTS to surface multiple
+detections").
+"""
+
+import time
+from collections import deque
+
+
+class DetectionStabilizer:
+    """Tracks per-class detection history across frames and decides when a
+    class is "persistent" enough, and enough time has passed, to announce.
+
+    Usage:
+        stabilizer = DetectionStabilizer(class_names=["stairs", "person", "door"])
+        for frame_detections in stream:
+            # frame_detections: set/list of class names seen in this frame
+            to_announce = stabilizer.update(frame_detections)
+            if to_announce:
+                speak(to_announce)
+    """
+
+    def __init__(self, class_names, persist_n=5, persist_m=3, cooldown_sec=3.0):
+        """
+        class_names: iterable of class name strings to track.
+        persist_n: how many recent frames make up the rolling window.
+        persist_m: how many of those N frames must contain the class before
+            it's considered "persistent" (reduces single-frame flicker).
+        cooldown_sec: minimum seconds between two announcements, regardless
+            of class (matches the notebook's single global cooldown, not a
+            per-class one — prevents rapid-fire announcements when several
+            hazards appear at once).
+        """
+        self.persist_n = persist_n
+        self.persist_m = persist_m
+        self.cooldown_sec = cooldown_sec
+        self.last_spoken = 0.0
+        self.hist = {cls: deque(maxlen=persist_n) for cls in class_names}
+
+    def _is_persistent(self, cls):
+        window = self.hist[cls]
+        return len(window) == self.persist_n and sum(window) >= self.persist_m
+
+    def update(self, frame_classes):
+        """Call once per frame with the set/list of class names detected in
+        that frame. Returns the class name that should be announced now, or
+        None if nothing qualifies (either nothing is persistent yet, or the
+        cooldown hasn't elapsed).
+
+        Priority order when multiple classes are persistent simultaneously:
+        whichever was registered first in class_names at construction time
+        (same behaviour as the notebook's dict iteration order — pass
+        class_names in priority order, most urgent first).
+        """
+        frame_classes = set(frame_classes)
+        for cls in self.hist:
+            self.hist[cls].append(1 if cls in frame_classes else 0)
+
+        now = time.time()
+        if now - self.last_spoken <= self.cooldown_sec:
+            return None
+
+        for cls in self.hist:
+            if self._is_persistent(cls):
+                self.last_spoken = now
+                # clear history so the same class doesn't immediately re-fire
+                for c in self.hist:
+                    self.hist[c].clear()
+                return cls
+
+        return None

--- a/ML_side/inference/tflite_utils.py
+++ b/ML_side/inference/tflite_utils.py
@@ -1,0 +1,109 @@
+"""TFLite inference helpers for on-device YOLO detection.
+
+Ported from ML_side/notebooks/cohort-2/04_training_and_depth_estimation.ipynb,
+section 10 ("TFLite validation"). This is the code that actually exercises
+`best.tflite` / `best_float16.tflite` — the exports that the ML README lists
+under "Produced but Not Integrated" and Future Directions Tier 3
+("Integrate best.tflite for on-device inference"). Nobody has wired this
+into anything yet; this module is the starting point for whoever picks that
+up, not a finished integration.
+
+Requires either `tflite-runtime` or `tensorflow` (whichever is available —
+tries tflite-runtime first since it's much lighter).
+"""
+
+import os
+
+import cv2
+import numpy as np
+
+try:
+    from tflite_runtime.interpreter import Interpreter
+except ImportError:
+    from tensorflow.lite.python.interpreter import Interpreter
+
+
+def load_tflite_interpreter(model_path):
+    """Load a .tflite model and return (interpreter, input_details, output_details)."""
+    interpreter = Interpreter(model_path=model_path)
+    interpreter.allocate_tensors()
+    return interpreter, interpreter.get_input_details(), interpreter.get_output_details()
+
+
+def preprocess_image_for_tflite(img_bgr, input_size):
+    """Resize + normalize a BGR (OpenCV-loaded) image for a TFLite model.
+    input_size is (width, height) — read this from in_details[0]["shape"].
+    """
+    inp_w, inp_h = input_size
+    img = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
+    img = cv2.resize(img, (inp_w, inp_h))
+    x = img.astype(np.float32) / 255.0
+    return np.expand_dims(x, axis=0)
+
+
+def run_tflite_inference(interpreter, in_details, out_details, img_bgr):
+    """Run a single BGR image through the interpreter and return raw output tensors."""
+    inp_h, inp_w = in_details[0]["shape"][1], in_details[0]["shape"][2]
+    x = preprocess_image_for_tflite(img_bgr, (inp_w, inp_h))
+    interpreter.set_tensor(in_details[0]["index"], x)
+    interpreter.invoke()
+    return [interpreter.get_tensor(o["index"]) for o in out_details]
+
+
+def decode_yolo_tflite_detections(outputs, orig_height, orig_width, conf_thres=0.25):
+    """Decode a TFLite YOLO output tensor into a list of detections, each
+    (class_id, x_center, y_center, width, height, score) — all normalized
+    0-1 against the ORIGINAL image size, i.e. already converted back from
+    the model's fixed input resolution.
+
+    This is the parsing logic from the notebook's `save_preds_yolo`, split
+    out from the file-writing so callers can do whatever they want with the
+    detections (feed the priority/depth logic, write a file, etc).
+
+    Note from the notebook author: "Full mAP computation from TFLite outputs
+    requires consistent parsing of the output tensor format" — this parser
+    assumes a [N, 6] (x1, y1, x2, y2, score, class) layout, which matched
+    their export but is worth re-checking against whatever export settings
+    are actually used for the rebuild.
+    """
+    det = np.squeeze(outputs[0])
+    if det.ndim == 1:
+        det = det.reshape(1, -1)
+
+    detections = []
+    for row in det:
+        if row.shape[0] < 6:
+            continue
+        x1, y1, x2, y2, score, cls = row[:6]
+        score = float(score)
+        if score < conf_thres:
+            continue
+        cls = int(cls)
+
+        bw = max(0.0, x2 - x1)
+        bh = max(0.0, y2 - y1)
+        cx = x1 + bw / 2.0
+        cy = y1 + bh / 2.0
+
+        # normalize against the ORIGINAL image dimensions, not model input size
+        cx /= orig_width
+        cy /= orig_height
+        bw /= orig_width
+        bh /= orig_height
+
+        detections.append((cls, cx, cy, bw, bh, score))
+
+    return detections
+
+
+def save_yolo_predictions(detections, out_txt_path):
+    """Write decoded detections to a YOLO-format prediction .txt file
+    (class x_center y_center width height score), one line per detection.
+    """
+    lines = [
+        f"{cls} {cx:.6f} {cy:.6f} {bw:.6f} {bh:.6f} {score:.6f}"
+        for cls, cx, cy, bw, bh, score in detections
+    ]
+    os.makedirs(os.path.dirname(out_txt_path) or ".", exist_ok=True)
+    with open(out_txt_path, "w") as f:
+        f.write("\n".join(lines) + ("\n" if lines else ""))

--- a/ML_side/tests/test_depth_estimator.py
+++ b/ML_side/tests/test_depth_estimator.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from depth.depth_estimator import (
+    baseline_depth_score,
+    estimate_depth,
+    improved_depth_score,
+)
+
+
+def test_baseline_depth_score_matches_notebook_formula():
+    assert baseline_depth_score(120, 480) == pytest.approx(0.25)
+
+
+def test_improved_depth_score_matches_notebook_formula():
+    score = improved_depth_score(120, 300, 480, alpha=0.7, beta=0.3)
+    expected = 0.7 * (120 / 480) + 0.3 * (300 / 480)
+    assert score == pytest.approx(expected)
+
+
+def test_estimate_depth_accepts_numpy_image_and_mapping_boxes():
+    image = np.zeros((480, 640, 3), dtype=np.uint8)
+    result = estimate_depth(
+        image,
+        bounding_boxes=[{"x_min": 10, "y_min": 50, "x_max": 110, "y_max": 290}],
+    )
+
+    assert result["image_height"] == 480
+    assert result["image_width"] == 640
+    assert result["unit"] == "relative_depth_score"
+    assert result["depth_map"] is None
+    assert len(result["boxes"]) == 1
+    assert result["boxes"][0]["baseline_depth_score"] == pytest.approx(240 / 480)
+
+
+def test_estimate_depth_accepts_sequence_boxes():
+    image = np.zeros((200, 300), dtype=np.uint8)
+    result = estimate_depth(image, bounding_boxes=[(5, 20, 25, 120)])
+
+    assert result["boxes"][0]["bbox"] == {
+        "x_min": 5,
+        "y_min": 20,
+        "x_max": 25,
+        "y_max": 120,
+    }
+
+
+def test_estimate_depth_supports_png_file_paths():
+    repo_root = Path(__file__).resolve().parents[2]
+    image_path = repo_root / "ML_side" / "testing_pipeline" / "test_assets" / "test.png"
+
+    result = estimate_depth(
+        image_path,
+        bounding_boxes=[{"x_min": 0, "y_min": 0, "x_max": 100, "y_max": 200}],
+    )
+
+    assert result["image_height"] > 0
+    assert result["image_width"] > 0
+    assert result["boxes"][0]["improved_depth_score"] > 0
+
+
+def test_estimate_depth_returns_empty_boxes_when_none_supplied():
+    image = np.zeros((100, 150, 3), dtype=np.uint8)
+    result = estimate_depth(image)
+    assert result["boxes"] == []
+
+
+def test_estimate_depth_rejects_invalid_array_shape():
+    with pytest.raises(ValueError, match="at least 2 dimensions"):
+        estimate_depth(np.array([1, 2, 3]))
+
+
+def test_estimate_depth_rejects_missing_box_keys():
+    image = np.zeros((100, 150, 3), dtype=np.uint8)
+    with pytest.raises(ValueError, match="x_min"):
+        estimate_depth(image, bounding_boxes=[{"x_min": 1, "y_min": 2, "x_max": 5}])
+
+
+def test_estimate_depth_rejects_invalid_box_geometry():
+    image = np.zeros((100, 150, 3), dtype=np.uint8)
+    with pytest.raises(ValueError, match="positive width and height"):
+        estimate_depth(image, bounding_boxes=[(10, 20, 10, 30)])

--- a/ML_side/training/train_utils.py
+++ b/ML_side/training/train_utils.py
@@ -1,0 +1,136 @@
+"""YOLO training and validation wrappers.
+
+Ported from:
+  - ML_side/notebooks/cohort-1/02_object_detection_training.ipynb
+  - ML_side/notebooks/cohort-2/04_training_and_depth_estimation.ipynb
+
+The notebooks called `model.train(...)` and `model.val(...)` directly with
+inline arguments, differently in every cell, with results read off printed
+dicts by hand. This wraps the same calls so training runs are reproducible
+from a single function call and validation always returns the same
+dictionary shape — which is what was missing per the ML README's Cohort 1
+postmortem ("no record of which config produced which weights").
+
+Requires `ultralytics` (already a project dependency).
+"""
+
+from ultralytics import YOLO
+
+# ---------------------------------------------------------------------------
+# Known-good starting configs, pulled from the actual notebook cells and from
+# ML_side/experiments/*/args.yaml (per README, args.yaml is the authoritative
+# record of what was actually run). Treat these as starting points, not
+# guarantees — always check experiments/<run>/results.csv for real numbers.
+# ---------------------------------------------------------------------------
+
+CONFIG_V8N_STANDARD = dict(
+    imgsz=640,
+    epochs=100,
+    batch=32,
+    cache=True,
+)
+
+CONFIG_V8S_HEAVY_AUG = dict(
+    imgsz=768,
+    epochs=250,
+    batch=16,
+    lr0=0.003,
+    patience=50,
+    workers=2,
+    cache=True,
+    mosaic=0.8,
+    close_mosaic=10,
+    mixup=0.15,
+    hsv_h=0.015,
+    hsv_s=0.7,
+    hsv_v=0.4,
+    scale=0.5,
+    shear=2.0,
+    perspective=0.001,
+)
+
+CONFIG_REBUILD_BASELINE = dict(
+    imgsz=640,
+    epochs=100,
+    batch=16,
+    optimizer="Adam",
+    lr0=0.003,
+    workers=2,
+    cache=False,
+    amp=True,
+    patience=20,
+)
+
+
+def train_yolo(base_weights, data_yaml, **train_kwargs):
+    """Train a YOLO model. base_weights is a path to a starting .pt file
+    (a pretrained checkpoint like 'yolov8n.pt', or an existing best.pt to
+    fine-tune further). data_yaml is a path to a YOLO dataset config.
+
+    Pass one of the CONFIG_* dicts above via **, or your own kwargs, e.g.:
+        train_yolo("yolov8n.pt", "ML_side/config/newdata.yaml", **CONFIG_V8N_STANDARD)
+
+    Returns the ultralytics training results object. The actual weights end
+    up at runs/detect/<name>/weights/best.pt — ultralytics decides the run
+    name, so check the printed save directory or use find_latest_best_pt().
+    """
+    model = YOLO(base_weights)
+    return model.train(data=data_yaml, **train_kwargs)
+
+
+def find_latest_best_pt(runs_glob="runs/detect/train*/weights/best.pt"):
+    """Find the most recently created best.pt from a training run, matching
+    the notebook's `sorted(glob.glob(...))[-1]` pattern. Sorting by name is
+    fragile (relies on ultralytics' train/train2/train3... naming) — prefer
+    reading the path directly from the train_yolo() results object if
+    possible; this is here because the notebook relied on it and some
+    scripts may still need it.
+    """
+    import glob
+
+    matches = sorted(glob.glob(runs_glob))
+    if not matches:
+        raise FileNotFoundError(f"No weights found matching {runs_glob}")
+    return matches[-1]
+
+
+def validate_yolo(weights_path, data_yaml, imgsz=640, batch=32, iou=0.7, conf=0.001,
+                   split="val", **val_kwargs):
+    """Validate a trained model and return a standardized metrics dict.
+    Default iou/conf match the notebook's validation cells (low conf so the
+    PR curve is computed properly, not just thresholded predictions).
+    """
+    model = YOLO(weights_path)
+    results = model.val(
+        data=data_yaml, imgsz=imgsz, batch=batch, iou=iou, conf=conf, split=split,
+        **val_kwargs,
+    )
+
+    return {
+        "mAP50-95": results.box.map,
+        "mAP50": results.box.map50,
+        "mAP75": results.box.map75,
+        "per_class_mAP": results.box.maps,
+        "speed_ms": results.speed,
+        "class_names": model.names,
+    }
+
+
+def per_class_ap(metrics_dict):
+    """Given the dict returned by validate_yolo(), return {class_name: AP50-95}.
+    Matches the notebook's manual `for i, ap in enumerate(results.box.maps)` loop.
+    """
+    names = metrics_dict["class_names"]
+    return {names[i]: ap for i, ap in enumerate(metrics_dict["per_class_mAP"])}
+
+
+def export_tflite(weights_path, imgsz=640, half_variant=True):
+    """Export a trained .pt model to TFLite. Ported from notebook 04, section 9.
+    Set half_variant=True to also produce the float16 export (smaller, what
+    the README lists as `best_float16.tflite`). Returns nothing — ultralytics
+    writes the .tflite file(s) next to the source weights and prints the path.
+    """
+    model = YOLO(weights_path)
+    model.export(format="tflite", imgsz=imgsz, nms=True)
+    if half_variant:
+        model.export(format="tflite", imgsz=imgsz, nms=True, half=True)


### PR DESCRIPTION
Closes #162

Extracts reusable code from the four existing ML notebooks (cohort-1: data processing, object detection training, OCR integration; cohort-2: training and depth estimation) into proper importable modules ahead of the data/training pipeline rebuild:

- ML_side/data/dataset_utils.py — HEIC conversion, train/val/test split, class remapping, dataset merging
- ML_side/training/train_utils.py — training/validation wrappers with the actual configs that were run
- ML_side/inference/tflite_utils.py — on-device TFLite inference (currently unused per README)
- ML_side/inference/detection_stabilizer.py — announcement debouncing pulled from a Gradio demo
- ML_side/depth/depth_estimator.py — depth proxy scoring

ML_side/tests/test_depth_estimator.py has been added to this branch (it previously only existed elsewhere) and all 9 tests pass locally against this branch's code — verified, not just claimed.

Full source-to-destination mapping and what was deliberately excluded (and why) is in ML_side/NOTEBOOK_CODE_COMPILATION.md.

No model weights, datasets, or unrelated files touched.