### PR TITLE
fix(backend): correct predictive path package imports

### DIFF
--- a/software_side/walkbuddy_reactNative/backend/predictive_path/evaluate_model.py
+++ b/software_side/walkbuddy_reactNative/backend/predictive_path/evaluate_model.py
@@ -1,38 +1,48 @@
-import pandas as pd
-from sklearn.metrics import classification_report, confusion_matrix, accuracy_score
-from ml_predictor import MLPredictor
+if __package__:
+    from .ml_predictor import MLPredictor
+else:
+    from ml_predictor import MLPredictor
 
-df = pd.read_csv("sensor_data.csv")
 
-y_true = df["risk_label"].astype(str).tolist()
+def main() -> None:
+    import pandas as pd
+    from sklearn.metrics import accuracy_score, classification_report, confusion_matrix
 
-ml = MLPredictor()
+    df = pd.read_csv("sensor_data.csv")
 
-y_pred = []
+    y_true = df["risk_label"].astype(str).tolist()
 
-for _, row in df.iterrows():
-    result = ml.predict(row["speed"], row["heading"], row["gyro"])
+    ml = MLPredictor()
 
-    # Handle different possible return types from ml_predictor.py
-    if isinstance(result, dict):
-        pred = result.get("prediction") or result.get("label") or result.get("risk_label")
-    elif isinstance(result, tuple) or isinstance(result, list):
-        pred = result[0]
-    else:
-        pred = result
+    y_pred = []
 
-    y_pred.append(str(pred))
+    for _, row in df.iterrows():
+        result = ml.predict(row["speed"], row["heading"], row["gyro"])
 
-labels = ["front", "front_right", "safe"]
+        # Handle different possible return types from ml_predictor.py
+        if isinstance(result, dict):
+            pred = result.get("prediction") or result.get("label") or result.get("risk_label")
+        elif isinstance(result, tuple) or isinstance(result, list):
+            pred = result[0]
+        else:
+            pred = result
 
-print("\nAccuracy:")
-print(accuracy_score(y_true, y_pred))
+        y_pred.append(str(pred))
 
-print("\nConfusion Matrix:")
-print(confusion_matrix(y_true, y_pred, labels=labels))
+    labels = ["front", "front_right", "safe"]
 
-print("\nLabels order:")
-print(labels)
+    print("\nAccuracy:")
+    print(accuracy_score(y_true, y_pred))
 
-print("\nClassification Report:")
-print(classification_report(y_true, y_pred, labels=labels))
+    print("\nConfusion Matrix:")
+    print(confusion_matrix(y_true, y_pred, labels=labels))
+
+    print("\nLabels order:")
+    print(labels)
+
+    print("\nClassification Report:")
+    print(classification_report(y_true, y_pred, labels=labels))
+
+
+if __name__ == "__main__":
+    main()

--- a/software_side/walkbuddy_reactNative/backend/predictive_path/predict_with_model.py
+++ b/software_side/walkbuddy_reactNative/backend/predictive_path/predict_with_model.py
@@ -13,8 +13,11 @@ Usage
 import sys
 import os
 sys.path.insert(0, os.path.dirname(__file__))
- 
-from ml_predictor import MLPredictor
+
+if __package__:
+    from .ml_predictor import MLPredictor
+else:
+    from ml_predictor import MLPredictor
  
  
 def predict_single(speed: float, heading: float, gyro: float) -> None:

