### PR TITLE
feat(ml): add current model baseline evaluator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ ML_side/data/train_dataset/
 ML_side/data/val_dataset/
 ML_side/models/*
 !ML_side/models/README.md
+ML_side/evaluation_results/
 
 software_side/walkbuddy_reactNative/frontend_reactNative/package-lock.json
 software_side.zip

--- a/ML_side/README.md
+++ b/ML_side/README.md
@@ -21,6 +21,9 @@ The postmortem and Cohort 1/Cohort 2 experiment sections below preserve historic
 
 The experimental entry point and historical demo material should not be used to infer production backend behaviour.
 
+For a reproducible, read-only baseline of a locally supplied `best.pt`, see
+[`docs/current_model_baseline.md`](docs/current_model_baseline.md).
+
 ### Unresolved Work
 
 The repository-configured v1 training taxonomy lacks important navigation-hazard classes such as stairs, doors, and people. The active best.pt metadata still requires confirmation in a valid backend environment. In addition, multiple class-to-risk policies exist across the system and can classify ordinary objects more severely than intended. Any runtime safety-policy change requires cross-stream review before implementation.

--- a/ML_side/docs/current_model_baseline.md
+++ b/ML_side/docs/current_model_baseline.md
@@ -1,0 +1,112 @@
+# Current WalkBuddy Model Baseline
+
+This workflow records the supplied local `best.pt` model's metadata and produces
+a reproducible baseline without training, replacing, exporting, or downloading a
+model or dataset.
+
+## Before you begin
+
+- Follow `docs/LOCAL_SETUP.md` to create the supported backend environment.
+- Obtain `ML_side/models/best.pt` through the approved model-asset process.
+- Inspect only model files from a trusted project source: loading `.pt` weights
+  involves model deserialization.
+- Do not commit model weights, private datasets, source images, or generated
+  evaluation output.
+
+The verified local artifact documented in `ML_side/models/README.md` has seven
+classes: `book`, `books`, `monitor`, `office-chair`, `whiteboard`, `table`, and
+`tv`. `ML_side/config/newdata.yaml` currently lists an additional `couch` class.
+Do not assume another `best.pt` has the same taxonomy unless its checksum and
+`model.names` metadata are inspected locally.
+
+## Unlabelled inference audit
+
+Use this mode for a supplied folder of `.jpg`, `.jpeg`, or `.png` images:
+
+```powershell
+& ".\software_side\walkbuddy_reactNative\backend\.venv\Scripts\python.exe" ".\ML_side\tools\evaluate_current_model.py" --model ".\ML_side\models\best.pt" --images ".\path\to\images" --output ".\ML_side\evaluation_results\unlabelled-baseline"
+```
+
+This is an **unlabelled inference audit**. It records detections, confidence,
+bounding boxes, failures, throughput, and class counts. It is not precision,
+recall, or mAP accuracy evaluation because no ground-truth annotations are used.
+
+## Labelled accuracy evaluation
+
+Use this mode only with a local YOLO dataset YAML whose image and annotation
+paths are already available. The tool refuses dataset YAML files with a
+`download:` directive.
+
+```powershell
+& ".\software_side\walkbuddy_reactNative\backend\.venv\Scripts\python.exe" ".\ML_side\tools\evaluate_current_model.py" --model ".\ML_side\models\best.pt" --dataset-yaml ".\path\to\labelled-dataset.yaml" --output ".\ML_side\evaluation_results\labelled-baseline"
+```
+
+This mode calls Ultralytics validation and records only metrics made available by
+that validation result: precision, recall, mAP50, mAP50-95, per-class metrics,
+validation image count, and timing where available. Missing values are written
+as `null` with an explanation; no values are estimated or fabricated.
+
+## Output files
+
+Each run writes these files to the requested output directory:
+
+- `model_metadata.json` — local path, size, SHA-256, and class mapping.
+- `summary.json` — run mode and aggregate results.
+- `predictions.json` — unlabelled mode only; per-image detections and failures.
+- `validation_metrics.json` — labelled mode only; available validation metrics.
+- `baseline_report.md` — readable summary.
+
+The tool refuses to write into a non-empty output directory unless `--overwrite`
+is supplied. It never copies source images into the output directory.
+
+## Verified local smoke test
+
+Windows local execution completed successfully with Ultralytics 8.4.7 and the
+actual seven-class `best.pt` artifact.
+
+- Images processed: 10
+- Failures: 0
+- Average inference time: 95.774 ms
+- Detected class counts: `books` 4, `monitor` 2, `table` 1
+
+This was an unlabelled smoke test, not an accuracy evaluation. The full
+representative baseline dataset is still pending.
+
+## Preliminary qualitative review
+
+| Intended scenario | Model result | Preliminary assessment |
+| --- | --- | --- |
+| Bicycle | No detection | Unsupported navigation class |
+| Books | No detection | Missed supported class |
+| Chair | Detected as table | Incorrect class prediction |
+| Door | Two books detections at low confidence | False-positive detections |
+| Empty hallway | No detection | Expected negative result |
+| Person | No detection | Unsupported navigation class |
+| Pole | Monitor and books detections | Multiple false-positive detections |
+| Table | No detection | Missed supported class |
+| TV | Detected as monitor | Confusion between separately defined supported classes |
+| Vehicle | No detection | Unsupported navigation class |
+
+- This was a 10-image unlabelled qualitative smoke test.
+- These observations are not precision, recall, or mAP measurements.
+- The test confirms that the evaluator works against the real model.
+- The active seven-class model does not cover several important navigation scenarios.
+- Supported objects were missed or confused in this small sample.
+- False-positive detections occurred on unrelated navigation scenes.
+- The current model should remain the baseline and should not automatically be
+  accepted as the future production model.
+- A larger representative test set and a labelled validation set are still required.
+
+## Review template
+
+Record qualitative errors alongside the generated JSON rather than changing the
+model or configuration during baseline collection.
+
+| Run | Image or class | False positive | Missed detection | Notes |
+| --- | --- | --- | --- | --- |
+| _add run identifier_ | _add image/class_ | _yes/no and detail_ | _yes/no and detail_ | _observed conditions_ |
+
+## Results
+
+_No evaluation results are recorded in this repository. Add local observations
+to a team-approved report after reviewing the generated output._

--- a/ML_side/tests/test_evaluate_current_model.py
+++ b/ML_side/tests/test_evaluate_current_model.py
@@ -1,0 +1,267 @@
+"""Tests for the read-only current-model baseline evaluation tool."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import evaluate_current_model as evaluator
+
+
+class FakeBox:
+    def __init__(self, class_id: int, confidence: float, coordinates: list[float]) -> None:
+        self.cls = [class_id]
+        self.conf = [confidence]
+        self.xyxy = [coordinates]
+
+
+class FakeResult:
+    def __init__(self, boxes: list[FakeBox]) -> None:
+        self.boxes = boxes
+
+
+class FakeMetricsBox:
+    ap_class_index = [0, 1]
+    p = [0.75, 0.5]
+    r = [0.6, 0.4]
+    ap50 = [0.7, 0.45]
+    ap = [0.55, 0.3]
+
+
+class FakeMetrics:
+    results_dict = {
+        "metrics/precision(B)": 0.625,
+        "metrics/recall(B)": 0.5,
+        "metrics/mAP50(B)": 0.575,
+        "metrics/mAP50-95(B)": 0.425,
+    }
+    nt_per_image = [1, 2, 1]
+    speed = {"inference": 12.5}
+    box = FakeMetricsBox()
+
+
+class FakeModel:
+    names = {0: "book", 1: "monitor"}
+
+    def __init__(self) -> None:
+        self.predict_sources: list[str] = []
+        self.validation_arguments: dict[str, object] | None = None
+
+    def predict(self, *, source: str, save: bool, verbose: bool) -> list[FakeResult]:
+        assert save is False
+        assert verbose is False
+        self.predict_sources.append(source)
+        if Path(source).name == "broken.jpeg":
+            raise RuntimeError("cannot decode image")
+        return [FakeResult([FakeBox(1, 0.91, [1.0, 2.0, 3.0, 4.0])])]
+
+    def val(self, **kwargs: object) -> FakeMetrics:
+        self.validation_arguments = kwargs
+        return FakeMetrics()
+
+
+class MissingNamesModel:
+    pass
+
+
+def make_model_file(tmp_path: Path) -> Path:
+    model_path = tmp_path / "best.pt"
+    model_path.write_bytes(b"walkbuddy-model")
+    return model_path
+
+
+def make_image_folder(tmp_path: Path) -> Path:
+    images = tmp_path / "images"
+    images.mkdir()
+    (images / "scene.jpg").write_bytes(b"image-one")
+    (images / "broken.jpeg").write_bytes(b"image-two")
+    (images / "notes.txt").write_text("unsupported", encoding="utf-8")
+    return images
+
+
+def test_discovers_supported_images_and_skips_unsupported_files(tmp_path: Path) -> None:
+    images = make_image_folder(tmp_path)
+
+    discovery = evaluator.discover_images(images)
+
+    assert [path.name for path in discovery.images] == ["broken.jpeg", "scene.jpg"]
+    assert [path.name for path in discovery.skipped_files] == ["notes.txt"]
+
+
+def test_empty_image_folder_is_rejected(tmp_path: Path) -> None:
+    images = tmp_path / "images"
+    images.mkdir()
+    (images / "notes.txt").write_text("unsupported", encoding="utf-8")
+
+    with pytest.raises(evaluator.EvaluationError, match="No supported images found"):
+        evaluator.discover_images(images)
+
+
+def test_missing_model_is_rejected_before_loading(tmp_path: Path) -> None:
+    images = make_image_folder(tmp_path)
+
+    with pytest.raises(evaluator.EvaluationError, match="Model file is missing"):
+        evaluator.evaluate(
+            model_path=tmp_path / "missing.pt",
+            images_path=images,
+            output_path=tmp_path / "output",
+            yolo_loader=lambda _: pytest.fail("loader must not be called"),
+        )
+
+
+def test_metadata_uses_checksum_and_model_class_mapping(tmp_path: Path) -> None:
+    model_path = make_model_file(tmp_path)
+
+    metadata, _ = evaluator.load_model_and_metadata(model_path, lambda _: FakeModel())
+
+    assert metadata.sha256 == hashlib.sha256(b"walkbuddy-model").hexdigest()
+    assert metadata.class_names == {0: "book", 1: "monitor"}
+
+
+def test_model_loading_and_metadata_failures_are_readable(tmp_path: Path) -> None:
+    model_path = make_model_file(tmp_path)
+
+    with pytest.raises(evaluator.EvaluationError, match="Model loading failed"):
+        evaluator.load_model_and_metadata(
+            model_path, lambda _: (_ for _ in ()).throw(RuntimeError("corrupt"))
+        )
+
+    with pytest.raises(evaluator.EvaluationError, match="malformed model.names"):
+        evaluator.load_model_and_metadata(model_path, lambda _: MissingNamesModel())
+
+
+def test_unlabelled_audit_serialises_predictions_and_preserves_source_images(
+    tmp_path: Path,
+) -> None:
+    model_path = make_model_file(tmp_path)
+    images = make_image_folder(tmp_path)
+    output = tmp_path / "results"
+    before = {path.name: path.read_bytes() for path in images.iterdir()}
+
+    summary = evaluator.evaluate(
+        model_path=model_path,
+        images_path=images,
+        output_path=output,
+        yolo_loader=lambda _: FakeModel(),
+    )
+
+    predictions = json.loads((output / "predictions.json").read_text(encoding="utf-8"))
+    assert summary["total_processed_images"] == 1
+    assert summary["failed_image_count"] == 1
+    assert summary["skipped_file_count"] == 1
+    assert summary["detection_counts_by_class"] == {"monitor": 1}
+    assert predictions["images"][0]["detections"] == [
+        {
+            "bbox_xyxy": [1.0, 2.0, 3.0, 4.0],
+            "class_id": 1,
+            "class_name": "monitor",
+            "confidence": 0.91,
+        }
+    ]
+    assert "not precision, recall, or mAP" in predictions["result_label"]
+    assert {path.name: path.read_bytes() for path in images.iterdir()} == before
+    assert not list(output.glob("*.jpg"))
+    assert (output / "model_metadata.json").is_file()
+    assert (output / "summary.json").is_file()
+    assert (output / "baseline_report.md").is_file()
+
+
+def test_non_empty_output_requires_overwrite(tmp_path: Path) -> None:
+    model_path = make_model_file(tmp_path)
+    images = make_image_folder(tmp_path)
+    output = tmp_path / "results"
+    output.mkdir()
+    (output / "old.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(evaluator.EvaluationError, match="Output directory is not empty"):
+        evaluator.evaluate(
+            model_path=model_path,
+            images_path=images,
+            output_path=output,
+            yolo_loader=lambda _: FakeModel(),
+        )
+
+    evaluator.evaluate(
+        model_path=model_path,
+        images_path=images,
+        output_path=output,
+        overwrite=True,
+        yolo_loader=lambda _: FakeModel(),
+    )
+    assert (output / "old.json").is_file()
+
+
+def test_output_write_failure_is_readable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_write(*_: object, **__: object) -> None:
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(Path, "write_text", fail_write)
+
+    with pytest.raises(evaluator.EvaluationError, match="Output write failed"):
+        evaluator._write_json(tmp_path / "results.json", {"result": "baseline"})
+
+
+def test_dataset_yaml_validation_rejects_missing_and_download_directives(tmp_path: Path) -> None:
+    with pytest.raises(evaluator.EvaluationError, match="Dataset YAML file is missing"):
+        evaluator.validate_dataset_yaml_path(tmp_path / "missing.yaml")
+
+    dataset_yaml = tmp_path / "data.yaml"
+    dataset_yaml.write_text("download: https://example.invalid/data.zip\n", encoding="utf-8")
+    with pytest.raises(evaluator.EvaluationError, match="downloads are refused"):
+        evaluator.validate_dataset_yaml_path(dataset_yaml)
+
+
+def test_labelled_validation_extracts_available_metrics(tmp_path: Path) -> None:
+    model_path = make_model_file(tmp_path)
+    dataset_yaml = tmp_path / "data.yaml"
+    dataset_yaml.write_text("path: local-data\ntrain: images\nval: images\n", encoding="utf-8")
+    output = tmp_path / "results"
+    model = FakeModel()
+
+    summary = evaluator.evaluate(
+        model_path=model_path,
+        dataset_yaml=dataset_yaml,
+        output_path=output,
+        yolo_loader=lambda _: model,
+    )
+
+    metrics = json.loads((output / "validation_metrics.json").read_text(encoding="utf-8"))
+    assert summary["mode"] == "labelled_validation"
+    assert metrics["precision"] == 0.625
+    assert metrics["recall"] == 0.5
+    assert metrics["mAP50"] == 0.575
+    assert metrics["mAP50_95"] == 0.425
+    assert metrics["validation_image_count"] == 3
+    assert metrics["per_class_results"]["0"]["class_name"] == "book"
+    assert model.validation_arguments is not None
+    assert model.validation_arguments["data"] == str(dataset_yaml.resolve())
+    assert model.validation_arguments["plots"] is False
+    assert model.validation_arguments["save_json"] is False
+
+
+def test_main_reports_a_readable_error(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    images = make_image_folder(tmp_path)
+
+    result = evaluator.main(
+        [
+            "--model",
+            str(tmp_path / "missing.pt"),
+            "--images",
+            str(images),
+            "--output",
+            str(tmp_path / "results"),
+        ]
+    )
+
+    assert result == 1
+    assert "Evaluation failed: Model file is missing" in capsys.readouterr().err

--- a/ML_side/tools/evaluate_current_model.py
+++ b/ML_side/tools/evaluate_current_model.py
@@ -1,0 +1,504 @@
+"""Read-only baseline evaluation for a locally supplied WalkBuddy YOLO model."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+import inspect_active_model as model_inspector
+
+
+DEFAULT_MODEL_PATH = Path(__file__).resolve().parents[1] / "models" / "best.pt"
+SUPPORTED_IMAGE_EXTENSIONS = frozenset({".jpg", ".jpeg", ".png"})
+UNLABELLED_AUDIT_LABEL = (
+    "Unlabelled inference audit — these results are not precision, recall, or "
+    "mAP accuracy metrics."
+)
+
+
+class EvaluationError(Exception):
+    """Raised when a baseline evaluation cannot be completed safely."""
+
+
+@dataclass(frozen=True)
+class ImageDiscovery:
+    """Supported images and ignored files discovered in a supplied folder."""
+
+    images: list[Path]
+    skipped_files: list[Path]
+
+
+def validate_model_path(model_path: str | Path) -> Path:
+    """Resolve a local model path without downloading or changing it."""
+    path = Path(model_path).expanduser().resolve()
+    if not path.exists():
+        raise EvaluationError(f"Model file is missing: {path}")
+    if not path.is_file():
+        raise EvaluationError(f"Model path is not a file: {path}")
+    return path
+
+
+def discover_images(images_path: str | Path) -> ImageDiscovery:
+    """Return supported image files without reading, copying, or changing them."""
+    path = Path(images_path).expanduser().resolve()
+    if not path.exists():
+        raise EvaluationError(f"Image folder is missing: {path}")
+    if not path.is_dir():
+        raise EvaluationError(f"Image path is not a directory: {path}")
+
+    files = sorted(candidate for candidate in path.rglob("*") if candidate.is_file())
+    images = [file for file in files if file.suffix.lower() in SUPPORTED_IMAGE_EXTENSIONS]
+    skipped_files = [file for file in files if file not in images]
+    if not images:
+        raise EvaluationError(
+            "No supported images found. Supported extensions are: .jpg, .jpeg, .png."
+        )
+    return ImageDiscovery(images=images, skipped_files=skipped_files)
+
+
+def validate_dataset_yaml_path(dataset_yaml: str | Path) -> Path:
+    """Validate a local dataset YAML and reject automatic-download directives."""
+    path = Path(dataset_yaml).expanduser().resolve()
+    if not path.exists():
+        raise EvaluationError(f"Dataset YAML file is missing: {path}")
+    if not path.is_file():
+        raise EvaluationError(f"Dataset YAML path is not a file: {path}")
+    if path.suffix.lower() not in {".yaml", ".yml"}:
+        raise EvaluationError(f"Dataset YAML path must end in .yaml or .yml: {path}")
+
+    try:
+        contents = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise EvaluationError(f"Dataset YAML could not be read: {path}") from exc
+
+    if re.search(r"^\s*download\s*:", contents, flags=re.MULTILINE):
+        raise EvaluationError(
+            "Dataset YAML declares a download directive. Automatic dataset downloads are refused."
+        )
+    return path
+
+
+def prepare_output_directory(output_path: str | Path, overwrite: bool) -> Path:
+    """Create an output directory, refusing non-empty directories by default."""
+    path = Path(output_path).expanduser().resolve()
+    if path.exists() and not path.is_dir():
+        raise EvaluationError(f"Output path is not a directory: {path}")
+    if path.exists() and any(path.iterdir()) and not overwrite:
+        raise EvaluationError(
+            f"Output directory is not empty: {path}. Use --overwrite to replace result files."
+        )
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise EvaluationError(f"Output directory could not be created: {path}") from exc
+    return path
+
+
+def load_model_and_metadata(
+    model_path: str | Path, yolo_loader: Callable[[str], Any] | None = None
+) -> tuple[model_inspector.ModelMetadata, Any]:
+    """Load only a supplied local model and extract its limited class metadata."""
+    path = validate_model_path(model_path)
+    try:
+        loader = yolo_loader or model_inspector._get_yolo_loader()
+    except model_inspector.InspectionError as exc:
+        raise EvaluationError(str(exc)) from exc
+
+    try:
+        model = loader(str(path))
+    except Exception as exc:
+        raise EvaluationError("Model loading failed.") from exc
+
+    try:
+        class_names = model_inspector.normalise_class_names(model.names)
+    except (AttributeError, model_inspector.InspectionError) as exc:
+        raise EvaluationError("Model metadata is missing or has malformed model.names.") from exc
+
+    metadata = model_inspector.ModelMetadata(
+        path=path,
+        size_bytes=path.stat().st_size,
+        sha256=model_inspector.calculate_sha256(path),
+        class_names=class_names,
+    )
+    return metadata, model
+
+
+def _as_list(value: object) -> list[object]:
+    """Convert common tensor-like values to a flat Python list."""
+    if hasattr(value, "tolist"):
+        value = value.tolist()  # type: ignore[union-attr]
+    if isinstance(value, (list, tuple)):
+        flattened: list[object] = []
+        for item in value:
+            flattened.extend(_as_list(item))
+        return flattened
+    return [value]
+
+
+def _as_float(value: object) -> float:
+    if hasattr(value, "item"):
+        value = value.item()  # type: ignore[union-attr]
+    values = _as_list(value)
+    if len(values) != 1:
+        raise ValueError("Expected a scalar value.")
+    return float(values[0])
+
+
+def _as_int(value: object) -> int:
+    return int(_as_float(value))
+
+
+def serialise_prediction_result(
+    result: Any, image_path: Path, class_names: Mapping[int, str], inference_ms: float
+) -> dict[str, object]:
+    """Serialise only detection fields needed for a reproducible inference audit."""
+    detections: list[dict[str, object]] = []
+    boxes = getattr(result, "boxes", None)
+    if boxes is not None:
+        for box in boxes:
+            coordinates = _as_list(getattr(box, "xyxy"))
+            if len(coordinates) < 4:
+                raise ValueError("Detection box is missing xyxy coordinates.")
+            class_id = _as_int(getattr(box, "cls"))
+            detections.append(
+                {
+                    "class_id": class_id,
+                    "class_name": class_names.get(class_id, f"unknown_{class_id}"),
+                    "confidence": _as_float(getattr(box, "conf")),
+                    "bbox_xyxy": [float(value) for value in coordinates[:4]],
+                }
+            )
+
+    return {
+        "image_filename": image_path.name,
+        "inference_time_ms": round(inference_ms, 3),
+        "detection_count": len(detections),
+        "detections": detections,
+    }
+
+
+def run_unlabelled_inference_audit(
+    model: Any, discovery: ImageDiscovery, class_names: Mapping[int, str]
+) -> tuple[list[dict[str, object]], list[dict[str, str]], dict[str, object]]:
+    """Run local inference one image at a time without saving or copying images."""
+    predictions: list[dict[str, object]] = []
+    failed_images: list[dict[str, str]] = []
+    inference_times: list[float] = []
+    detection_counts: Counter[str] = Counter()
+
+    for image_path in discovery.images:
+        try:
+            started = perf_counter()
+            results = model.predict(source=str(image_path), save=False, verbose=False)
+            inference_ms = (perf_counter() - started) * 1000
+            if not results:
+                raise ValueError("Model returned no result.")
+            prediction = serialise_prediction_result(
+                results[0], image_path, class_names, inference_ms
+            )
+        except Exception as exc:
+            failed_images.append({"image_filename": image_path.name, "error": str(exc)})
+            continue
+
+        predictions.append(prediction)
+        inference_times.append(float(prediction["inference_time_ms"]))
+        for detection in prediction["detections"]:  # type: ignore[union-attr]
+            detection_counts[str(detection["class_name"])] += 1
+
+    summary = {
+        "mode": "unlabelled_inference_audit",
+        "result_label": UNLABELLED_AUDIT_LABEL,
+        "total_discovered_images": len(discovery.images),
+        "total_processed_images": len(predictions),
+        "skipped_file_count": len(discovery.skipped_files),
+        "failed_image_count": len(failed_images),
+        "failed_images": failed_images,
+        "average_inference_time_ms": (
+            round(sum(inference_times) / len(inference_times), 3)
+            if inference_times
+            else None
+        ),
+        "detection_counts_by_class": dict(sorted(detection_counts.items())),
+    }
+    return predictions, failed_images, summary
+
+
+def _metric_value(metrics: Any, mapping_keys: Sequence[str], attribute_names: Sequence[str]) -> float | None:
+    results_dict = getattr(metrics, "results_dict", None)
+    if isinstance(results_dict, Mapping):
+        for key in mapping_keys:
+            if key in results_dict:
+                try:
+                    return _as_float(results_dict[key])
+                except (TypeError, ValueError):
+                    return None
+
+    box = getattr(metrics, "box", None)
+    for attribute_name in attribute_names:
+        value = getattr(box, attribute_name, None) if box is not None else None
+        if value is None:
+            value = getattr(metrics, attribute_name, None)
+        if value is not None:
+            try:
+                return _as_float(value)
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _sequence_value(value: object, index: int) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(_as_list(value)[index])
+    except (IndexError, TypeError, ValueError):
+        return None
+
+
+def extract_validation_metrics(
+    metrics: Any, class_names: Mapping[int, str]
+) -> dict[str, object]:
+    """Extract available Ultralytics validation metrics without inventing values."""
+    metric_specs = {
+        "precision": (["metrics/precision(B)", "precision"], ["mp", "precision"]),
+        "recall": (["metrics/recall(B)", "recall"], ["mr", "recall"]),
+        "mAP50": (["metrics/mAP50(B)", "mAP50"], ["map50"]),
+        "mAP50_95": (["metrics/mAP50-95(B)", "mAP50-95"], ["map"]),
+    }
+    extracted = {
+        name: _metric_value(metrics, mapping_keys, attributes)
+        for name, (mapping_keys, attributes) in metric_specs.items()
+    }
+    notes = [
+        f"{name} was unavailable from the Ultralytics validation result."
+        for name, value in extracted.items()
+        if value is None
+    ]
+
+    image_counts = getattr(metrics, "nt_per_image", None)
+    validation_image_count = len(_as_list(image_counts)) if image_counts is not None else None
+    if validation_image_count is None:
+        notes.append("Validation image count was unavailable from the Ultralytics result.")
+
+    speed = getattr(metrics, "speed", None)
+    inference_timing_ms = (
+        {str(key): float(value) for key, value in speed.items()}
+        if isinstance(speed, Mapping)
+        else None
+    )
+    if inference_timing_ms is None:
+        notes.append("Inference timing was unavailable from the Ultralytics result.")
+
+    per_class_results: dict[str, dict[str, object]] = {}
+    box = getattr(metrics, "box", None)
+    class_indices = getattr(box, "ap_class_index", None) if box is not None else None
+    if class_indices is not None:
+        for index, raw_class_id in enumerate(_as_list(class_indices)):
+            class_id = int(raw_class_id)
+            per_class_results[str(class_id)] = {
+                "class_name": class_names.get(class_id, f"unknown_{class_id}"),
+                "precision": _sequence_value(getattr(box, "p", None), index),
+                "recall": _sequence_value(getattr(box, "r", None), index),
+                "mAP50": _sequence_value(getattr(box, "ap50", None), index),
+                "mAP50_95": _sequence_value(getattr(box, "ap", None), index),
+            }
+    else:
+        notes.append("Per-class validation results were unavailable from the Ultralytics result.")
+
+    return {
+        **extracted,
+        "validation_image_count": validation_image_count,
+        "inference_timing_ms": inference_timing_ms,
+        "per_class_results": per_class_results or None,
+        "metric_notes": notes,
+    }
+
+
+def _metadata_payload(metadata: model_inspector.ModelMetadata) -> dict[str, object]:
+    return {
+        "filename": metadata.path.name,
+        "resolved_path": str(metadata.path),
+        "file_size_bytes": metadata.size_bytes,
+        "sha256": metadata.sha256,
+        "class_count": len(metadata.class_names),
+        "class_id_to_name": {str(key): value for key, value in metadata.class_names.items()},
+    }
+
+
+def _write_json(path: Path, payload: Mapping[str, object]) -> None:
+    try:
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    except (OSError, TypeError) as exc:
+        raise EvaluationError(f"Output write failed: {path}") from exc
+
+
+def _write_report(path: Path, content: str) -> None:
+    try:
+        path.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        raise EvaluationError(f"Output write failed: {path}") from exc
+
+
+def _format_report(
+    metadata: model_inspector.ModelMetadata, summary: Mapping[str, object]
+) -> str:
+    lines = [
+        "# Current WalkBuddy Model Baseline",
+        "",
+        "## Model metadata",
+        "",
+        f"- Filename: `{metadata.path.name}`",
+        f"- Resolved path: `{metadata.path}`",
+        f"- File size: {metadata.size_bytes} bytes",
+        f"- SHA-256: `{metadata.sha256}`",
+        f"- Class count: {len(metadata.class_names)}",
+        "- Class mapping:",
+    ]
+    lines.extend(f"  - {class_id}: `{name}`" for class_id, name in metadata.class_names.items())
+    lines.extend(["", "## Evaluation result", ""])
+
+    if summary["mode"] == "unlabelled_inference_audit":
+        lines.extend(
+            [
+                f"> {UNLABELLED_AUDIT_LABEL}",
+                "",
+                f"- Processed images: {summary['total_processed_images']}",
+                f"- Failed images: {summary['failed_image_count']}",
+                f"- Unsupported files skipped: {summary['skipped_file_count']}",
+                f"- Average inference time: {summary['average_inference_time_ms']} ms",
+                "",
+                "See `predictions.json` for per-image detections and failures.",
+            ]
+        )
+    else:
+        metrics = summary["validation_metrics"]
+        lines.extend(
+            [
+                "Labelled validation uses Ultralytics validation metrics from the supplied local dataset YAML.",
+                "",
+                f"- Precision: {metrics['precision']}",
+                f"- Recall: {metrics['recall']}",
+                f"- mAP50: {metrics['mAP50']}",
+                f"- mAP50-95: {metrics['mAP50_95']}",
+                f"- Validation image count: {metrics['validation_image_count']}",
+                "",
+                "See `validation_metrics.json` for available per-class values and metric notes.",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def evaluate(
+    *,
+    model_path: str | Path,
+    output_path: str | Path,
+    images_path: str | Path | None = None,
+    dataset_yaml: str | Path | None = None,
+    overwrite: bool = False,
+    yolo_loader: Callable[[str], Any] | None = None,
+) -> dict[str, object]:
+    """Evaluate a local model in exactly one safe, explicit mode."""
+    if (images_path is None) == (dataset_yaml is None):
+        raise EvaluationError("Provide exactly one of an image folder or a dataset YAML file.")
+
+    model = validate_model_path(model_path)
+    discovery = discover_images(images_path) if images_path is not None else None
+    dataset = validate_dataset_yaml_path(dataset_yaml) if dataset_yaml is not None else None
+    output = prepare_output_directory(output_path, overwrite)
+    metadata, yolo_model = load_model_and_metadata(model, yolo_loader)
+    metadata_payload = _metadata_payload(metadata)
+
+    if discovery is not None:
+        predictions, failed_images, summary = run_unlabelled_inference_audit(
+            yolo_model, discovery, metadata.class_names
+        )
+        _write_json(output / "model_metadata.json", metadata_payload)
+        _write_json(
+            output / "predictions.json",
+            {
+                "mode": "unlabelled_inference_audit",
+                "result_label": UNLABELLED_AUDIT_LABEL,
+                "images": predictions,
+                "failed_images": failed_images,
+            },
+        )
+        _write_json(output / "summary.json", summary)
+    else:
+        try:
+            validation_result = yolo_model.val(
+                data=str(dataset),
+                project=str(output),
+                name="ultralytics_validation",
+                exist_ok=True,
+                plots=False,
+                save_json=False,
+                verbose=False,
+            )
+        except Exception as exc:
+            raise EvaluationError("Labelled validation failed.") from exc
+
+        validation_metrics = extract_validation_metrics(validation_result, metadata.class_names)
+        summary = {
+            "mode": "labelled_validation",
+            "dataset_yaml": str(dataset),
+            "validation_metrics": validation_metrics,
+        }
+        _write_json(output / "model_metadata.json", metadata_payload)
+        _write_json(output / "validation_metrics.json", validation_metrics)
+        _write_json(output / "summary.json", summary)
+
+    _write_report(output / "baseline_report.md", _format_report(metadata, summary))
+    return summary
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read-only WalkBuddy model baseline evaluation."
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL_PATH,
+        help=f"Local YOLO model file (default: {DEFAULT_MODEL_PATH})",
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--images", help="Folder of local .jpg, .jpeg, or .png images.")
+    mode.add_argument("--dataset-yaml", help="Local labelled YOLO dataset YAML for validation.")
+    parser.add_argument("--output", required=True, help="Directory for generated result files.")
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow writing result files into a non-empty output directory.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the evaluator and return a non-zero exit code on a safe failure."""
+    args = parse_args(argv)
+    try:
+        summary = evaluate(
+            model_path=args.model,
+            output_path=args.output,
+            images_path=args.images,
+            dataset_yaml=args.dataset_yaml,
+            overwrite=args.overwrite,
+        )
+    except EvaluationError as exc:
+        print(f"Evaluation failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Baseline evaluation complete: {args.output}")
+    print(f"Mode: {summary['mode']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a reproducible, read-only evaluation tool for establishing the baseline of the current WalkBuddy `best.pt` model.

The tool supports:

- unlabelled image-folder inference audits;
- labelled Ultralytics validation datasets;
- model metadata and checksum recording;
- prediction and timing summaries;
- machine-readable JSON output;
- readable Markdown reports;
- safe output overwrite protection.

## Added

- `ML_side/tools/evaluate_current_model.py`
- `ML_side/tests/test_evaluate_current_model.py`
- `ML_side/docs/current_model_baseline.md`

## Updated

- `ML_side/README.md`
- `.gitignore`

## Verified model

The current local artifact was confirmed as:

- 7 classes
- 6,244,458 bytes
- SHA-256: `198df54da4f6aa071b342bee77b100e78f243df785b325ec364036e106572238`

Classes:

- `book`
- `books`
- `monitor`
- `office-chair`
- `whiteboard`
- `table`
- `tv`

The repository configuration still lists an additional `couch` class, which remains documented as a model/configuration lineage mismatch.

## Real local smoke test

The evaluator was run on Windows using:

- the actual `best.pt`;
- Ultralytics 8.4.7;
- 10 local images.

Results:

- 10 images processed;
- 0 failures;
- 0 unsupported files skipped;
- average inference time: 95.774 ms.

Detected-class counts:

- `books`: 4
- `monitor`: 2
- `table`: 1

This was an unlabelled qualitative smoke test, not a precision, recall, or mAP evaluation.

The small review showed missed supported objects, class confusion, false-positive detections, and an inability to detect proposed navigation classes that are outside the current taxonomy.

## Verification

```text
python -m pytest ML_side/tests -q
21 passed