### PR TITLE
Add navigation dataset manifest validation

### DIFF
--- a/ML_side/config/navigation_mvp.yaml
+++ b/ML_side/config/navigation_mvp.yaml
@@ -1,0 +1,17 @@
+# Placeholder configuration for the proposed navigation-model MVP taxonomy.
+# It does not identify an approved or locally available dataset release.
+path: datasets/releases/navigation_mvp_v1
+train: train/images
+val: validation/images
+test: test/images
+
+nc: 8
+names:
+  0: person
+  1: stairs
+  2: door
+  3: chair
+  4: table
+  5: pole
+  6: bicycle
+  7: vehicle

--- a/ML_side/datasets/README.md
+++ b/ML_side/datasets/README.md
@@ -1,0 +1,73 @@
+# WalkBuddy navigation dataset manifests
+
+This directory contains Git-safe metadata for proposed navigation-model dataset releases. A manifest records dataset lineage, licence-review evidence, target-taxonomy mapping, split membership, integrity counts, and external-storage references. It does not make a dataset legally approved, fit for training, or safe for deployment.
+
+## Approved MVP taxonomy
+
+Only these classes are allowed in a release manifest, in this exact ID order:
+
+| ID | Class |
+|---:|---|
+| 0 | person |
+| 1 | stairs |
+| 2 | door |
+| 3 | chair |
+| 4 | table |
+| 5 | pole |
+| 6 | bicycle |
+| 7 | vehicle |
+
+The companion YOLO configuration is [`../config/navigation_mvp.yaml`](../config/navigation_mvp.yaml). Its dataset root is a placeholder; it does not identify an approved local dataset.
+
+## Files and storage boundary
+
+- [`manifest.schema.json`](manifest.schema.json) defines the version `1.0.0` manifest structure.
+- [`sample_manifest.json`](sample_manifest.json) is fictional, non-sensitive, and demonstrates the required fields. It is not an approved dataset release.
+- Images, annotations, model weights, consent records, and other sensitive or large material belong in controlled external storage. Commit only the manifest and related text configuration.
+
+## Create and validate a manifest
+
+Copy the sample, replace every fictional value with reviewed metadata, and keep image and label paths relative to the controlled dataset root. Use explicit class-mapping rationale for every source-to-target mapping; excluded and unmapped source classes must remain visible rather than being silently reclassified.
+
+From the repository root in Windows PowerShell:
+
+```powershell
+python .\ML_side\tools\validate_dataset_manifest.py .\ML_side\datasets\sample_manifest.json
+```
+
+On macOS or Linux:
+
+```bash
+python ML_side/tools/validate_dataset_manifest.py ML_side/datasets/sample_manifest.json
+```
+
+To check that referenced relative image and label files exist, provide the local controlled dataset root explicitly:
+
+```powershell
+python .\ML_side\tools\validate_dataset_manifest.py `
+  .\ML_side\datasets\sample_manifest.json `
+  --dataset-root D:\controlled-datasets\navigation-mvp-v1 `
+  --check-files
+```
+
+Without `--check-files`, validation is metadata-only and does not access datasets. The validator rejects absolute personal paths, file URIs, literal or percent-encoded path traversal, and mixed slash/backslash traversal in release records. File checking confirms only that listed paths exist beneath the supplied root; it does not inspect image content, annotations, consent, or licence validity.
+
+## What validation does and does not establish
+
+Structural validation uses the bundled Draft 2020-12 `manifest.schema.json` through a project-specific standard-library implementation. It enforces the schema keywords used here: `$defs`, `$ref`, `type`, `required`, `properties`, `additionalProperties`, `items`, `minItems`, `minLength`, `minimum`, `pattern`, `enum`, and `const`. The tool rejects a future schema that introduces an unsupported validation keyword. It is not a complete general-purpose JSON Schema implementation. Semantic validation enforces the approved taxonomy, mapping consistency, split isolation, safe relative paths, checksums, count and dimension bounds, and optional file existence.
+
+When supplied, checksums must be SHA-256 values: exactly 64 hexadecimal characters, optionally prefixed with `sha256:`. Uppercase and lowercase hexadecimal characters are accepted deliberately; checksum comparison is outside this metadata validator.
+
+Validation does not grant formal legal or licensing approval. A manifest must contain licence evidence and a reviewer decision, but the projectâ€™s authorised reviewers remain responsible for evaluating the evidence. Likewise, a valid manifest is not evidence that a dataset is representative, unbiased, sufficiently labelled, or suitable for a production navigation model.
+
+## Split leakage protection and future training
+
+Every sample records a group or sequence ID. The validator rejects a group reused across train, validation, and test splits, helping prevent near-duplicate frames from inflating future evaluation results. It also rejects duplicate sample IDs and images reused across splits.
+
+After the dataset has independent review and an approved release decision, a future training workflow can use the manifest to build controlled YOLO split directories and update the MVP dataset configuration. Training, downloading data, and model selection are deliberately outside this manifest-validation tool.
+
+## Known limitations
+
+- File checks are opt-in and cannot validate external storage availability or permissions.
+- Bounding-box validation applies only when boxes are recorded directly in the manifest; normal YOLO label-file parsing is future work.
+- The manifest records review evidence but cannot replace legal, privacy, accessibility, or data-governance review.

--- a/ML_side/datasets/manifest.schema.json
+++ b/ML_side/datasets/manifest.schema.json
@@ -1,0 +1,275 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://walkbuddy.example/schema/dataset-manifest-1.0.0.json",
+  "title": "WalkBuddy navigation dataset manifest",
+  "description": "Git-safe metadata for a candidate WalkBuddy navigation-model dataset release.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "dataset",
+    "source_provenance",
+    "licence",
+    "taxonomy",
+    "splits",
+    "quality",
+    "storage_release"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "dataset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "source_version",
+        "description",
+        "release_date",
+        "release_decision"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1, "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "name": { "type": "string", "minLength": 1 },
+        "source_version": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "release_date": { "type": "string", "minLength": 1 },
+        "release_decision": {
+          "type": "string",
+          "enum": ["draft", "under_review", "approved_for_training", "rejected", "retired", "example_only"]
+        }
+      }
+    },
+    "source_provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_reference", "accessed_on"],
+      "properties": {
+        "source_reference": { "type": "string", "minLength": 1 },
+        "accessed_on": { "type": "string", "minLength": 1 },
+        "original_source": { "type": "string", "minLength": 1 },
+        "publisher": { "type": "string", "minLength": 1 }
+      }
+    },
+    "licence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "evidence_reference",
+        "machine_learning_use_permitted",
+        "modification_permitted",
+        "redistribution_permitted",
+        "attribution_required",
+        "attribution_requirements",
+        "restrictions",
+        "reviewer",
+        "review_date",
+        "review_decision"
+      ],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "evidence_reference": { "type": "string", "minLength": 1 },
+        "machine_learning_use_permitted": { "type": "boolean" },
+        "modification_permitted": { "type": "boolean" },
+        "redistribution_permitted": { "type": "boolean" },
+        "attribution_required": { "type": "boolean" },
+        "attribution_requirements": { "type": "string" },
+        "restrictions": { "type": "string" },
+        "reviewer": { "type": "string", "minLength": 1 },
+        "review_date": { "type": "string", "minLength": 1 },
+        "review_decision": {
+          "type": "string",
+          "enum": ["pending", "approved", "conditional", "rejected", "example_only"]
+        }
+      }
+    },
+    "taxonomy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target_classes",
+        "class_mappings",
+        "excluded_source_classes",
+        "unmapped_source_classes",
+        "bounding_box_coordinate_format"
+      ],
+      "properties": {
+        "target_classes": {
+          "type": "array",
+          "minItems": 8,
+          "items": { "$ref": "#/$defs/targetClass" }
+        },
+        "class_mappings": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/classMapping" }
+        },
+        "excluded_source_classes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/sourceClassDecision" }
+        },
+        "unmapped_source_classes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/sourceClassDecision" }
+        },
+        "bounding_box_coordinate_format": {
+          "type": "string",
+          "enum": ["normalized_xywh", "pixel_xywh"]
+        }
+      }
+    },
+    "splits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["train", "validation", "test"],
+      "properties": {
+        "train": { "$ref": "#/$defs/split" },
+        "validation": { "$ref": "#/$defs/split" },
+        "test": { "$ref": "#/$defs/split" }
+      }
+    },
+    "quality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "image_count",
+        "annotation_count",
+        "duplicate_count",
+        "corrupt_file_count",
+        "invalid_annotation_count",
+        "excluded_sample_count",
+        "quality_review_status",
+        "known_limitations"
+      ],
+      "properties": {
+        "image_count": { "type": "integer", "minimum": 0 },
+        "annotation_count": { "type": "integer", "minimum": 0 },
+        "duplicate_count": { "type": "integer", "minimum": 0 },
+        "corrupt_file_count": { "type": "integer", "minimum": 0 },
+        "invalid_annotation_count": { "type": "integer", "minimum": 0 },
+        "excluded_sample_count": { "type": "integer", "minimum": 0 },
+        "checksums": {
+          "type": "object",
+          "additionalProperties": { "type": "string", "pattern": "^(sha256:)?[A-Fa-f0-9]{64}$" }
+        },
+        "quality_review_status": {
+          "type": "string",
+          "enum": ["not_reviewed", "in_progress", "completed", "blocked", "example_only"]
+        },
+        "known_limitations": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "storage_release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authoritative_storage_reference",
+        "git_safe_metadata_only",
+        "release_version"
+      ],
+      "properties": {
+        "authoritative_storage_reference": { "type": "string", "minLength": 1 },
+        "git_safe_metadata_only": { "type": "boolean", "const": true },
+        "release_version": { "type": "string", "minLength": 1 },
+        "manifest_checksum": { "type": "string", "pattern": "^(sha256:)?[A-Fa-f0-9]{64}$" },
+        "associated_git_commit": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "$defs": {
+    "targetClass": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "integer", "minimum": 0 },
+        "name": { "type": "string", "minLength": 1 }
+      }
+    },
+    "classMapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_class",
+        "target_class_id",
+        "target_class_name",
+        "mapping_rationale",
+        "review_decision"
+      ],
+      "properties": {
+        "source_class": { "type": "string", "minLength": 1 },
+        "target_class_id": { "type": "integer", "minimum": 0 },
+        "target_class_name": { "type": "string", "minLength": 1 },
+        "mapping_rationale": { "type": "string", "minLength": 1 },
+        "review_decision": { "type": "string", "const": "mapped" }
+      }
+    },
+    "sourceClassDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_class", "reason"],
+      "properties": {
+        "source_class": { "type": "string", "minLength": 1 },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "split": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["samples"],
+      "properties": {
+        "samples": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/sample" }
+        }
+      }
+    },
+    "sample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sample_id", "image_path", "group_id", "labelled"],
+      "properties": {
+        "sample_id": { "type": "string", "minLength": 1 },
+        "image_path": { "type": "string", "minLength": 1 },
+        "label_path": { "type": "string", "minLength": 1 },
+        "group_id": { "type": "string", "minLength": 1 },
+        "labelled": { "type": "boolean" },
+        "checksum": { "type": "string", "pattern": "^(sha256:)?[A-Fa-f0-9]{64}$" },
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 },
+        "annotation_summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "bounding_box_count": { "type": "integer", "minimum": 0 },
+            "class_ids": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 0 }
+            }
+          }
+        },
+        "bounding_boxes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/boundingBox" }
+        }
+      }
+    },
+    "boundingBox": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["class_id", "x", "y", "width", "height"],
+      "properties": {
+        "class_id": { "type": "integer", "minimum": 0 },
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "width": { "type": "number" },
+        "height": { "type": "number" }
+      }
+    }
+  }
+}

--- a/ML_side/datasets/sample_manifest.json
+++ b/ML_side/datasets/sample_manifest.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": "1.0.0",
+  "dataset": {
+    "id": "example-navigation-mvp-v1",
+    "name": "Fictional navigation MVP manifest example",
+    "source_version": "fictional-source-v1.0",
+    "description": "A non-sensitive, fictional manifest that demonstrates WalkBuddy dataset metadata only.",
+    "release_date": "2026-08-05",
+    "release_decision": "example_only"
+  },
+  "source_provenance": {
+    "source_reference": "example://walkbuddy/fictional-navigation-source-v1",
+    "accessed_on": "2026-08-05",
+    "original_source": "Fictional source used solely to demonstrate the manifest format.",
+    "publisher": "Example dataset steward"
+  },
+  "licence": {
+    "name": "Example licence (fictional)",
+    "evidence_reference": "example://walkbuddy/licensing/example-evidence",
+    "machine_learning_use_permitted": true,
+    "modification_permitted": true,
+    "redistribution_permitted": false,
+    "attribution_required": true,
+    "attribution_requirements": "Example attribution requirement for documentation only.",
+    "restrictions": "This fictional example is not a real licence decision.",
+    "reviewer": "Example dataset governance reviewer",
+    "review_date": "2026-08-05",
+    "review_decision": "example_only"
+  },
+  "taxonomy": {
+    "target_classes": [
+      { "id": 0, "name": "person" },
+      { "id": 1, "name": "stairs" },
+      { "id": 2, "name": "door" },
+      { "id": 3, "name": "chair" },
+      { "id": 4, "name": "table" },
+      { "id": 5, "name": "pole" },
+      { "id": 6, "name": "bicycle" },
+      { "id": 7, "name": "vehicle" }
+    ],
+    "class_mappings": [
+      { "source_class": "pedestrian", "target_class_id": 0, "target_class_name": "person", "mapping_rationale": "Explicit source-to-target review.", "review_decision": "mapped" },
+      { "source_class": "staircase", "target_class_id": 1, "target_class_name": "stairs", "mapping_rationale": "Explicit source-to-target review.", "review_decision": "mapped" },
+      { "source_class": "entry-door", "target_class_id": 2, "target_class_name": "door", "mapping_rationale": "Explicit source-to-target review.", "review_decision": "mapped" },
+      { "source_class": "seat-chair", "target_class_id": 3, "target_class_name": "chair", "mapping_rationale": "Explicit source-to-target review.", "review_decision": "mapped" },
+      { "source_class": "desk-table", "target_class_id": 4, "target_class_name": "table", "mapping_rationale": "Explicit source-to-target review.", "review_decision": "mapped" },
+      { "source_class": "support-pole", "target_class_id": 5, "target_class_name": "pole", "mapping_rationale": "Explicit source-to-target review.", "review_decision": "mapped" },
+      { "source_class": "bike", "target_class_id": 6, "target_class_name": "bicycle", "mapping_rationale": "Explicit source-to-target review.", "review_decision": "mapped" },
+      { "source_class": "road-vehicle", "target_class_id": 7, "target_class_name": "vehicle", "mapping_rationale": "Explicit source-to-target review.", "review_decision": "mapped" }
+    ],
+    "excluded_source_classes": [
+      { "source_class": "ceiling", "reason": "Not an approved MVP navigation target class." }
+    ],
+    "unmapped_source_classes": [
+      { "source_class": "unclear-reflection", "reason": "Requires explicit review before any target mapping." }
+    ],
+    "bounding_box_coordinate_format": "normalized_xywh"
+  },
+  "splits": {
+    "train": {
+      "samples": [
+        {
+          "sample_id": "example-train-person-001",
+          "image_path": "train/images/person_001.jpg",
+          "label_path": "train/labels/person_001.txt",
+          "group_id": "example-sequence-train-a",
+          "labelled": true,
+          "width": 1280,
+          "height": 720,
+          "annotation_summary": { "bounding_box_count": 1, "class_ids": [0] }
+        },
+        {
+          "sample_id": "example-train-stairs-001",
+          "image_path": "train/images/stairs_001.jpg",
+          "label_path": "train/labels/stairs_001.txt",
+          "group_id": "example-sequence-train-b",
+          "labelled": true,
+          "width": 1280,
+          "height": 720,
+          "annotation_summary": { "bounding_box_count": 1, "class_ids": [1] }
+        }
+      ]
+    },
+    "validation": {
+      "samples": [
+        {
+          "sample_id": "example-validation-door-001",
+          "image_path": "validation/images/door_001.jpg",
+          "label_path": "validation/labels/door_001.txt",
+          "group_id": "example-sequence-validation-a",
+          "labelled": true,
+          "width": 1280,
+          "height": 720,
+          "annotation_summary": { "bounding_box_count": 1, "class_ids": [2] }
+        }
+      ]
+    },
+    "test": {
+      "samples": [
+        {
+          "sample_id": "example-test-chair-001",
+          "image_path": "test/images/chair_001.jpg",
+          "label_path": "test/labels/chair_001.txt",
+          "group_id": "example-sequence-test-a",
+          "labelled": true,
+          "width": 1280,
+          "height": 720,
+          "annotation_summary": { "bounding_box_count": 1, "class_ids": [3] }
+        }
+      ]
+    }
+  },
+  "quality": {
+    "image_count": 4,
+    "annotation_count": 4,
+    "duplicate_count": 0,
+    "corrupt_file_count": 0,
+    "invalid_annotation_count": 0,
+    "excluded_sample_count": 0,
+    "quality_review_status": "example_only",
+    "known_limitations": [
+      "This is a fictional metadata-only example, not a candidate dataset release.",
+      "The placeholder paths are intentionally not checked unless a dataset root is supplied."
+    ]
+  },
+  "storage_release": {
+    "authoritative_storage_reference": "example://walkbuddy/controlled-storage/example-navigation-mvp-v1",
+    "git_safe_metadata_only": true,
+    "release_version": "v0.0-example",
+    "associated_git_commit": "not-applicable-example-only"
+  }
+}

--- a/ML_side/tests/test_dataset_manifest_validation.py
+++ b/ML_side/tests/test_dataset_manifest_validation.py
@@ -1,0 +1,349 @@
+"""Tests for the Git-safe WalkBuddy navigation dataset manifest validator."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ML_SIDE_DIR = Path(__file__).resolve().parents[1]
+TOOLS_DIR = ML_SIDE_DIR / "tools"
+SAMPLE_MANIFEST_PATH = ML_SIDE_DIR / "datasets" / "sample_manifest.json"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import validate_dataset_manifest as validator
+
+
+def sample_manifest() -> dict[str, object]:
+    return json.loads(SAMPLE_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def validation_messages(
+    manifest: dict[str, object], *, dataset_root: Path | None = None, check_files: bool = False
+) -> list[str]:
+    return [
+        f"{issue.location}: {issue.message}"
+        for issue in validator.validate_manifest(
+            manifest, dataset_root=dataset_root, check_files=check_files
+        )
+    ]
+
+
+def first_sample(manifest: dict[str, object], split: str = "train") -> dict[str, object]:
+    return manifest["splits"][split]["samples"][0]  # type: ignore[index]
+
+
+def write_manifest(tmp_path: Path, manifest: dict[str, object]) -> Path:
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return path
+
+
+def test_sample_manifest_passes_without_dataset_file_checks() -> None:
+    assert validation_messages(sample_manifest()) == []
+
+
+def test_schema_guard_rejects_an_unsupported_keyword() -> None:
+    with pytest.raises(validator.ManifestValidationError, match="Unsupported schema keyword"):
+        validator._ensure_supported_schema_keywords({"format": "date"})
+
+
+def test_missing_required_field_fails() -> None:
+    manifest = sample_manifest()
+    del manifest["dataset"]["description"]  # type: ignore[index]
+
+    assert "missing required field 'description'" in "\n".join(validation_messages(manifest))
+
+
+def test_missing_licence_evidence_fails() -> None:
+    manifest = sample_manifest()
+    manifest["licence"]["evidence_reference"] = ""  # type: ignore[index]
+
+    assert "evidence_reference" in "\n".join(validation_messages(manifest))
+
+
+def test_unknown_target_class_fails() -> None:
+    manifest = sample_manifest()
+    mapping = manifest["taxonomy"]["class_mappings"][0]  # type: ignore[index]
+    mapping["target_class_id"] = 99
+    mapping["target_class_name"] = "unsupported-target"
+
+    assert "matching ID/name pair" in "\n".join(validation_messages(manifest))
+
+
+def test_incorrect_target_class_id_or_order_fails() -> None:
+    manifest = sample_manifest()
+    targets = manifest["taxonomy"]["target_classes"]  # type: ignore[index]
+    targets[0], targets[1] = targets[1], targets[0]
+
+    assert "must exactly match the approved IDs and order" in "\n".join(validation_messages(manifest))
+
+
+def test_duplicate_target_class_names_fail() -> None:
+    manifest = sample_manifest()
+    manifest["taxonomy"]["target_classes"][1]["name"] = "person"  # type: ignore[index]
+
+    assert "duplicate target class name" in "\n".join(validation_messages(manifest))
+
+
+def test_duplicate_target_class_ids_fail() -> None:
+    manifest = sample_manifest()
+    manifest["taxonomy"]["target_classes"][1]["id"] = 0  # type: ignore[index]
+
+    assert "duplicate target class ID" in "\n".join(validation_messages(manifest))
+
+
+def test_duplicate_sample_ids_fail() -> None:
+    manifest = sample_manifest()
+    first_sample(manifest, "validation")["sample_id"] = first_sample(manifest)["sample_id"]
+
+    assert "duplicates sample_id" in "\n".join(validation_messages(manifest))
+
+
+def test_image_reused_across_splits_fails() -> None:
+    manifest = sample_manifest()
+    first_sample(manifest, "validation")["image_path"] = first_sample(manifest)["image_path"]
+
+    assert "image is reused across splits" in "\n".join(validation_messages(manifest))
+
+
+def test_normalised_image_path_reused_across_splits_fails() -> None:
+    manifest = sample_manifest()
+    first_sample(manifest, "validation")["image_path"] = first_sample(manifest)["image_path"].replace(
+        "/", "\\"
+    )
+
+    assert "image is reused across splits" in "\n".join(validation_messages(manifest))
+
+
+def test_duplicate_image_record_in_one_split_fails() -> None:
+    manifest = sample_manifest()
+    duplicate = copy.deepcopy(first_sample(manifest))
+    duplicate["sample_id"] = "example-train-person-duplicate"
+    manifest["splits"]["train"]["samples"].append(duplicate)  # type: ignore[index]
+
+    assert "image appears more than once in the same split" in "\n".join(
+        validation_messages(manifest)
+    )
+
+
+def test_group_reused_across_splits_fails() -> None:
+    manifest = sample_manifest()
+    first_sample(manifest, "validation")["group_id"] = first_sample(manifest)["group_id"]
+
+    assert "group or sequence" in "\n".join(validation_messages(manifest))
+
+
+def test_path_traversal_fails() -> None:
+    manifest = sample_manifest()
+    first_sample(manifest)["image_path"] = "train/images/../private.jpg"
+
+    assert "path traversal" in "\n".join(validation_messages(manifest))
+
+
+def test_personal_absolute_windows_path_fails() -> None:
+    manifest = sample_manifest()
+    first_sample(manifest)["image_path"] = r"C:\dataset\private.jpg"
+
+    assert "must not be an absolute Windows or POSIX path" in "\n".join(validation_messages(manifest))
+
+
+def test_personal_absolute_posix_path_fails() -> None:
+    manifest = sample_manifest()
+    first_sample(manifest)["image_path"] = "/data/private.jpg"
+
+    assert "must not be an absolute Windows or POSIX path" in "\n".join(validation_messages(manifest))
+
+
+@pytest.mark.parametrize(
+    "unsafe_path",
+    (
+        r"C:drive-relative.jpg",
+        r"\\server\share\private.jpg",
+        r"..\private.jpg",
+        "%2e%2e%2fprivate.jpg",
+        "file:///private.jpg",
+    ),
+)
+def test_other_unsafe_windows_and_encoded_paths_fail(unsafe_path: str) -> None:
+    manifest = sample_manifest()
+    first_sample(manifest)["image_path"] = unsafe_path
+
+    messages = "\n".join(validation_messages(manifest))
+    assert "path traversal" in messages or "absolute" in messages or "file URI" in messages
+
+
+def test_personal_absolute_provenance_and_storage_references_fail() -> None:
+    manifest = sample_manifest()
+    manifest["source_provenance"]["source_reference"] = r"C:\dataset\source"  # type: ignore[index]
+    manifest["storage_release"]["authoritative_storage_reference"] = "/data/private"  # type: ignore[index]
+
+    messages = "\n".join(validation_messages(manifest))
+    assert "$.source_provenance.source_reference" in messages
+    assert "$.storage_release.authoritative_storage_reference" in messages
+def test_invalid_release_decision_fails() -> None:
+    manifest = sample_manifest()
+    manifest["dataset"]["release_decision"] = "approved-because-schema-passed"  # type: ignore[index]
+
+    assert "must be one of" in "\n".join(validation_messages(manifest))
+
+
+def test_negative_quality_counts_fail() -> None:
+    manifest = sample_manifest()
+    manifest["quality"]["invalid_annotation_count"] = -1  # type: ignore[index]
+
+    assert "must be at least 0" in "\n".join(validation_messages(manifest))
+
+
+def test_malformed_checksums_fail() -> None:
+    manifest = sample_manifest()
+    first_sample(manifest)["checksum"] = "not-a-sha256"
+
+    assert "required format" in "\n".join(validation_messages(manifest))
+
+
+@pytest.mark.parametrize("checksum", ("a" * 64, "sha256:" + "A" * 64))
+def test_sha256_checksums_accept_uppercase_and_lowercase_hexadecimal(checksum: str) -> None:
+    manifest = sample_manifest()
+    first_sample(manifest)["checksum"] = checksum
+
+    assert validation_messages(manifest) == []
+
+
+def test_non_positive_image_dimensions_fail() -> None:
+    manifest = sample_manifest()
+    first_sample(manifest)["width"] = 0
+
+    assert "must be at least 1" in "\n".join(validation_messages(manifest))
+
+
+def test_missing_referenced_files_fail_when_checking_is_enabled(tmp_path: Path) -> None:
+    messages = validation_messages(sample_manifest(), dataset_root=tmp_path, check_files=True)
+
+    assert any("referenced file is missing" in message for message in messages)
+
+
+def test_file_checking_requires_an_explicit_dataset_root() -> None:
+    messages = validation_messages(sample_manifest(), check_files=True)
+
+    assert messages == ["--check-files: requires --dataset-root."]
+
+
+def test_valid_relative_paths_pass_with_file_checking(tmp_path: Path) -> None:
+    manifest = sample_manifest()
+    for _, _, sample in validator._iter_samples(manifest):
+        for path_name in ("image_path", "label_path"):
+            path_value = sample.get(path_name)
+            if isinstance(path_value, str):
+                path = tmp_path / Path(path_value)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("placeholder", encoding="utf-8")
+
+    assert validation_messages(manifest, dataset_root=tmp_path, check_files=True) == []
+
+
+def test_file_checking_reports_a_missing_label_file_with_its_field_context(tmp_path: Path) -> None:
+    manifest = sample_manifest()
+    for _, _, sample in validator._iter_samples(manifest):
+        image_path = tmp_path / Path(str(sample["image_path"]))
+        image_path.parent.mkdir(parents=True, exist_ok=True)
+        image_path.write_text("placeholder", encoding="utf-8")
+
+    messages = validation_messages(manifest, dataset_root=tmp_path, check_files=True)
+
+    assert any("$.splits.train.samples[0].label_path" in message for message in messages)
+    assert any("referenced file is missing" in message for message in messages)
+
+
+def test_file_checks_reject_a_symlink_that_resolves_outside_the_dataset_root(tmp_path: Path) -> None:
+    dataset_root = tmp_path / "dataset-root"
+    external_directory = tmp_path / "external-directory"
+    dataset_root.mkdir()
+    external_directory.mkdir()
+    (external_directory / "outside.jpg").write_text("placeholder", encoding="utf-8")
+    link = dataset_root / "linked"
+    try:
+        link.symlink_to(external_directory, target_is_directory=True)
+    except OSError:
+        pytest.skip("The current platform does not allow test symlink creation.")
+
+    manifest = sample_manifest()
+    sample = first_sample(manifest)
+    sample["image_path"] = "linked/outside.jpg"
+    sample["labelled"] = False
+    sample.pop("label_path")
+
+    assert "resolves outside the supplied dataset root" in "\n".join(
+        validation_messages(manifest, dataset_root=dataset_root, check_files=True)
+    )
+
+
+def test_cli_reports_ordinary_validation_failure_without_traceback(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    manifest = sample_manifest()
+    first_sample(manifest)["image_path"] = "../not-allowed.jpg"
+
+    assert validator.main([str(write_manifest(tmp_path, manifest))]) == 1
+    error_output = capsys.readouterr().err
+    assert "Dataset manifest validation failed" in error_output
+    assert "Traceback" not in error_output
+
+
+def test_cli_reports_multiple_ordinary_validation_errors(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    manifest = sample_manifest()
+    first_sample(manifest)["image_path"] = "../not-allowed.jpg"
+    manifest["dataset"]["release_decision"] = "not-a-controlled-decision"  # type: ignore[index]
+    manifest["quality"]["image_count"] = -1  # type: ignore[index]
+
+    assert validator.main([str(write_manifest(tmp_path, manifest))]) == 1
+    error_output = capsys.readouterr().err
+    assert "failed (3 issue(s))" in error_output
+    assert "image_path" in error_output
+    assert "release_decision" in error_output
+    assert "image_count" in error_output
+    assert "Traceback" not in error_output
+
+
+def test_cli_accepts_a_utf8_bom_manifest(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    manifest_path = tmp_path / "bom-manifest.json"
+    manifest_path.write_text(json.dumps(sample_manifest()), encoding="utf-8-sig")
+
+    assert validator.main([str(manifest_path)]) == 0
+    assert "Dataset manifest validation passed" in capsys.readouterr().out
+
+
+def test_cli_help_succeeds(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exit_result:
+        validator.main(["--help"])
+
+    assert exit_result.value.code == 0
+    assert "--check-files" in capsys.readouterr().out
+
+
+def test_direct_bounding_boxes_must_fit_declared_normalized_bounds() -> None:
+    manifest = sample_manifest()
+    sample = first_sample(manifest)
+    sample["bounding_boxes"] = [
+        {"class_id": 0, "x": 0.8, "y": 0.1, "width": 0.3, "height": 0.2}
+    ]
+
+    assert "normalized image bounds" in "\n".join(validation_messages(manifest))
+
+
+def test_conflicting_source_class_mapping_fails() -> None:
+    manifest = sample_manifest()
+    conflicting_mapping = copy.deepcopy(manifest["taxonomy"]["class_mappings"][0])  # type: ignore[index]
+    conflicting_mapping["target_class_id"] = 1
+    conflicting_mapping["target_class_name"] = "stairs"
+    manifest["taxonomy"]["class_mappings"].append(conflicting_mapping)  # type: ignore[index]
+
+    assert "conflicts with an existing source-class mapping" in "\n".join(
+        validation_messages(manifest)
+    )

--- a/ML_side/tools/validate_dataset_manifest.py
+++ b/ML_side/tools/validate_dataset_manifest.py
@@ -1,0 +1,739 @@
+"""Validate Git-safe WalkBuddy navigation dataset manifests without network access.
+
+The structural validator implements a project-specific subset of the bundled
+Draft 2020-12 JSON Schema document: ``$defs``, ``$ref``, ``type``, ``required``,
+``properties``, ``additionalProperties``, ``items``, ``minItems``,
+``minLength``, ``minimum``, ``pattern``, ``enum``, and ``const``. It is not a
+general-purpose JSON Schema implementation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from functools import lru_cache
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any
+from urllib.parse import unquote
+
+
+ML_SIDE_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_SCHEMA_PATH = ML_SIDE_DIR / "datasets" / "manifest.schema.json"
+APPROVED_TAXONOMY: tuple[tuple[int, str], ...] = (
+    (0, "person"),
+    (1, "stairs"),
+    (2, "door"),
+    (3, "chair"),
+    (4, "table"),
+    (5, "pole"),
+    (6, "bicycle"),
+    (7, "vehicle"),
+)
+APPROVED_TARGETS = dict(APPROVED_TAXONOMY)
+IMAGE_EXTENSIONS = frozenset({".jpg", ".jpeg", ".png", ".bmp", ".webp", ".tif", ".tiff"})
+LABEL_EXTENSIONS = frozenset({".txt"})
+SUPPORTED_SCHEMA_KEYWORDS = frozenset(
+    {
+        "$defs",
+        "$ref",
+        "type",
+        "required",
+        "properties",
+        "additionalProperties",
+        "items",
+        "minItems",
+        "minLength",
+        "minimum",
+        "pattern",
+        "enum",
+        "const",
+    }
+)
+SCHEMA_ANNOTATION_KEYWORDS = frozenset({"$schema", "$id", "title", "description"})
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """One readable structural or semantic validation problem."""
+
+    location: str
+    message: str
+
+
+class ManifestValidationError(Exception):
+    """Raised when a manifest or the local validation schema cannot be read."""
+
+
+def _issue(location: str, message: str) -> ValidationIssue:
+    return ValidationIssue(location=location, message=message)
+
+
+@lru_cache(maxsize=1)
+def load_schema(schema_path: Path = DEFAULT_SCHEMA_PATH) -> dict[str, object]:
+    """Read the bundled JSON Schema without accessing datasets or the network."""
+    try:
+        with schema_path.open("r", encoding="utf-8-sig") as schema_file:
+            schema = json.load(schema_file)
+    except FileNotFoundError as exc:
+        raise ManifestValidationError(f"Schema file is missing: {schema_path}") from exc
+    except OSError as exc:
+        raise ManifestValidationError(f"Schema file could not be read: {schema_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ManifestValidationError(f"Schema file is not valid JSON: {schema_path}") from exc
+
+    if not isinstance(schema, dict):
+        raise ManifestValidationError(f"Schema root must be an object: {schema_path}")
+    _ensure_supported_schema_keywords(schema)
+    return schema
+
+
+def _ensure_supported_schema_keywords(schema: Mapping[str, object], location: str = "$") -> None:
+    """Reject a future schema keyword that this project-specific validator cannot enforce."""
+    for keyword, value in schema.items():
+        if keyword not in SUPPORTED_SCHEMA_KEYWORDS | SCHEMA_ANNOTATION_KEYWORDS:
+            raise ManifestValidationError(f"Unsupported schema keyword {keyword!r} at {location}.")
+
+        if keyword == "properties" and isinstance(value, Mapping):
+            for property_name, property_schema in value.items():
+                if isinstance(property_schema, Mapping):
+                    _ensure_supported_schema_keywords(property_schema, f"{location}.properties.{property_name}")
+        elif keyword in {"items", "additionalProperties"} and isinstance(value, Mapping):
+            _ensure_supported_schema_keywords(value, f"{location}.{keyword}")
+        elif keyword == "$defs" and isinstance(value, Mapping):
+            for definition_name, definition_schema in value.items():
+                if isinstance(definition_schema, Mapping):
+                    _ensure_supported_schema_keywords(definition_schema, f"{location}.$defs.{definition_name}")
+
+
+def _is_integer(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _matches_type(value: object, expected_type: str) -> bool:
+    type_checks = {
+        "object": lambda: isinstance(value, dict),
+        "array": lambda: isinstance(value, list),
+        "string": lambda: isinstance(value, str),
+        "integer": lambda: _is_integer(value),
+        "number": lambda: _is_number(value),
+        "boolean": lambda: isinstance(value, bool),
+        "null": lambda: value is None,
+    }
+    check = type_checks.get(expected_type)
+    return check() if check is not None else True
+
+
+def _resolve_reference(reference: str, root_schema: Mapping[str, object]) -> Mapping[str, object]:
+    if not reference.startswith("#/"):
+        raise ManifestValidationError(f"Unsupported schema reference: {reference}")
+
+    target: object = root_schema
+    for raw_part in reference[2:].split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(target, Mapping) or part not in target:
+            raise ManifestValidationError(f"Schema reference cannot be resolved: {reference}")
+        target = target[part]
+
+    if not isinstance(target, Mapping):
+        raise ManifestValidationError(f"Schema reference is not an object: {reference}")
+    return target
+
+
+def _schema_issues(
+    value: object,
+    schema: Mapping[str, object],
+    root_schema: Mapping[str, object],
+    location: str,
+) -> list[ValidationIssue]:
+    """Validate the JSON-Schema subset used by the bundled manifest schema."""
+    reference = schema.get("$ref")
+    if isinstance(reference, str):
+        return _schema_issues(value, _resolve_reference(reference, root_schema), root_schema, location)
+
+    issues: list[ValidationIssue] = []
+    expected_type = schema.get("type")
+    if isinstance(expected_type, str) and not _matches_type(value, expected_type):
+        return [_issue(location, f"must be a {expected_type}.")]
+
+    if "const" in schema and value != schema["const"]:
+        issues.append(_issue(location, f"must equal {schema['const']!r}."))
+
+    allowed_values = schema.get("enum")
+    if isinstance(allowed_values, list) and value not in allowed_values:
+        issues.append(_issue(location, f"must be one of {allowed_values!r}."))
+
+    if isinstance(value, str):
+        min_length = schema.get("minLength")
+        if _is_integer(min_length) and len(value) < min_length:
+            issues.append(_issue(location, f"must contain at least {min_length} character(s)."))
+        pattern = schema.get("pattern")
+        if isinstance(pattern, str) and re.search(pattern, value) is None:
+            issues.append(_issue(location, "does not match the required format."))
+
+    if _is_number(value):
+        minimum = schema.get("minimum")
+        if _is_number(minimum) and value < minimum:
+            issues.append(_issue(location, f"must be at least {minimum}."))
+
+    if isinstance(value, list):
+        min_items = schema.get("minItems")
+        if _is_integer(min_items) and len(value) < min_items:
+            issues.append(_issue(location, f"must contain at least {min_items} item(s)."))
+        item_schema = schema.get("items")
+        if isinstance(item_schema, Mapping):
+            for index, item in enumerate(value):
+                issues.extend(_schema_issues(item, item_schema, root_schema, f"{location}[{index}]"))
+
+    if isinstance(value, dict):
+        required = schema.get("required")
+        if isinstance(required, list):
+            for property_name in required:
+                if isinstance(property_name, str) and property_name not in value:
+                    issues.append(_issue(location, f"is missing required field {property_name!r}."))
+
+        properties = schema.get("properties")
+        property_schemas = properties if isinstance(properties, Mapping) else {}
+        for property_name, property_value in value.items():
+            property_location = f"{location}.{property_name}"
+            property_schema = property_schemas.get(property_name)
+            if isinstance(property_schema, Mapping):
+                issues.extend(
+                    _schema_issues(property_value, property_schema, root_schema, property_location)
+                )
+                continue
+
+            additional_properties = schema.get("additionalProperties", True)
+            if additional_properties is False:
+                issues.append(_issue(property_location, "is not an allowed field."))
+            elif isinstance(additional_properties, Mapping):
+                issues.extend(
+                    _schema_issues(property_value, additional_properties, root_schema, property_location)
+                )
+
+    return issues
+
+
+def _as_mapping(value: object) -> Mapping[str, object] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _as_list(value: object) -> list[object] | None:
+    return value if isinstance(value, list) else None
+
+
+def _normalise_identifier(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip().casefold()
+
+
+def _unsafe_path_reason(path: str) -> str | None:
+    if path.casefold().startswith("file:"):
+        return "must not be a file URI."
+
+    windows_path = PureWindowsPath(path)
+    posix_path = PurePosixPath(path.replace("\\", "/"))
+    if (
+        windows_path.is_absolute()
+        or posix_path.is_absolute()
+        or path.startswith("\\")
+        or re.match(r"^[A-Za-z]:", path) is not None
+    ):
+        return "must not be an absolute Windows or POSIX path."
+
+    parts = [part for part in re.split(r"[\\/]", path) if part]
+    if ".." in parts:
+        return "must not contain path traversal ('..')."
+    return None
+
+
+def _is_safe_relative_path(value: object) -> tuple[bool, str | None]:
+    if not isinstance(value, str) or not value.strip():
+        return False, "must be a non-empty relative path."
+
+    path = value.strip()
+    path_reason = _unsafe_path_reason(path)
+    if path_reason is not None:
+        return False, path_reason
+
+    decoded_path = path
+    for _ in range(2):
+        next_path = unquote(decoded_path)
+        if next_path == decoded_path:
+            break
+        decoded_path = next_path
+    decoded_reason = _unsafe_path_reason(decoded_path)
+    if decoded_reason is not None:
+        return False, f"must not use percent-encoded syntax that {decoded_reason.removeprefix('must not ')}"
+    return True, None
+
+
+def _resolve_dataset_reference(dataset_root: Path, relative_path: str) -> Path | None:
+    """Resolve a checked file path and reject a symlink that leaves the dataset root."""
+    candidate = dataset_root.joinpath(*relative_path.replace("\\", "/").split("/")).resolve()
+    try:
+        candidate.relative_to(dataset_root)
+    except ValueError:
+        return None
+    return candidate
+
+
+def _validate_date(value: object, location: str, issues: list[ValidationIssue]) -> None:
+    if not isinstance(value, str):
+        return
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        issues.append(_issue(location, "must be an ISO 8601 calendar date (YYYY-MM-DD)."))
+
+
+def _iter_samples(manifest: Mapping[str, object]) -> Iterable[tuple[str, int, Mapping[str, object]]]:
+    splits = _as_mapping(manifest.get("splits"))
+    if splits is None:
+        return
+    for split_name in ("train", "validation", "test"):
+        split = _as_mapping(splits.get(split_name))
+        samples = _as_list(split.get("samples")) if split is not None else None
+        if samples is None:
+            continue
+        for index, sample in enumerate(samples):
+            mapping = _as_mapping(sample)
+            if mapping is not None:
+                yield split_name, index, mapping
+
+
+def _validate_taxonomy(manifest: Mapping[str, object], issues: list[ValidationIssue]) -> None:
+    taxonomy = _as_mapping(manifest.get("taxonomy"))
+    if taxonomy is None:
+        return
+
+    target_classes = _as_list(taxonomy.get("target_classes"))
+    actual_taxonomy: list[tuple[object, object]] = []
+    target_ids: list[int] = []
+    if target_classes is not None:
+        for index, target in enumerate(target_classes):
+            target_mapping = _as_mapping(target)
+            if target_mapping is None:
+                continue
+            target_id = target_mapping.get("id")
+            target_name = target_mapping.get("name")
+            actual_taxonomy.append((target_id, target_name))
+            if _is_integer(target_id):
+                target_ids.append(target_id)
+            if _is_integer(target_id) and target_name not in {name for _, name in APPROVED_TAXONOMY}:
+                issues.append(
+                    _issue(
+                        f"$.taxonomy.target_classes[{index}].name",
+                        "is not an approved WalkBuddy target class.",
+                    )
+                )
+
+    if actual_taxonomy != list(APPROVED_TAXONOMY):
+        issues.append(
+            _issue(
+                "$.taxonomy.target_classes",
+                "must exactly match the approved IDs and order: "
+                + ", ".join(f"{class_id}:{name}" for class_id, name in APPROVED_TAXONOMY)
+                + ".",
+            )
+        )
+    for target_id, count in Counter(target_ids).items():
+        if count > 1:
+            issues.append(
+                _issue("$.taxonomy.target_classes", f"contains duplicate target class ID {target_id}.")
+            )
+    target_names = [target_name for _, target_name in actual_taxonomy if isinstance(target_name, str)]
+    for target_name, count in Counter(target_names).items():
+        if count > 1:
+            issues.append(
+                _issue("$.taxonomy.target_classes", f"contains duplicate target class name {target_name!r}.")
+            )
+
+    class_mappings = _as_list(taxonomy.get("class_mappings"))
+    mapped_sources: dict[str, tuple[object, object]] = {}
+    if class_mappings is not None:
+        for index, mapping in enumerate(class_mappings):
+            mapping_data = _as_mapping(mapping)
+            if mapping_data is None:
+                continue
+            location = f"$.taxonomy.class_mappings[{index}]"
+            source_class = _normalise_identifier(mapping_data.get("source_class"))
+            target_id = mapping_data.get("target_class_id")
+            target_name = mapping_data.get("target_class_name")
+            rationale = mapping_data.get("mapping_rationale")
+
+            if source_class is not None:
+                prior_target = mapped_sources.get(source_class)
+                target = (target_id, target_name)
+                if prior_target is not None:
+                    if prior_target == target:
+                        issues.append(_issue(location, "duplicates an existing source-class mapping."))
+                    else:
+                        issues.append(_issue(location, "conflicts with an existing source-class mapping."))
+                else:
+                    mapped_sources[source_class] = target
+
+            if not _is_integer(target_id) or APPROVED_TARGETS.get(target_id) != target_name:
+                issues.append(
+                    _issue(
+                        location,
+                        "must map to a matching ID/name pair in the approved WalkBuddy taxonomy.",
+                    )
+                )
+            if isinstance(rationale, str) and rationale and not rationale.strip():
+                issues.append(
+                    _issue(location, "must include a non-empty mapping_rationale for an explicit mapping.")
+                )
+
+    source_decision_sets: dict[str, set[str]] = defaultdict(set)
+    for category in ("excluded_source_classes", "unmapped_source_classes"):
+        decisions = _as_list(taxonomy.get(category))
+        if decisions is None:
+            continue
+        for index, decision in enumerate(decisions):
+            decision_data = _as_mapping(decision)
+            if decision_data is None:
+                continue
+            source_class = _normalise_identifier(decision_data.get("source_class"))
+            if source_class is not None:
+                source_decision_sets[source_class].add(category)
+            reason = decision_data.get("reason")
+            if isinstance(reason, str) and reason and not reason.strip():
+                issues.append(_issue(f"$.taxonomy.{category}[{index}]", "must include a non-empty reason."))
+
+    for source_class in mapped_sources:
+        if source_class in source_decision_sets:
+            issues.append(
+                _issue(
+                    "$.taxonomy",
+                    f"source class {source_class!r} cannot be both mapped and excluded or unmapped.",
+                )
+            )
+    for source_class, categories in source_decision_sets.items():
+        if len(categories) > 1:
+            issues.append(
+                _issue(
+                    "$.taxonomy",
+                    f"source class {source_class!r} cannot be both excluded and unmapped.",
+                )
+            )
+
+
+def _validate_bounding_boxes(
+    sample: Mapping[str, object], coordinate_format: object, location: str, issues: list[ValidationIssue]
+) -> None:
+    boxes = _as_list(sample.get("bounding_boxes"))
+    if boxes is None:
+        return
+
+    image_width = sample.get("width")
+    image_height = sample.get("height")
+    for index, box in enumerate(boxes):
+        box_data = _as_mapping(box)
+        if box_data is None:
+            continue
+        box_location = f"{location}.bounding_boxes[{index}]"
+        class_id = box_data.get("class_id")
+        if not _is_integer(class_id) or class_id not in APPROVED_TARGETS:
+            issues.append(_issue(f"{box_location}.class_id", "must be an approved target class ID."))
+
+        values: dict[str, float] = {}
+        for field_name in ("x", "y", "width", "height"):
+            value = box_data.get(field_name)
+            if not _is_number(value) or not math.isfinite(float(value)):
+                issues.append(_issue(f"{box_location}.{field_name}", "must be a finite number."))
+                continue
+            values[field_name] = float(value)
+        if len(values) != 4:
+            continue
+
+        x, y, width, height = (values[name] for name in ("x", "y", "width", "height"))
+        if width <= 0 or height <= 0:
+            issues.append(_issue(box_location, "must have positive width and height."))
+            continue
+
+        if coordinate_format == "normalized_xywh":
+            if x < 0 or y < 0 or x + width > 1 or y + height > 1:
+                issues.append(
+                    _issue(box_location, "must fit within normalized image bounds from 0 to 1.")
+                )
+        elif coordinate_format == "pixel_xywh":
+            if not _is_integer(image_width) or not _is_integer(image_height):
+                issues.append(
+                    _issue(location, "requires positive width and height for pixel_xywh bounding boxes.")
+                )
+            elif x < 0 or y < 0 or x + width > image_width or y + height > image_height:
+                issues.append(_issue(box_location, "must fit within the declared image bounds."))
+
+
+def _validate_samples(
+    manifest: Mapping[str, object], dataset_root: Path | None, check_files: bool, issues: list[ValidationIssue]
+) -> None:
+    taxonomy = _as_mapping(manifest.get("taxonomy"))
+    coordinate_format = taxonomy.get("bounding_box_coordinate_format") if taxonomy else None
+    sample_ids: dict[str, str] = {}
+    image_splits: dict[str, set[str]] = defaultdict(set)
+    group_splits: dict[str, set[str]] = defaultdict(set)
+    image_locations: dict[str, str] = {}
+    image_occurrences: dict[str, list[str]] = defaultdict(list)
+
+    root_is_available = True
+    resolved_root: Path | None = None
+    if check_files and dataset_root is not None:
+        resolved_root = dataset_root.expanduser().resolve()
+        if not resolved_root.is_dir():
+            issues.append(_issue("--dataset-root", f"is not an existing directory: {resolved_root}"))
+            root_is_available = False
+
+    for split_name, index, sample in _iter_samples(manifest):
+        location = f"$.splits.{split_name}.samples[{index}]"
+        sample_id = _normalise_identifier(sample.get("sample_id"))
+        if sample_id is not None:
+            prior_location = sample_ids.get(sample_id)
+            if prior_location is not None:
+                issues.append(_issue(location, f"duplicates sample_id from {prior_location}."))
+            else:
+                sample_ids[sample_id] = location
+
+        image_path = sample.get("image_path")
+        image_is_safe = False
+        if isinstance(image_path, str) and image_path.strip():
+            image_is_safe, image_path_error = _is_safe_relative_path(image_path)
+            if not image_is_safe:
+                issues.append(_issue(f"{location}.image_path", image_path_error or "is invalid."))
+        if image_is_safe and isinstance(image_path, str):
+            image_suffix = Path(image_path).suffix.lower()
+            if image_suffix not in IMAGE_EXTENSIONS:
+                issues.append(_issue(f"{location}.image_path", "has an unsupported image extension."))
+            normalized_image = image_path.replace("\\", "/").casefold()
+            image_splits[normalized_image].add(split_name)
+            image_locations.setdefault(normalized_image, location)
+            image_occurrences[normalized_image].append(location)
+
+        label_path = sample.get("label_path")
+        if sample.get("labelled") is True and not isinstance(label_path, str):
+            issues.append(_issue(location, "requires label_path when labelled is true."))
+        label_is_safe = False
+        if isinstance(label_path, str) and label_path.strip():
+            label_is_safe, label_path_error = _is_safe_relative_path(label_path)
+            if not label_is_safe:
+                issues.append(_issue(f"{location}.label_path", label_path_error or "is invalid."))
+            elif Path(label_path).suffix.lower() not in LABEL_EXTENSIONS:
+                issues.append(_issue(f"{location}.label_path", "has an unsupported label extension."))
+
+        group_id = _normalise_identifier(sample.get("group_id"))
+        if group_id is not None:
+            group_splits[group_id].add(split_name)
+
+        annotation_summary = _as_mapping(sample.get("annotation_summary"))
+        if annotation_summary is not None:
+            class_ids = _as_list(annotation_summary.get("class_ids"))
+            if class_ids is not None:
+                for class_index, class_id in enumerate(class_ids):
+                    if not _is_integer(class_id) or class_id not in APPROVED_TARGETS:
+                        issues.append(
+                            _issue(
+                                f"{location}.annotation_summary.class_ids[{class_index}]",
+                                "must be an approved target class ID.",
+                            )
+                        )
+
+        _validate_bounding_boxes(sample, coordinate_format, location, issues)
+
+        if check_files and root_is_available and resolved_root is not None:
+            for path_name, path_value in (("image_path", image_path), ("label_path", label_path)):
+                if path_value is None or not isinstance(path_value, str):
+                    continue
+                path_is_safe = (path_name == "image_path" and image_is_safe) or (
+                    path_name == "label_path" and label_is_safe
+                )
+                if not path_is_safe:
+                    continue
+                candidate = _resolve_dataset_reference(resolved_root, path_value)
+                if candidate is None:
+                    issues.append(
+                        _issue(
+                            f"{location}.{path_name}",
+                            "resolves outside the supplied dataset root.",
+                        )
+                    )
+                elif not candidate.is_file():
+                    issues.append(_issue(f"{location}.{path_name}", f"referenced file is missing: {candidate}"))
+
+    for image_path, splits in image_splits.items():
+        if len(splits) > 1:
+            issues.append(
+                _issue(
+                    image_locations[image_path],
+                    f"image is reused across splits: {', '.join(sorted(splits))}.",
+                )
+            )
+        elif len(image_occurrences[image_path]) > 1:
+            issues.append(
+                _issue(
+                    image_locations[image_path],
+                    "image appears more than once in the same split.",
+                )
+            )
+    for group_id, splits in group_splits.items():
+        if len(splits) > 1:
+            issues.append(
+                _issue(
+                    "$.splits",
+                    f"group or sequence {group_id!r} is reused across splits: {', '.join(sorted(splits))}.",
+                )
+            )
+
+
+def _validate_quality_and_release(manifest: Mapping[str, object], issues: list[ValidationIssue]) -> None:
+    dataset = _as_mapping(manifest.get("dataset"))
+    provenance = _as_mapping(manifest.get("source_provenance"))
+    licence = _as_mapping(manifest.get("licence"))
+    storage_release = _as_mapping(manifest.get("storage_release"))
+
+    if dataset is not None:
+        _validate_date(dataset.get("release_date"), "$.dataset.release_date", issues)
+    if provenance is not None:
+        _validate_date(provenance.get("accessed_on"), "$.source_provenance.accessed_on", issues)
+        source_reference = provenance.get("source_reference")
+        source_is_safe, source_path_error = _is_safe_relative_path(source_reference)
+        if (
+            not source_is_safe
+            and source_path_error is not None
+            and ("absolute" in source_path_error or "file URI" in source_path_error)
+        ):
+            issues.append(
+                _issue(
+                    "$.source_provenance.source_reference",
+                    "must not be a personal absolute filesystem path.",
+                )
+            )
+    if licence is not None:
+        _validate_date(licence.get("review_date"), "$.licence.review_date", issues)
+        if licence.get("attribution_required") is True:
+            requirements = licence.get("attribution_requirements")
+            if not isinstance(requirements, str) or not requirements.strip():
+                issues.append(
+                    _issue(
+                        "$.licence.attribution_requirements",
+                        "must be non-empty when attribution_required is true.",
+                    )
+                )
+
+    if storage_release is not None:
+        storage_reference = storage_release.get("authoritative_storage_reference")
+        storage_is_safe, storage_path_error = _is_safe_relative_path(storage_reference)
+        if (
+            not storage_is_safe
+            and storage_path_error is not None
+            and ("absolute" in storage_path_error or "file URI" in storage_path_error)
+        ):
+            issues.append(
+                _issue(
+                    "$.storage_release.authoritative_storage_reference",
+                    "must not be a personal absolute filesystem path.",
+                )
+            )
+
+
+def validate_manifest(
+    manifest: Mapping[str, object],
+    *,
+    dataset_root: str | Path | None = None,
+    check_files: bool = False,
+) -> list[ValidationIssue]:
+    """Return all practical structural and semantic issues for one manifest."""
+    if check_files and dataset_root is None:
+        return [_issue("--check-files", "requires --dataset-root.")]
+
+    schema = load_schema()
+    issues = _schema_issues(manifest, schema, schema, "$")
+    _validate_taxonomy(manifest, issues)
+    _validate_quality_and_release(manifest, issues)
+    root = Path(dataset_root) if dataset_root is not None else None
+    _validate_samples(manifest, root, check_files, issues)
+    return issues
+
+
+def load_manifest(manifest_path: str | Path) -> tuple[Path, dict[str, object]]:
+    """Load one local JSON manifest and turn ordinary read errors into messages."""
+    path = Path(manifest_path).expanduser().resolve()
+    if not path.exists():
+        raise ManifestValidationError(f"Manifest file is missing: {path}")
+    if not path.is_file():
+        raise ManifestValidationError(f"Manifest path is not a file: {path}")
+
+    try:
+        with path.open("r", encoding="utf-8-sig") as manifest_file:
+            manifest = json.load(manifest_file)
+    except OSError as exc:
+        raise ManifestValidationError(f"Manifest file could not be read: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ManifestValidationError(
+            f"Manifest file is not valid JSON: {path} (line {exc.lineno}, column {exc.colno})"
+        ) from exc
+
+    if not isinstance(manifest, dict):
+        raise ManifestValidationError(f"Manifest root must be an object: {path}")
+    return path, manifest
+
+
+def format_issues(issues: Sequence[ValidationIssue]) -> str:
+    """Format all findings without a traceback or a premature first-error exit."""
+    lines = [f"Dataset manifest validation failed ({len(issues)} issue(s)):" ]
+    lines.extend(f"- {issue.location}: {issue.message}" for issue in issues)
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate a Git-safe WalkBuddy navigation dataset manifest without network access."
+    )
+    parser.add_argument("manifest", help="Path to a JSON dataset manifest.")
+    parser.add_argument(
+        "--dataset-root",
+        help="Local controlled dataset root used only with --check-files.",
+    )
+    parser.add_argument(
+        "--check-files",
+        action="store_true",
+        help="Check that manifest image and label paths exist beneath --dataset-root.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the validator and return zero only when no validation issue is found."""
+    args = parse_args(argv)
+    try:
+        manifest_path, manifest = load_manifest(args.manifest)
+        issues = validate_manifest(
+            manifest,
+            dataset_root=args.dataset_root,
+            check_files=args.check_files,
+        )
+    except ManifestValidationError as exc:
+        print(f"Dataset manifest validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    if issues:
+        print(format_issues(issues), file=sys.stderr)
+        return 1
+
+    print(f"Dataset manifest validation passed: {manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2><p>Adds the controlled dataset-manifest and intake-validation foundation for the WalkBuddy navigation-model MVP.</p><h2>Changes</h2><ul><li><p>adds the approved eight-class navigation taxonomy configuration;</p></li><li><p>adds a versioned dataset-manifest schema;</p></li><li><p>adds a fictional valid sample manifest;</p></li><li><p>adds a standard-library command-line validator;</p></li><li><p>validates taxonomy, provenance, licensing-review metadata, paths, checksums, dimensions and split leakage;</p></li><li><p>supports optional local file-existence checks;</p></li><li><p>adds comprehensive automated tests;</p></li><li><p>documents storage boundaries, validation usage and limitations.</p></li></ul><h2>Approved MVP taxonomy</h2>
ID | Class
-- | --
0 | person
1 | stairs
2 | door
3 | chair
4 | table
5 | pole
6 | bicycle
7 | vehicle

<h2>Validation behaviour</h2><p>The validator checks:</p><ul><li><p>exact approved class names, IDs and order;</p></li><li><p>unknown and duplicate classes;</p></li><li><p>invalid source-to-target mappings;</p></li><li><p>duplicate sample IDs and image paths;</p></li><li><p>train, validation and test group leakage;</p></li><li><p>Windows, POSIX, UNC and drive-relative absolute paths;</p></li><li><p>traversal, encoded traversal and dataset-root escape attempts;</p></li><li><p>malformed checksums;</p></li><li><p>non-positive image dimensions;</p></li><li><p>direct bounding-box validity;</p></li><li><p>required source, licence and review metadata;</p></li><li><p>optional image and label file existence.</p></li></ul><p>The bundled schema declares JSON Schema Draft 2020-12. The validator implements the project-specific schema subset used by the bundled schema and rejects unsupported future validation keywords rather than silently ignoring them.</p><h2>Verification</h2><ul><li><p>focused dataset-manifest tests: 39 passed;</p></li><li><p>complete relevant ML-side test suite: 69 passed;</p></li><li><p>Python syntax compilation passed;</p></li><li><p>JSON syntax validation passed;</p></li><li><p>valid sample CLI validation passed;</p></li><li><p>invalid CLI validation returned exit code 1 without a traceback;</p></li><li><p><code inline="">--check-files</code> without a dataset root returned a clear error;</p></li><li><p>CLI help passed;</p></li><li><p><code inline="">git diff --check</code> passed;</p></li><li><p>security and scope scan passed.</p></li></ul><h2>Scope boundaries</h2><p>This pull request does not:</p><ul><li><p>download or include datasets;</p></li><li><p>train a model;</p></li><li><p>modify model weights;</p></li><li><p>change production backend behaviour;</p></li><li><p>legally approve a dataset;</p></li><li><p>establish privacy compliance;</p></li><li><p>determine whether a dataset is suitable for production.</p></li></ul><p>A valid manifest records the required evidence and review decision, but validation alone does not constitute dataset approval.</p><h2>Known limitations</h2><ul><li><p>YOLO label-file contents are not yet parsed;</p></li><li><p>direct bounding-box validation applies only when boxes are stored in the manifest;</p></li><li><p>the validator performs no network requests;</p></li><li><p>legal, privacy and ethical decisions remain human-review responsibilities.</p></li></ul><h2>Follow-up</h2><ul><li><p>create manifests for the selected real candidate datasets;</p></li><li><p>add image and YOLO annotation-quality inspection;</p></li><li><p>produce the first versioned MVP dataset release;</p></li><li><p>implement the reproducible training pipeline.</p></li></ul></body></html><!--EndFragment-->
</body>
</html>