--- a/software_side/walkbuddy_reactNative/backend/predictive_path/predictive_path.py
+++ b/software_side/walkbuddy_reactNative/backend/predictive_path/predictive_path.py
@@ -13,7 +13,11 @@ Components
 """
  
 import math
-from ml_predictor import MLPredictor
+
+if __package__:
+    from .ml_predictor import MLPredictor
+else:
+    from ml_predictor import MLPredictor
  
  
 # ── PathPredictor ─────────────────────────────────────────────────────────────

--- a/software_side/walkbuddy_reactNative/backend/tests/test_predictive_path_package_imports.py
+++ b/software_side/walkbuddy_reactNative/backend/tests/test_predictive_path_package_imports.py
@@ -1,0 +1,98 @@
+"""Package and standalone import checks for Predictive Path utilities."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+PREDICTIVE_PATH_DIR = BACKEND_DIR / "predictive_path"
+PACKAGE_MODULES = (
+    "predictive_path.predictive_path",
+    "predictive_path.evaluate_model",
+    "predictive_path.predict_with_model",
+)
+STANDALONE_SCRIPTS = (
+    "predictive_path.py",
+    "evaluate_model.py",
+    "predict_with_model.py",
+)
+_MISSING = object()
+
+
+def _is_predictive_path_module(module_name: str) -> bool:
+    return (
+        module_name == "ml_predictor"
+        or module_name == "predictive_path"
+        or module_name.startswith("predictive_path.")
+    )
+
+
+def _clear_predictive_path_modules() -> None:
+    for module_name in tuple(sys.modules):
+        if _is_predictive_path_module(module_name):
+            sys.modules.pop(module_name)
+
+
+@pytest.fixture
+def import_environment() -> Iterator[None]:
+    """Provide only the NumPy symbol needed while modules are imported."""
+    original_modules = {
+        module_name: module
+        for module_name, module in sys.modules.items()
+        if _is_predictive_path_module(module_name)
+    }
+    original_sys_path = sys.path.copy()
+    original_numpy = sys.modules.get("numpy", _MISSING)
+
+    numpy_stub = ModuleType("numpy")
+    numpy_stub.ndarray = object
+
+    try:
+        _clear_predictive_path_modules()
+        sys.path.insert(0, str(BACKEND_DIR))
+        sys.modules["numpy"] = numpy_stub
+        yield
+    finally:
+        _clear_predictive_path_modules()
+        if original_numpy is _MISSING:
+            sys.modules.pop("numpy", None)
+        else:
+            sys.modules["numpy"] = original_numpy
+        sys.modules.update(original_modules)
+        sys.path[:] = original_sys_path
+
+
+def test_predictive_path_modules_import_through_package(
+    import_environment: None,
+) -> None:
+    predictor_module = importlib.import_module("predictive_path.ml_predictor")
+
+    for module_name in PACKAGE_MODULES:
+        module = importlib.import_module(module_name)
+        assert module.MLPredictor is predictor_module.MLPredictor
+
+
+@pytest.mark.parametrize("script_name", STANDALONE_SCRIPTS)
+def test_predictive_path_scripts_keep_direct_import_support(
+    import_environment: None, script_name: str
+) -> None:
+    sys.path.insert(0, str(PREDICTIVE_PATH_DIR))
+    module_name = f"direct_import_{Path(script_name).stem}"
+    spec = importlib.util.spec_from_file_location(
+        module_name, PREDICTIVE_PATH_DIR / script_name
+    )
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    predictor_module = importlib.import_module("ml_predictor")
+    assert module.MLPredictor is predictor_module.MLPredictor


### PR DESCRIPTION
## Summary

Fixes the Predictive Path import failure that occurs when the backend loads the feature as a Python package.

The affected modules previously used `from ml_predictor import MLPredictor`, which caused:

`ModuleNotFoundError: No module named 'ml_predictor'`

## Changes

- Updated Predictive Path modules to use package-relative imports when loaded by the backend.
- Preserved existing direct-script execution.
- Moved the execution logic in `evaluate_model.py` into `main()`.
- Prevented importing `evaluate_model.py` from reading `sensor_data.csv`, loading model files, running predictions, or printing evaluation results.
- Added focused tests for package and direct-script imports.
- Ensured tests restore `sys.modules`, `sys.path`, and the original NumPy module state after execution.

## Verification

- Predictive Path import tests: **4 passed**
- Focused and relevant backend tests: **23 passed**
- ML-side tests: **30 passed**
- `git diff --check`: **passed**

Tests were run in the existing verification environment. The backend virtual environment is valid and uses Python 3.11.9, but it does not currently include `pytest`.

## Scope

No changes were made to:

- API routes, request methods, or response schemas
- frontend files
- model or `.pkl` files
- datasets
- dependency versions
- safety or risk behaviour
- Vision Assist behaviour