### PR TITLE
Add candidate dataset inspection tooling

### DIFF
--- a/ML_side/datasets/README.md
+++ b/ML_side/datasets/README.md
@@ -71,3 +71,89 @@ After the dataset has independent review and an approved release decision, a fut
 - File checks are opt-in and cannot validate external storage availability or permissions.
 - Bounding-box validation applies only when boxes are recorded directly in the manifest; normal YOLO label-file parsing is future work.
 - The manifest records review evidence but cannot replace legal, privacy, accessibility, or data-governance review.
+
+## Inspect a local YOLO candidate dataset
+
+`../tools/inspect_candidate_dataset.py` is the read-only inspection step before a candidate dataset is represented by a release manifest. It reads the supplied local dataset root and YOLO YAML, writes reports only to an explicitly selected directory outside that root, and makes no network requests. It does not download data, train a model, copy images, or change labels.
+
+The YAML must use safe relative paths beneath the supplied root. `train` and `validation` (or `val`) are required; `test` is inspected when present. Common directory layouts such as `train/images` with paired `train/labels`, or `images/train` with paired `labels/train`, are supported through the paths declared in the YAML. Absolute paths, path traversal, and symlink escapes are rejected.
+
+From the repository root in Windows PowerShell:
+
+```powershell
+python .\ML_side\tools\inspect_candidate_dataset.py `
+  --dataset-root D:\controlled-datasets\candidate-navigation-v1 `
+  --dataset-yaml D:\controlled-datasets\candidate-navigation-v1\dataset.yaml `
+  --output-dir D:\controlled-reports\candidate-navigation-v1
+```
+
+On macOS or Linux:
+
+```bash
+python ML_side/tools/inspect_candidate_dataset.py \
+  --dataset-root /controlled-datasets/candidate-navigation-v1 \
+  --dataset-yaml /controlled-datasets/candidate-navigation-v1/dataset.yaml \
+  --output-dir /controlled-reports/candidate-navigation-v1
+```
+
+Image decoding and SHA-256 checksum calculation are enabled by default when the existing Python environment has Pillow. Use `--skip-image-decode` or `--skip-checksums` only when an explicitly documented limitation is acceptable; skipped checks are reported as warnings. The output directory must be outside the dataset root, so this tool cannot write reports into the inspected dataset.
+
+### Quality checks and leakage rules
+
+The inspector reports image and label totals by split, images without labels, orphan labels, empty label files, unsupported extensions, unreadable images, malformed YOLO rows, source- and target-class annotation distributions, and samples without valid annotations. A YOLO row must be exactly `class_id x_center y_center width height`, with a non-negative integer source ID, finite numeric values, positive dimensions, and a bounding box fully inside normalized bounds.
+
+SHA-256 checksums identify byte-identical images. Identical checksums in different splits are a failure because they indicate direct split leakage; same-split duplicates remain a visible warning for review. The report also flags duplicate filename-stem sample identifiers and duplicate normalized paths. Filename similarity is never treated as group leakage. To check sequence or group leakage, supply an explicit group map:
+
+```json
+{
+  "groups": {
+    "train/images/frame_001.jpg": "walk-sequence-a",
+    "validation/images/frame_101.jpg": "walk-sequence-b"
+  }
+}
+```
+
+Keys are safe relative image paths from the dataset root, and values are non-empty group IDs. The inspector fails if one supplied group occurs in more than one split. Without a group map it records a limitation and does not infer groups from names or paths.
+
+The controlled verdict is `fail` when validation errors exist, `pass_with_warnings` when no errors but one or more warnings exist, and `pass` otherwise. A passing result does not establish legal, privacy, ethical, accessibility, representativeness, model-quality, production-readiness, or final dataset-fitness approval.
+
+### Explicit mapping and candidate manifest metadata
+
+An optional reviewed metadata JSON or YAML file supplies source-to-WalkBuddy mapping decisions. It must use the following project-specific shape; values below are fictional examples only:
+
+```json
+{
+  "class_mapping": [
+    {
+      "source_class_id": 0,
+      "target_class_id": 0,
+      "target_class_name": "person",
+      "mapping_rationale": "Reviewed semantic equivalence."
+    }
+  ],
+  "excluded_source_classes": [
+    { "source_class_id": 9, "reason": "Outside the approved MVP taxonomy." }
+  ],
+  "unmapped_source_classes": [
+    { "source_class_id": 10, "reason": "Requires explicit taxonomy review." }
+  ]
+}
+```
+
+Every source class in the dataset YAML is displayed as mapped, excluded, or unmapped. The inspector never infers a target mapping: a mapping must use an exact approved WalkBuddy target ID/name pair and a non-empty rationale. Unknown or mismatched targets fail inspection. Excluded classes remain visible in source counts and are not added to target counts.
+
+To request `candidate_manifest.json`, add `--generate-manifest`, `--metadata`, and a complete `--group-map`. In addition to the class decisions above, metadata must provide `dataset`, `source_provenance`, `licence`, `storage_release`, `quality_review_status`, and `known_limitations` using the fields required by [`manifest.schema.json`](manifest.schema.json). The tool withholds the manifest when any required review metadata, source-class decision, group identifier, or passing quality result is missing. It then validates a generated manifest with the existing validator before writing it. A generated file remains a candidate or review-stage record unless the supplied, reviewed metadata validly says otherwise; inspection cannot invent source, licence, reviewer, approval, or release-version values.
+
+Example with metadata and candidate-manifest generation in PowerShell:
+
+```powershell
+python .\ML_side\tools\inspect_candidate_dataset.py `
+  --dataset-root D:\controlled-datasets\candidate-navigation-v1 `
+  --dataset-yaml D:\controlled-datasets\candidate-navigation-v1\dataset.yaml `
+  --metadata D:\controlled-datasets\candidate-navigation-v1\reviewed_metadata.json `
+  --group-map D:\controlled-datasets\candidate-navigation-v1\reviewed_groups.json `
+  --output-dir D:\controlled-reports\candidate-navigation-v1 `
+  --generate-manifest
+```
+
+The reports are `dataset_quality_report.json` and `dataset_quality_report.md`; apart from isolated execution-time metadata, their ordering is deterministic for unchanged input. Keep raw images, labels, review evidence, and generated reports in controlled external storage rather than Git. After appropriate independent review, the resulting candidate manifest can feed a future controlled training workflow; this tool itself does not perform training or select a model.

--- a/ML_side/tests/test_inspect_candidate_dataset.py
+++ b/ML_side/tests/test_inspect_candidate_dataset.py
@@ -1,0 +1,500 @@
+"""Temporary-fixture tests for the read-only candidate YOLO dataset inspector."""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ML_SIDE_DIR = Path(__file__).resolve().parents[1]
+TOOLS_DIR = ML_SIDE_DIR / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import inspect_candidate_dataset as inspector
+import validate_dataset_manifest as manifest_validator
+
+
+# A tiny valid GIF fixture encoded directly in the test.  Pillow identifies
+# it from the content, while the .png fixture names exercise path handling.
+IMAGE_BYTES = base64.b64decode(
+    "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+)
+
+
+def write_yaml(root: Path, *, names: list[str], train: str = "train/images", val: str = "val/images", test: str | None = None, path: str = ".") -> Path:
+    lines = [f"path: {path}", f"train: {train}", f"val: {val}"]
+    if test is not None:
+        lines.append(f"test: {test}")
+    lines.append("names:")
+    lines.extend(f"  {index}: {name}" for index, name in enumerate(names))
+    yaml_path = root / "candidate.yaml"
+    yaml_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return yaml_path
+
+
+def add_pair(
+    root: Path,
+    split: str,
+    name: str,
+    label: str = "0 0.5 0.5 0.2 0.2\n",
+    image: bytes | None = None,
+) -> tuple[Path, Path]:
+    image_path = root / split / "images" / name
+    label_path = root / split / "labels" / Path(name).with_suffix(".txt")
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    label_path.parent.mkdir(parents=True, exist_ok=True)
+    image_path.write_bytes(IMAGE_BYTES + name.encode("utf-8") if image is None else image)
+    label_path.write_text(label, encoding="utf-8")
+    return image_path, label_path
+
+
+def create_dataset(
+    tmp_path: Path,
+    *,
+    names: list[str] | None = None,
+    include_test: bool = False,
+) -> tuple[Path, Path]:
+    root = tmp_path / "dataset"
+    root.mkdir()
+    names = names or ["person"]
+    add_pair(root, "train", "train.png")
+    add_pair(root, "val", "validation.png")
+    if include_test:
+        add_pair(root, "test", "test.png")
+    return root, write_yaml(root, names=names, test="test/images" if include_test else None)
+
+
+def approved_metadata(names: list[str]) -> dict[str, object]:
+    target_ids = {name: class_id for class_id, name in inspector.APPROVED_TAXONOMY}
+    mappings = []
+    unmapped = []
+    for source_id, name in enumerate(names):
+        if name in target_ids:
+            mappings.append(
+                {
+                    "source_class_id": source_id,
+                    "target_class_id": target_ids[name],
+                    "target_class_name": name,
+                    "mapping_rationale": "Fictional test-only explicit mapping.",
+                }
+            )
+        else:
+            unmapped.append(
+                {"source_class_id": source_id, "reason": "Fictional test-only unresolved class."}
+            )
+    return {
+        "dataset": {
+            "id": "fictional-candidate-v1",
+            "name": "Fictional candidate dataset",
+            "source_version": "fictional-v1",
+            "description": "Temporary test metadata only.",
+            "release_date": "2026-08-05",
+            "release_decision": "example_only",
+        },
+        "source_provenance": {
+            "source_reference": "example://fictional/source",
+            "accessed_on": "2026-08-05",
+            "original_source": "Fictional test source.",
+            "publisher": "Test publisher",
+        },
+        "licence": {
+            "name": "Fictional test licence",
+            "evidence_reference": "example://fictional/licence",
+            "machine_learning_use_permitted": True,
+            "modification_permitted": True,
+            "redistribution_permitted": False,
+            "attribution_required": True,
+            "attribution_requirements": "Test attribution only.",
+            "restrictions": "Fictional test metadata.",
+            "reviewer": "Test reviewer",
+            "review_date": "2026-08-05",
+            "review_decision": "example_only",
+        },
+        "storage_release": {
+            "authoritative_storage_reference": "example://fictional/storage",
+            "git_safe_metadata_only": True,
+            "release_version": "test-v1",
+        },
+        "quality_review_status": "example_only",
+        "known_limitations": ["Fictional temporary test dataset."],
+        "class_mapping": mappings,
+        "excluded_source_classes": [],
+        "unmapped_source_classes": unmapped,
+    }
+
+
+def write_json(path: Path, data: object) -> Path:
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def group_map_for(root: Path) -> Path:
+    groups = {
+        path.relative_to(root).as_posix(): f"group-{index}"
+        for index, path in enumerate(sorted(root.glob("*/images/**/*.png")), start=1)
+    }
+    return write_json(root / "groups.json", {"groups": groups})
+
+
+def inspect(root: Path, yaml_path: Path, **kwargs: object) -> dict[str, object]:
+    report, _ = inspector.inspect_dataset(root, yaml_path, execution_time_utc="2026-08-05T00:00:00Z", **kwargs)
+    return report
+
+
+def messages(report: dict[str, object]) -> str:
+    return "\n".join(
+        f"{item['location']}: {item['message']}" for item in report["validation_errors"]  # type: ignore[index]
+    )
+
+
+def test_valid_minimal_dataset_passes_with_explicit_mapping_and_groups(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    metadata_path = write_json(root / "metadata.json", approved_metadata(["person"]))
+    report = inspect(root, yaml_path, metadata_path=metadata_path, group_map_path=group_map_for(root))
+
+    assert report["quality_verdict"] == "pass"
+    assert report["totals"]["image_count"] == 2  # type: ignore[index]
+    assert report["annotation_counts_by_walkbuddy_target_class"][0]["count"] == 2  # type: ignore[index]
+
+
+def test_train_validation_and_test_splits_are_counted(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path, include_test=True)
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert [report["splits"][split]["image_count"] for split in ("train", "validation", "test")] == [1, 1, 1]  # type: ignore[index]
+
+
+def test_validation_alias_is_supported(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    yaml_path.write_text(
+        yaml_path.read_text(encoding="utf-8").replace("val: val/images", "validation: val/images"),
+        encoding="utf-8",
+    )
+    report = inspect(root, yaml_path, decode_images=False, checksums=False)
+
+    assert report["splits"]["validation"]["image_count"] == 1  # type: ignore[index]
+
+
+def test_missing_source_class_definitions_fail(tmp_path: Path) -> None:
+    root, _ = create_dataset(tmp_path)
+    yaml_path = root / "missing-names.yaml"
+    yaml_path.write_text("path: .\ntrain: train/images\nval: val/images\n", encoding="utf-8")
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert "$.names" in messages(report)
+
+
+def test_missing_image_label_is_reported(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    (root / "train" / "labels" / "train.txt").unlink()
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert report["totals"]["images_without_labels"] == 1  # type: ignore[index]
+
+
+def test_orphan_label_is_reported(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    orphan = root / "train" / "labels" / "orphan.txt"
+    orphan.write_text("0 0.5 0.5 0.2 0.2\n", encoding="utf-8")
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert "train/labels/orphan.txt" in report["splits"]["train"]["labels_without_images"]  # type: ignore[index]
+
+
+def test_empty_label_is_reported(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    (root / "train" / "labels" / "train.txt").write_text("\n", encoding="utf-8")
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert "train/labels/train.txt" in report["splits"]["train"]["empty_label_files"]  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("0 0.5 0.5 0.2\n", "exactly 5 fields"),
+        ("0 not-a-number 0.5 0.2 0.2\n", "must be numeric"),
+        ("0 nan 0.5 0.2 0.2\n", "must be finite"),
+        ("5 0.5 0.5 0.2 0.2\n", "outside the source YAML taxonomy"),
+        ("0 0.5 0.5 0 0.2\n", "must be positive"),
+        ("0 0.95 0.5 0.2 0.2\n", "outside normalized YOLO bounds"),
+    ],
+)
+def test_invalid_yolo_rows_fail(tmp_path: Path, label: str, expected: str) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    (root / "train" / "labels" / "train.txt").write_text(label, encoding="utf-8")
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert report["quality_verdict"] == "fail"
+    assert expected in messages(report)
+
+
+def test_valid_boundary_box_passes(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    (root / "train" / "labels" / "train.txt").write_text("0 0.5 0.5 1.0 1.0\n", encoding="utf-8")
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert "normalized YOLO bounds" not in messages(report)
+
+
+def test_duplicate_image_checksums_are_reported(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    add_pair(root, "train", "duplicate.png", image=(root / "train" / "images" / "train.png").read_bytes())
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert len(report["duplicates"]["duplicate_checksums"]) == 1  # type: ignore[index]
+
+
+def test_duplicate_images_across_splits_fail(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    (root / "val" / "images" / "validation.png").write_bytes((root / "train" / "images" / "train.png").read_bytes())
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert report["duplicates"]["cross_split_duplicate_images"]  # type: ignore[index]
+    assert report["quality_verdict"] == "fail"
+
+
+def test_configured_group_leakage_across_splits_fails(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    groups = {
+        "train/images/train.png": "same-sequence",
+        "val/images/validation.png": "same-sequence",
+    }
+    report = inspect(root, yaml_path, group_map_path=write_json(root / "groups.json", {"groups": groups}), decode_images=False, checksums=False)
+
+    assert report["duplicates"]["cross_split_group_leakage"]  # type: ignore[index]
+    assert report["quality_verdict"] == "fail"
+
+
+def test_no_unconfigured_grouping_assumption_is_made(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    report = inspect(root, yaml_path, decode_images=False, checksums=False)
+
+    assert report["duplicates"]["grouping_configured"] is False  # type: ignore[index]
+    assert "filename similarity was not used" in "\n".join(item["message"] for item in report["warnings"])  # type: ignore[index]
+
+
+def test_unknown_walkbuddy_mapping_target_fails(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    metadata = approved_metadata(["person"])
+    metadata["class_mapping"][0]["target_class_id"] = 99  # type: ignore[index]
+    metadata["class_mapping"][0]["target_class_name"] = "unknown"  # type: ignore[index]
+    report = inspect(root, yaml_path, metadata_path=write_json(root / "metadata.json", metadata), decode_images=False)
+
+    assert "approved WalkBuddy target" in messages(report)
+
+
+def test_excluded_source_classes_are_reported_but_not_mapped(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path, names=["person", "ceiling"])
+    (root / "train" / "labels" / "train.txt").write_text("1 0.5 0.5 0.2 0.2\n", encoding="utf-8")
+    metadata = approved_metadata(["person", "ceiling"])
+    metadata["unmapped_source_classes"] = []
+    metadata["excluded_source_classes"] = [{"source_class_id": 1, "reason": "Out of scope."}]
+    report = inspect(root, yaml_path, metadata_path=write_json(root / "metadata.json", metadata), decode_images=False, checksums=False)
+
+    assert report["mapping_summary"]["excluded_source_classes"][0]["source_class_name"] == "ceiling"  # type: ignore[index]
+    assert report["annotation_counts_by_walkbuddy_target_class"][0]["count"] == 1  # type: ignore[index]
+
+
+def test_unmapped_source_classes_are_reported(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path, names=["person", "unclear"])
+    metadata = approved_metadata(["person", "unclear"])
+    report = inspect(root, yaml_path, metadata_path=write_json(root / "metadata.json", metadata), decode_images=False, checksums=False)
+
+    assert report["mapping_summary"]["unmapped_source_classes"][0]["source_class_name"] == "unclear"  # type: ignore[index]
+
+
+@pytest.mark.parametrize("unsafe_path", ["../outside", r"C:\\outside", "/outside"])
+def test_path_traversal_and_absolute_paths_fail(tmp_path: Path, unsafe_path: str) -> None:
+    root, _ = create_dataset(tmp_path)
+    yaml_path = write_yaml(root, names=["person"], train=unsafe_path)
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert report["quality_verdict"] == "fail"
+    assert "path traversal" in messages(report) or "absolute" in messages(report)
+
+
+def test_symlink_escape_fails_where_supported(tmp_path: Path) -> None:
+    root, _ = create_dataset(tmp_path)
+    outside = tmp_path / "outside"
+    (outside / "images").mkdir(parents=True)
+    link = root / "linked"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("The current platform does not allow test symlink creation.")
+    yaml_path = write_yaml(root, names=["person"], train="linked/images")
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert "outside the supplied dataset root" in messages(report)
+
+
+def test_individual_image_symlink_escape_fails_where_supported(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    outside_image = tmp_path / "outside.png"
+    outside_image.write_bytes(IMAGE_BYTES)
+    link = root / "train" / "images" / "linked.png"
+    try:
+        link.symlink_to(outside_image)
+    except OSError:
+        pytest.skip("The current platform does not allow test symlink creation.")
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert "image symlink resolves outside" in messages(report)
+
+
+def test_missing_split_directory_is_reported(tmp_path: Path) -> None:
+    root, _ = create_dataset(tmp_path)
+    yaml_path = write_yaml(root, names=["person"], train="missing/images")
+    report = inspect(root, yaml_path, decode_images=False)
+
+    assert "existing split directory" in messages(report)
+
+
+def test_corrupt_image_and_unsupported_extension_are_reported(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    (root / "train" / "images" / "corrupt.jpg").write_bytes(b"not an image")
+    (root / "train" / "images" / "unsupported.gif").write_bytes(b"gif")
+    report = inspect(root, yaml_path)
+
+    assert "train/images/corrupt.jpg" in report["image_issues"]["unreadable_images"]  # type: ignore[index]
+    assert "train/images/unsupported.gif" in report["splits"]["train"]["unsupported_image_files"]  # type: ignore[index]
+
+
+def test_duplicate_filename_stem_is_reported(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    add_pair(root, "train", "nested/train.png")
+    report = inspect(root, yaml_path, decode_images=False, checksums=False)
+
+    assert report["duplicates"]["duplicate_sample_identifiers"]  # type: ignore[index]
+
+
+def test_deterministic_json_and_markdown_report_generation(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    report = inspect(root, yaml_path, decode_images=False, checksums=False)
+    first_output = tmp_path / "first-output"
+    second_output = tmp_path / "second-output"
+    inspector.write_outputs(report, None, first_output, root)
+    inspector.write_outputs(report, None, second_output, root)
+
+    assert (first_output / "dataset_quality_report.json").read_bytes() == (second_output / "dataset_quality_report.json").read_bytes()
+    assert (first_output / "dataset_quality_report.md").read_text(encoding="utf-8").startswith("# Candidate dataset quality report")
+
+
+def test_output_directory_inside_dataset_root_is_rejected(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    report = inspect(root, yaml_path, decode_images=False, checksums=False)
+
+    with pytest.raises(inspector.CandidateInspectionError, match="outside the supplied dataset root"):
+        inspector.write_outputs(report, None, root / "reports", root)
+
+
+def test_candidate_manifest_is_generated_and_passes_existing_validator(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    metadata_path = write_json(root / "metadata.json", approved_metadata(["person"]))
+    report, candidate = inspector.inspect_dataset(
+        root,
+        yaml_path,
+        metadata_path=metadata_path,
+        group_map_path=group_map_for(root),
+        generate_manifest=True,
+        execution_time_utc="2026-08-05T00:00:00Z",
+    )
+
+    assert report["candidate_manifest"]["generated"] is True  # type: ignore[index]
+    assert candidate is not None
+    assert manifest_validator.validate_manifest(candidate) == []
+
+
+def test_candidate_manifest_output_is_written_only_when_valid(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    metadata_path = write_json(root / "metadata.json", approved_metadata(["person"]))
+    report, candidate = inspector.inspect_dataset(
+        root,
+        yaml_path,
+        metadata_path=metadata_path,
+        group_map_path=group_map_for(root),
+        generate_manifest=True,
+        execution_time_utc="2026-08-05T00:00:00Z",
+    )
+    output = tmp_path / "reports"
+    inspector.write_outputs(report, candidate, output, root)
+
+    written = json.loads((output / "candidate_manifest.json").read_text(encoding="utf-8"))
+    assert manifest_validator.validate_manifest(written) == []
+
+
+def test_candidate_manifest_is_withheld_when_metadata_is_incomplete(tmp_path: Path) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    report, candidate = inspector.inspect_dataset(
+        root, yaml_path, generate_manifest=True, execution_time_utc="2026-08-05T00:00:00Z"
+    )
+
+    assert candidate is None
+    assert "metadata file" in report["candidate_manifest"]["missing_requirements"]  # type: ignore[index]
+
+
+def test_cli_valid_fixture_writes_both_reports(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    output = tmp_path / "reports"
+
+    assert inspector.main(
+        [
+            "--dataset-root",
+            str(root),
+            "--dataset-yaml",
+            str(yaml_path),
+            "--output-dir",
+            str(output),
+            "--skip-image-decode",
+            "--skip-checksums",
+        ]
+    ) == 0
+    assert (output / "dataset_quality_report.json").is_file()
+    assert (output / "dataset_quality_report.md").is_file()
+    assert "pass_with_warnings" in capsys.readouterr().out
+
+
+def test_cli_invalid_input_exits_nonzero_without_traceback(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    root, _ = create_dataset(tmp_path)
+    missing_yaml = root / "missing.yaml"
+
+    assert inspector.main(["--dataset-root", str(root), "--dataset-yaml", str(missing_yaml), "--output-dir", str(tmp_path / "output")]) == 1
+    error = capsys.readouterr().err
+    assert "Candidate dataset inspection failed" in error
+    assert "Traceback" not in error
+
+
+def test_cli_invalid_label_fixture_exits_nonzero_without_traceback(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root, yaml_path = create_dataset(tmp_path)
+    (root / "train" / "labels" / "train.txt").write_text("invalid\n", encoding="utf-8")
+
+    assert inspector.main(
+        [
+            "--dataset-root",
+            str(root),
+            "--dataset-yaml",
+            str(yaml_path),
+            "--output-dir",
+            str(tmp_path / "reports"),
+            "--skip-image-decode",
+            "--skip-checksums",
+        ]
+    ) == 1
+    output = capsys.readouterr().out
+    assert "Candidate dataset inspection verdict: fail" in output
+    assert "Traceback" not in output
+
+
+def test_cli_help_succeeds(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exit_result:
+        inspector.main(["--help"])
+
+    assert exit_result.value.code == 0
+    assert "--generate-manifest" in capsys.readouterr().out

--- a/ML_side/tools/inspect_candidate_dataset.py
+++ b/ML_side/tools/inspect_candidate_dataset.py
@@ -1,0 +1,1108 @@
+"""Read-only quality inspection for local YOLO-format candidate datasets.
+
+The tool deliberately reuses the WalkBuddy manifest validator's approved
+taxonomy and path-safety helpers.  It never downloads, modifies, or copies
+dataset files.  Reports are deterministic apart from ``execution.time_utc``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+import validate_dataset_manifest as manifest_validator
+
+
+TOOL_NAME = "inspect_candidate_dataset"
+TOOL_VERSION = "1.0.0"
+SPLIT_KEYS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("train", ("train",)),
+    ("validation", ("validation", "val")),
+    ("test", ("test",)),
+)
+APPROVED_TAXONOMY = manifest_validator.APPROVED_TAXONOMY
+APPROVED_TARGETS = manifest_validator.APPROVED_TARGETS
+IMAGE_EXTENSIONS = manifest_validator.IMAGE_EXTENSIONS
+
+
+class CandidateInspectionError(Exception):
+    """Raised for an input that cannot be inspected safely."""
+
+
+def _issue(location: str, message: str) -> dict[str, str]:
+    return {"location": location, "message": message}
+
+
+def _normalise_relative_path(value: str) -> str:
+    return "/".join(part for part in value.replace("\\", "/").split("/") if part not in {"", "."})
+
+
+def _relative_path(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _resolves_beneath(root: Path, path: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+def _sort_issues(issues: list[dict[str, str]]) -> list[dict[str, str]]:
+    return sorted(issues, key=lambda item: (item["location"], item["message"]))
+
+
+def _safe_resolve(root: Path, raw_path: object, location: str, errors: list[dict[str, str]]) -> Path | None:
+    is_safe, reason = manifest_validator._is_safe_relative_path(raw_path)
+    if not is_safe:
+        errors.append(_issue(location, reason or "must be a safe relative path."))
+        return None
+    assert isinstance(raw_path, str)
+    resolved = manifest_validator._resolve_dataset_reference(root, raw_path.strip())
+    if resolved is None:
+        errors.append(_issue(location, "resolves outside the supplied dataset root."))
+    return resolved
+
+
+def _load_structured_file(path: Path, description: str) -> dict[str, object]:
+    try:
+        text = path.read_text(encoding="utf-8-sig")
+    except FileNotFoundError as exc:
+        raise CandidateInspectionError(f"{description} is missing: {path}") from exc
+    except OSError as exc:
+        raise CandidateInspectionError(f"{description} could not be read: {path}") from exc
+
+    if path.suffix.casefold() == ".json":
+        try:
+            loaded = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise CandidateInspectionError(f"{description} is not valid JSON: {path}") from exc
+    else:
+        try:
+            import yaml
+        except ImportError as exc:
+            raise CandidateInspectionError(
+                f"{description} requires PyYAML for this YAML file; no dependency was installed."
+            ) from exc
+        try:
+            loaded = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            raise CandidateInspectionError(f"{description} is not valid YAML: {path}") from exc
+
+    if not isinstance(loaded, dict):
+        raise CandidateInspectionError(f"{description} root must be an object: {path}")
+    return loaded
+
+
+def _source_taxonomy(dataset_yaml: Mapping[str, object], errors: list[dict[str, str]]) -> dict[int, str]:
+    names = dataset_yaml.get("names")
+    taxonomy: dict[int, str] = {}
+    if isinstance(names, list):
+        for class_id, class_name in enumerate(names):
+            if not isinstance(class_name, str) or not class_name.strip():
+                errors.append(_issue(f"$.names[{class_id}]", "must be a non-empty class name."))
+            else:
+                taxonomy[class_id] = class_name.strip()
+    elif isinstance(names, Mapping):
+        for raw_id, class_name in names.items():
+            if isinstance(raw_id, bool):
+                errors.append(_issue("$.names", "contains a boolean rather than an integer class ID."))
+                continue
+            try:
+                class_id = int(raw_id)
+            except (TypeError, ValueError):
+                errors.append(_issue("$.names", f"contains non-integer class ID {raw_id!r}."))
+                continue
+            if isinstance(raw_id, str) and raw_id.strip() != str(class_id):
+                errors.append(_issue("$.names", f"contains malformed class ID {raw_id!r}."))
+                continue
+            if class_id < 0:
+                errors.append(_issue("$.names", f"contains negative class ID {class_id}."))
+            elif not isinstance(class_name, str) or not class_name.strip():
+                errors.append(_issue(f"$.names[{class_id}]", "must be a non-empty class name."))
+            elif class_id in taxonomy:
+                errors.append(_issue("$.names", f"contains duplicate class ID {class_id}."))
+            else:
+                taxonomy[class_id] = class_name.strip()
+    else:
+        errors.append(_issue("$.names", "is required and must be a list or an ID-to-name object."))
+
+    if not taxonomy:
+        errors.append(_issue("$.names", "must define at least one source class."))
+    for name, count in Counter(value.casefold() for value in taxonomy.values()).items():
+        if count > 1:
+            errors.append(_issue("$.names", f"contains duplicate source class name {name!r}."))
+    return dict(sorted(taxonomy.items()))
+
+
+def _resolve_layout(
+    dataset_root: Path, dataset_yaml: Mapping[str, object], errors: list[dict[str, str]]
+) -> dict[str, dict[str, Path | str | None]]:
+    yaml_root_value = dataset_yaml.get("path", ".")
+    yaml_root = _safe_resolve(dataset_root, yaml_root_value, "$.path", errors)
+    if yaml_root is None:
+        return {}
+    if not yaml_root.is_dir():
+        errors.append(_issue("$.path", "does not resolve to an existing directory beneath the dataset root."))
+        return {}
+
+    layout: dict[str, dict[str, Path | str | None]] = {}
+    seen_image_directories: dict[Path, str] = {}
+    for canonical_name, yaml_names in SPLIT_KEYS:
+        raw_split_path: object | None = next(
+            (dataset_yaml[key] for key in yaml_names if key in dataset_yaml), None
+        )
+        if raw_split_path is None:
+            if canonical_name == "test":
+                continue
+            errors.append(_issue(f"$.{yaml_names[0]}", "is required for candidate dataset inspection."))
+            continue
+        image_directory = _safe_resolve(
+            yaml_root, raw_split_path, f"$.{yaml_names[0]}", errors
+        )
+        if image_directory is None:
+            continue
+        if not image_directory.is_dir():
+            errors.append(
+                _issue(f"$.{yaml_names[0]}", "does not resolve to an existing split directory.")
+            )
+            continue
+        prior_split = seen_image_directories.get(image_directory)
+        if prior_split is not None:
+            errors.append(
+                _issue(
+                    f"$.{yaml_names[0]}",
+                    f"normalizes to the same image directory as the {prior_split!r} split.",
+                )
+            )
+        seen_image_directories[image_directory] = canonical_name
+        label_directory = _derive_label_directory(image_directory)
+        layout[canonical_name] = {
+            "declared_path": _normalise_relative_path(str(raw_split_path)),
+            "image_directory": image_directory,
+            "label_directory": label_directory,
+        }
+    return layout
+
+
+def _derive_label_directory(image_directory: Path) -> Path:
+    """Derive the paired labels directory for common YOLO directory layouts."""
+    parts = list(image_directory.parts)
+    image_indices = [index for index, part in enumerate(parts) if part.casefold() == "images"]
+    if image_indices:
+        parts[image_indices[-1]] = "labels"
+        return Path(*parts)
+    return image_directory.parent / "labels"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _image_dimensions(path: Path) -> tuple[int, int]:
+    try:
+        from PIL import Image, UnidentifiedImageError
+    except ImportError as exc:
+        raise CandidateInspectionError("Pillow is unavailable for requested image decoding.") from exc
+    try:
+        with Image.open(path) as image:
+            image.verify()
+        with Image.open(path) as image:
+            width, height = image.size
+    except (OSError, SyntaxError, UnidentifiedImageError, ValueError) as exc:
+        raise CandidateInspectionError(str(exc)) from exc
+    if width < 1 or height < 1:
+        raise CandidateInspectionError("image dimensions must be positive.")
+    return int(width), int(height)
+
+
+def _pillow_available() -> bool:
+    """Return whether the already-installed optional decoder can be imported."""
+    try:
+        import PIL  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _read_group_map(path: Path | None, dataset_root: Path, errors: list[dict[str, str]]) -> dict[str, str] | None:
+    if path is None:
+        return None
+    loaded = _load_structured_file(path, "Group mapping file")
+    raw_groups = loaded.get("groups", loaded)
+    if not isinstance(raw_groups, Mapping):
+        errors.append(_issue("$.groups", "must be an object mapping relative image paths to group IDs."))
+        return {}
+    groups: dict[str, str] = {}
+    for raw_path, raw_group_id in raw_groups.items():
+        location = f"$.groups[{raw_path!r}]"
+        is_safe, reason = manifest_validator._is_safe_relative_path(raw_path)
+        if not is_safe:
+            errors.append(_issue(location, reason or "must be a safe relative image path."))
+            continue
+        if not isinstance(raw_path, str) or not isinstance(raw_group_id, str) or not raw_group_id.strip():
+            errors.append(_issue(location, "must map a relative image path to a non-empty group ID."))
+            continue
+        resolved = manifest_validator._resolve_dataset_reference(dataset_root, raw_path)
+        if resolved is None:
+            errors.append(_issue(location, "resolves outside the supplied dataset root."))
+            continue
+        normalised = _normalise_relative_path(raw_path).casefold()
+        if normalised in groups:
+            errors.append(_issue(location, "duplicates a normalized group-map image path."))
+        else:
+            groups[normalised] = raw_group_id.strip()
+    return groups
+
+
+def _mapping_summary(
+    metadata: Mapping[str, object] | None,
+    source_taxonomy: Mapping[int, str],
+    errors: list[dict[str, str]],
+    warnings: list[dict[str, str]],
+) -> tuple[dict[int, dict[str, object]], dict[int, str], dict[int, str]]:
+    mapping_entries = metadata.get("class_mapping", []) if metadata is not None else []
+    excluded_entries = metadata.get("excluded_source_classes", []) if metadata is not None else []
+    unmapped_entries = metadata.get("unmapped_source_classes", []) if metadata is not None else []
+    if not isinstance(mapping_entries, list):
+        errors.append(_issue("$.class_mapping", "must be a list of explicit source-to-target mappings."))
+        mapping_entries = []
+    if not isinstance(excluded_entries, list):
+        errors.append(_issue("$.excluded_source_classes", "must be a list."))
+        excluded_entries = []
+    if not isinstance(unmapped_entries, list):
+        errors.append(_issue("$.unmapped_source_classes", "must be a list."))
+        unmapped_entries = []
+
+    mappings: dict[int, dict[str, object]] = {}
+    for index, entry in enumerate(mapping_entries):
+        location = f"$.class_mapping[{index}]"
+        if not isinstance(entry, Mapping):
+            errors.append(_issue(location, "must be an object."))
+            continue
+        source_id = entry.get("source_class_id")
+        target_id = entry.get("target_class_id")
+        target_name = entry.get("target_class_name")
+        rationale = entry.get("mapping_rationale")
+        if not isinstance(source_id, int) or isinstance(source_id, bool) or source_id not in source_taxonomy:
+            errors.append(_issue(f"{location}.source_class_id", "must identify a source class defined by the dataset YAML."))
+            continue
+        if not isinstance(target_id, int) or isinstance(target_id, bool) or APPROVED_TARGETS.get(target_id) != target_name:
+            errors.append(_issue(location, "must map to a matching approved WalkBuddy target ID/name pair."))
+            continue
+        if not isinstance(rationale, str) or not rationale.strip():
+            errors.append(_issue(f"{location}.mapping_rationale", "must be a non-empty explicit rationale."))
+            continue
+        if source_id in mappings:
+            errors.append(_issue(location, f"duplicates a mapping for source class ID {source_id}."))
+            continue
+        mappings[source_id] = {
+            "target_class_id": target_id,
+            "target_class_name": target_name,
+            "mapping_rationale": rationale.strip(),
+        }
+
+    def decision_entries(raw_entries: object, category: str) -> dict[int, str]:
+        decisions: dict[int, str] = {}
+        assert isinstance(raw_entries, list)
+        for index, entry in enumerate(raw_entries):
+            location = f"$.{category}[{index}]"
+            if not isinstance(entry, Mapping):
+                errors.append(_issue(location, "must be an object."))
+                continue
+            source_id = entry.get("source_class_id")
+            reason = entry.get("reason")
+            if not isinstance(source_id, int) or isinstance(source_id, bool) or source_id not in source_taxonomy:
+                errors.append(_issue(f"{location}.source_class_id", "must identify a source class defined by the dataset YAML."))
+                continue
+            if not isinstance(reason, str) or not reason.strip():
+                errors.append(_issue(f"{location}.reason", "must be a non-empty reason."))
+                continue
+            if source_id in decisions:
+                errors.append(_issue(location, f"duplicates a decision for source class ID {source_id}."))
+                continue
+            decisions[source_id] = reason.strip()
+        return decisions
+
+    excluded = decision_entries(excluded_entries, "excluded_source_classes")
+    unmapped = decision_entries(unmapped_entries, "unmapped_source_classes")
+    for source_id in sorted(set(mappings) & (set(excluded) | set(unmapped))):
+        errors.append(_issue("$.class_mapping", f"source class ID {source_id} cannot be both mapped and excluded or unmapped."))
+    for source_id in sorted(set(excluded) & set(unmapped)):
+        errors.append(_issue("$.excluded_source_classes", f"source class ID {source_id} cannot be both excluded and unmapped."))
+    for source_id, source_name in source_taxonomy.items():
+        if source_id not in mappings and source_id not in excluded and source_id not in unmapped:
+            warnings.append(
+                _issue(
+                    "$.class_mapping",
+                    f"source class {source_id}:{source_name} has no explicit mapping, exclusion, or unmapped decision.",
+                )
+            )
+    return mappings, excluded, unmapped
+
+
+def _parse_label_file(
+    label_path: Path,
+    display_path: str,
+    source_taxonomy: Mapping[int, str],
+    mappings: Mapping[int, Mapping[str, object]],
+    excluded: Mapping[int, str],
+    errors: list[dict[str, str]],
+) -> tuple[list[dict[str, object]], int, bool]:
+    try:
+        lines = label_path.read_text(encoding="utf-8-sig").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        errors.append(_issue(display_path, f"label file could not be read as UTF-8: {exc}"))
+        return [], 1, False
+    annotations: list[dict[str, object]] = []
+    invalid_rows = 0
+    contains_annotation_text = False
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        contains_annotation_text = True
+        location = f"{display_path}:{line_number}"
+        fields = line.split()
+        if len(fields) != 5:
+            errors.append(_issue(location, "YOLO label rows must contain exactly 5 fields."))
+            invalid_rows += 1
+            continue
+        raw_class_id, *raw_values = fields
+        if re.fullmatch(r"[0-9]+", raw_class_id) is None:
+            errors.append(_issue(location, "class ID must be a non-negative integer."))
+            invalid_rows += 1
+            continue
+        class_id = int(raw_class_id)
+        if class_id not in source_taxonomy:
+            errors.append(_issue(location, f"class ID {class_id} is outside the source YAML taxonomy."))
+            invalid_rows += 1
+            continue
+        try:
+            x_center, y_center, width, height = (float(value) for value in raw_values)
+        except ValueError:
+            errors.append(_issue(location, "bounding-box coordinates must be numeric."))
+            invalid_rows += 1
+            continue
+        values = (x_center, y_center, width, height)
+        if not all(math.isfinite(value) for value in values):
+            errors.append(_issue(location, "bounding-box coordinates must be finite."))
+            invalid_rows += 1
+            continue
+        if width <= 0 or height <= 0:
+            errors.append(_issue(location, "bounding-box width and height must be positive."))
+            invalid_rows += 1
+            continue
+        if (
+            x_center < 0
+            or y_center < 0
+            or x_center > 1
+            or y_center > 1
+            or x_center - width / 2 < 0
+            or x_center + width / 2 > 1
+            or y_center - height / 2 < 0
+            or y_center + height / 2 > 1
+        ):
+            errors.append(_issue(location, "bounding box extends outside normalized YOLO bounds."))
+            invalid_rows += 1
+            continue
+        mapping = mappings.get(class_id)
+        annotations.append(
+            {
+                "source_class_id": class_id,
+                "source_class_name": source_taxonomy[class_id],
+                "target_class_id": mapping.get("target_class_id") if mapping else None,
+                "target_class_name": mapping.get("target_class_name") if mapping else None,
+                "excluded": class_id in excluded,
+                "x_center": x_center,
+                "y_center": y_center,
+                "width": width,
+                "height": height,
+            }
+        )
+    return annotations, invalid_rows, not contains_annotation_text
+
+
+def _scan_split(
+    split_name: str,
+    layout: Mapping[str, Path | str | None],
+    dataset_root: Path,
+    source_taxonomy: Mapping[int, str],
+    mappings: Mapping[int, Mapping[str, object]],
+    excluded: Mapping[int, str],
+    *,
+    decode_images: bool,
+    checksums: bool,
+    errors: list[dict[str, str]],
+    warnings: list[dict[str, str]],
+) -> tuple[dict[str, object], list[dict[str, object]]]:
+    image_directory = layout["image_directory"]
+    label_directory = layout["label_directory"]
+    assert isinstance(image_directory, Path) and isinstance(label_directory, Path)
+    images: list[Path] = []
+    for path in image_directory.rglob("*"):
+        if not path.is_file() or path.suffix.casefold() not in IMAGE_EXTENSIONS:
+            continue
+        if not _resolves_beneath(dataset_root, path):
+            errors.append(
+                _issue(_relative_path(dataset_root, path), "image symlink resolves outside the supplied dataset root.")
+            )
+            continue
+        images.append(path)
+    images.sort(key=lambda path: _relative_path(dataset_root, path).casefold())
+    unsupported = sorted(
+        _relative_path(dataset_root, path)
+        for path in image_directory.rglob("*")
+        if path.is_file() and path.suffix.casefold() not in IMAGE_EXTENSIONS
+    )
+    if unsupported:
+        warnings.append(
+            _issue(
+                f"splits.{split_name}",
+                f"contains {len(unsupported)} file(s) with unsupported image extensions.",
+            )
+        )
+
+    label_paths: dict[str, Path] = {}
+    if label_directory.is_dir():
+        for path in sorted(label_directory.rglob("*.txt"), key=lambda item: item.as_posix().casefold()):
+            if not _resolves_beneath(dataset_root, path):
+                errors.append(
+                    _issue(_relative_path(dataset_root, path), "label symlink resolves outside the supplied dataset root.")
+                )
+                continue
+            key = path.relative_to(label_directory).with_suffix("").as_posix().casefold()
+            label_paths[key] = path
+    else:
+        warnings.append(_issue(f"splits.{split_name}", "paired labels directory is missing."))
+
+    records: list[dict[str, object]] = []
+    image_keys: set[str] = set()
+    invalid_annotation_count = 0
+    for image_path in images:
+        relative_image = _relative_path(dataset_root, image_path)
+        image_key = image_path.relative_to(image_directory).with_suffix("").as_posix().casefold()
+        image_keys.add(image_key)
+        label_path = label_paths.get(image_key)
+        annotations: list[dict[str, object]] = []
+        label_is_empty = False
+        if label_path is None:
+            warnings.append(_issue(relative_image, "image has no paired YOLO label file."))
+        else:
+            annotations, invalid_rows, label_is_empty = _parse_label_file(
+                label_path,
+                _relative_path(dataset_root, label_path),
+                source_taxonomy,
+                mappings,
+                excluded,
+                errors,
+            )
+            invalid_annotation_count += invalid_rows
+        dimensions: tuple[int, int] | None = None
+        if decode_images:
+            try:
+                dimensions = _image_dimensions(image_path)
+            except CandidateInspectionError as exc:
+                errors.append(_issue(relative_image, f"image is unreadable or corrupt: {exc}"))
+        checksum: str | None = None
+        if checksums:
+            try:
+                checksum = _sha256(image_path)
+            except OSError as exc:
+                errors.append(_issue(relative_image, f"image checksum could not be read: {exc}"))
+        records.append(
+            {
+                "split": split_name,
+                "image_path": relative_image,
+                "label_path": _relative_path(dataset_root, label_path) if label_path is not None else None,
+                "source_sample_identifier": image_path.stem.casefold(),
+                "annotations": annotations,
+                "label_is_empty": label_is_empty,
+                "checksum": checksum,
+                "width": dimensions[0] if dimensions else None,
+                "height": dimensions[1] if dimensions else None,
+            }
+        )
+    orphan_labels = sorted(
+        _relative_path(dataset_root, label_path)
+        for key, label_path in label_paths.items()
+        if key not in image_keys
+    )
+    for orphan in orphan_labels:
+        warnings.append(_issue(orphan, "label has no paired supported image file."))
+    empty_labels = sorted(
+        record["label_path"]
+        for record in records
+        if record["label_path"] is not None and record["label_is_empty"]
+    )
+    return (
+        {
+            "declared_path": layout["declared_path"],
+            "image_directory": _relative_path(dataset_root, image_directory),
+            "label_directory": _relative_path(dataset_root, label_directory),
+            "image_count": len(images),
+            "label_file_count": len(label_paths),
+            "images_without_labels": sorted(
+                record["image_path"] for record in records if record["label_path"] is None
+            ),
+            "labels_without_images": orphan_labels,
+            "empty_label_files": empty_labels,
+            "unsupported_image_files": unsupported,
+            "invalid_annotation_count": invalid_annotation_count,
+        },
+        records,
+    )
+
+
+def _analysis_findings(
+    records: Sequence[Mapping[str, object]],
+    group_map: Mapping[str, str] | None,
+    errors: list[dict[str, str]],
+    warnings: list[dict[str, str]],
+) -> dict[str, object]:
+    sample_ids: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    checksums: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    groups: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    normalised_paths: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    unused_groups = set(group_map or {})
+    for record in records:
+        image_path = str(record["image_path"])
+        sample_ids[str(record["source_sample_identifier"])].append(record)
+        normalised_paths[_normalise_relative_path(image_path).casefold()].append(record)
+        checksum = record.get("checksum")
+        if isinstance(checksum, str):
+            checksums[checksum].append(record)
+        if group_map is not None:
+            group_id = group_map.get(_normalise_relative_path(image_path).casefold())
+            if group_id is not None:
+                groups[group_id].append(record)
+                unused_groups.discard(_normalise_relative_path(image_path).casefold())
+            else:
+                warnings.append(_issue(image_path, "has no supplied group identifier."))
+
+    def duplicate_entries(values: Mapping[str, Sequence[Mapping[str, object]]], field: str) -> list[dict[str, object]]:
+        return [
+            {
+                field: key,
+                "images": sorted(str(record["image_path"]) for record in entries),
+                "splits": sorted({str(record["split"]) for record in entries}),
+            }
+            for key, entries in sorted(values.items())
+            if len(entries) > 1
+        ]
+
+    duplicate_sample_identifiers = duplicate_entries(sample_ids, "sample_identifier")
+    duplicate_normalised_paths = duplicate_entries(normalised_paths, "normalized_path")
+    duplicate_checksums = duplicate_entries(checksums, "sha256")
+    cross_split_duplicates = [entry for entry in duplicate_checksums if len(entry["splits"]) > 1]
+    group_leakage = [entry for entry in duplicate_entries(groups, "group_id") if len(entry["splits"]) > 1]
+    if duplicate_sample_identifiers:
+        warnings.append(_issue("duplicates.sample_identifiers", "duplicate filename-stem sample identifiers were found."))
+    if duplicate_normalised_paths:
+        errors.append(_issue("duplicates.normalized_paths", "the same normalized image path was listed more than once."))
+    if duplicate_checksums:
+        warnings.append(_issue("duplicates.checksums", "identical image checksums were found."))
+    for entry in cross_split_duplicates:
+        errors.append(
+            _issue("leakage.image_checksums", f"identical image checksum is present across {entry['splits']!r}.")
+        )
+    for entry in group_leakage:
+        errors.append(_issue("leakage.groups", f"group {entry['group_id']!r} is present across {entry['splits']!r}."))
+    if group_map is None:
+        warnings.append(
+            _issue(
+                "leakage.groups",
+                "no group mapping was supplied; filename similarity was not used to infer group leakage.",
+            )
+        )
+    for unused_path in sorted(unused_groups):
+        warnings.append(_issue(f"groups[{unused_path}]", "does not match an inspected image path."))
+    return {
+        "duplicate_sample_identifiers": duplicate_sample_identifiers,
+        "duplicate_normalized_paths": duplicate_normalised_paths,
+        "duplicate_checksums": duplicate_checksums,
+        "cross_split_duplicate_images": cross_split_duplicates,
+        "cross_split_group_leakage": group_leakage,
+        "grouping_configured": group_map is not None,
+    }
+
+
+def _manifest_metadata_missing(
+    metadata: Mapping[str, object] | None,
+    source_taxonomy: Mapping[int, str],
+    mappings: Mapping[int, Mapping[str, object]],
+    excluded: Mapping[int, str],
+    unmapped: Mapping[int, str],
+    records: Sequence[Mapping[str, object]],
+    group_map: Mapping[str, str] | None,
+) -> list[str]:
+    if metadata is None:
+        return ["metadata file"]
+    missing = [
+        field
+        for field in (
+            "dataset",
+            "source_provenance",
+            "licence",
+            "storage_release",
+            "quality_review_status",
+            "known_limitations",
+        )
+        if field not in metadata
+    ]
+    for source_id in source_taxonomy:
+        if source_id not in mappings and source_id not in excluded and source_id not in unmapped:
+            missing.append(f"taxonomy decision for source class {source_id}:{source_taxonomy[source_id]}")
+    if group_map is None:
+        missing.append("explicit group identifiers for every image")
+    else:
+        for record in records:
+            if _normalise_relative_path(str(record["image_path"])).casefold() not in group_map:
+                missing.append("explicit group identifiers for every image")
+                break
+    return missing
+
+
+def _candidate_manifest(
+    report: Mapping[str, object],
+    metadata: Mapping[str, object],
+    source_taxonomy: Mapping[int, str],
+    mappings: Mapping[int, Mapping[str, object]],
+    excluded: Mapping[int, str],
+    unmapped: Mapping[int, str],
+    records: Sequence[Mapping[str, object]],
+    group_map: Mapping[str, str],
+) -> dict[str, object]:
+    split_samples: dict[str, list[dict[str, object]]] = {"train": [], "validation": [], "test": []}
+    for record in sorted(records, key=lambda item: (str(item["split"]), str(item["image_path"]))):
+        image_path = str(record["image_path"])
+        sample_id = "candidate-" + hashlib.sha256(image_path.encode("utf-8")).hexdigest()[:20]
+        annotation_ids = sorted(
+            {
+                int(annotation["target_class_id"])
+                for annotation in record["annotations"]  # type: ignore[index]
+                if annotation.get("target_class_id") is not None and not annotation.get("excluded")
+            }
+        )
+        sample: dict[str, object] = {
+            "sample_id": sample_id,
+            "image_path": image_path,
+            "group_id": group_map[_normalise_relative_path(image_path).casefold()],
+            "labelled": record["label_path"] is not None,
+            "annotation_summary": {
+                "bounding_box_count": len(record["annotations"]),
+                "class_ids": annotation_ids,
+            },
+        }
+        if record["label_path"] is not None:
+            sample["label_path"] = record["label_path"]
+        if isinstance(record.get("checksum"), str):
+            sample["checksum"] = f"sha256:{record['checksum']}"
+        if isinstance(record.get("width"), int) and isinstance(record.get("height"), int):
+            sample["width"] = record["width"]
+            sample["height"] = record["height"]
+        split_samples[str(record["split"])].append(sample)
+
+    all_annotations = [annotation for record in records for annotation in record["annotations"]]  # type: ignore[index]
+    duplicate_count = len(report["duplicates"]["duplicate_checksums"])  # type: ignore[index]
+    unreadable_count = len(report["image_issues"]["unreadable_images"])  # type: ignore[index]
+    invalid_annotation_count = int(report["totals"]["invalid_annotation_count"])  # type: ignore[index]
+    excluded_sample_count = sum(
+        1
+        for record in records
+        if any(annotation.get("excluded") for annotation in record["annotations"])  # type: ignore[index]
+    )
+    quality: dict[str, object] = {
+        "image_count": int(report["totals"]["image_count"]),  # type: ignore[index]
+        "annotation_count": len(all_annotations),
+        "duplicate_count": duplicate_count,
+        "corrupt_file_count": unreadable_count,
+        "invalid_annotation_count": invalid_annotation_count,
+        "excluded_sample_count": excluded_sample_count,
+        "quality_review_status": metadata["quality_review_status"],
+        "known_limitations": metadata["known_limitations"],
+    }
+    checksum_values = {
+        str(record["image_path"]): f"sha256:{record['checksum']}"
+        for record in records
+        if isinstance(record.get("checksum"), str)
+    }
+    if checksum_values:
+        quality["checksums"] = dict(sorted(checksum_values.items()))
+    return {
+        "schema_version": "1.0.0",
+        "dataset": metadata["dataset"],
+        "source_provenance": metadata["source_provenance"],
+        "licence": metadata["licence"],
+        "taxonomy": {
+            "target_classes": [{"id": class_id, "name": name} for class_id, name in APPROVED_TAXONOMY],
+            "class_mappings": [
+                {
+                    "source_class": source_taxonomy[source_id],
+                    "target_class_id": mapping["target_class_id"],
+                    "target_class_name": mapping["target_class_name"],
+                    "mapping_rationale": mapping["mapping_rationale"],
+                    "review_decision": "mapped",
+                }
+                for source_id, mapping in sorted(mappings.items())
+            ],
+            "excluded_source_classes": [
+                {"source_class": source_taxonomy[source_id], "reason": reason}
+                for source_id, reason in sorted(excluded.items())
+            ],
+            "unmapped_source_classes": [
+                {"source_class": source_taxonomy[source_id], "reason": reason}
+                for source_id, reason in sorted(unmapped.items())
+            ],
+            "bounding_box_coordinate_format": "normalized_xywh",
+        },
+        "splits": {split_name: {"samples": split_samples[split_name]} for split_name in split_samples},
+        "quality": quality,
+        "storage_release": metadata["storage_release"],
+    }
+
+
+def inspect_dataset(
+    dataset_root: Path,
+    dataset_yaml_path: Path,
+    *,
+    metadata_path: Path | None = None,
+    group_map_path: Path | None = None,
+    decode_images: bool = True,
+    checksums: bool = True,
+    generate_manifest: bool = False,
+    execution_time_utc: str | None = None,
+) -> tuple[dict[str, object], dict[str, object] | None]:
+    """Inspect a local YOLO dataset and return a report plus optional candidate manifest.
+
+    Inputs are read-only.  The caller is responsible for choosing an output
+    directory outside the dataset root when writing the returned data.
+    """
+    root = dataset_root.resolve()
+    if not root.is_dir():
+        raise CandidateInspectionError(f"Dataset root is not an existing directory: {dataset_root}")
+    dataset_yaml = _load_structured_file(dataset_yaml_path, "Dataset YAML")
+    metadata = _load_structured_file(metadata_path, "Metadata file") if metadata_path else None
+    errors: list[dict[str, str]] = []
+    warnings: list[dict[str, str]] = []
+    source_taxonomy = _source_taxonomy(dataset_yaml, errors)
+    mappings, excluded, unmapped = _mapping_summary(metadata, source_taxonomy, errors, warnings)
+    layout = _resolve_layout(root, dataset_yaml, errors)
+    group_map = _read_group_map(group_map_path, root, errors)
+    if decode_images:
+        if not _pillow_available():
+            decode_images = False
+            warnings.append(_issue("image_decoding", "Pillow is unavailable; full image decoding was skipped."))
+    else:
+        warnings.append(_issue("image_decoding", "image decoding was explicitly skipped."))
+    if not checksums:
+        warnings.append(_issue("checksums", "SHA-256 checksum calculation was explicitly skipped."))
+
+    split_reports: dict[str, object] = {}
+    records: list[dict[str, object]] = []
+    for split_name in ("train", "validation", "test"):
+        if split_name not in layout:
+            split_reports[split_name] = {
+                "declared_path": None,
+                "image_directory": None,
+                "label_directory": None,
+                "image_count": 0,
+                "label_file_count": 0,
+                "images_without_labels": [],
+                "labels_without_images": [],
+                "empty_label_files": [],
+                "unsupported_image_files": [],
+                "invalid_annotation_count": 0,
+            }
+            continue
+        split_report, split_records = _scan_split(
+            split_name,
+            layout[split_name],
+            root,
+            source_taxonomy,
+            mappings,
+            excluded,
+            decode_images=decode_images,
+            checksums=checksums,
+            errors=errors,
+            warnings=warnings,
+        )
+        split_reports[split_name] = split_report
+        records.extend(split_records)
+
+    findings = _analysis_findings(records, group_map, errors, warnings)
+    source_counts = Counter(
+        int(annotation["source_class_id"])
+        for record in records
+        for annotation in record["annotations"]  # type: ignore[index]
+    )
+    target_counts = Counter(
+        int(annotation["target_class_id"])
+        for record in records
+        for annotation in record["annotations"]  # type: ignore[index]
+        if annotation.get("target_class_id") is not None and not annotation.get("excluded")
+    )
+    unreadable_images = sorted(
+        error["location"]
+        for error in errors
+        if error["message"].startswith("image is unreadable or corrupt")
+    )
+    samples_without_annotations = sorted(
+        str(record["image_path"]) for record in records if not record["annotations"]
+    )
+    image_count = len(records)
+    annotation_count = sum(len(record["annotations"]) for record in records)
+    invalid_annotation_count = sum(
+        int(split_report["invalid_annotation_count"])
+        for split_report in split_reports.values()  # type: ignore[union-attr]
+    )
+    totals = {
+        "image_count": image_count,
+        "label_file_count": sum(int(split_report["label_file_count"]) for split_report in split_reports.values()),  # type: ignore[union-attr]
+        "annotation_count": annotation_count,
+        "invalid_annotation_count": invalid_annotation_count,
+        "images_without_labels": sum(len(split_report["images_without_labels"]) for split_report in split_reports.values()),  # type: ignore[union-attr]
+        "labels_without_images": sum(len(split_report["labels_without_images"]) for split_report in split_reports.values()),  # type: ignore[union-attr]
+        "empty_label_files": sum(len(split_report["empty_label_files"]) for split_report in split_reports.values()),  # type: ignore[union-attr]
+        "samples_without_annotations": len(samples_without_annotations),
+    }
+    if errors:
+        verdict = "fail"
+    elif warnings:
+        verdict = "pass_with_warnings"
+    else:
+        verdict = "pass"
+    report: dict[str, object] = {
+        "tool": {"name": TOOL_NAME, "version": TOOL_VERSION},
+        "execution": {
+            "time_utc": execution_time_utc
+            or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "network_access": False,
+            "read_only_dataset_inspection": True,
+        },
+        "dataset_identity": metadata.get("dataset", {}).get("id")
+        if isinstance(metadata, Mapping) and isinstance(metadata.get("dataset"), Mapping)
+        else None,
+        "settings": {"image_decoding": decode_images, "checksums": checksums},
+        "splits": split_reports,
+        "source_taxonomy": [{"id": class_id, "name": name} for class_id, name in source_taxonomy.items()],
+        "walkbuddy_target_taxonomy": [
+            {"id": class_id, "name": name} for class_id, name in APPROVED_TAXONOMY
+        ],
+        "mapping_summary": {
+            "mapped_source_classes": [
+                {
+                    "source_class_id": source_id,
+                    "source_class_name": source_taxonomy[source_id],
+                    **mapping,
+                }
+                for source_id, mapping in sorted(mappings.items())
+            ],
+            "excluded_source_classes": [
+                {"source_class_id": source_id, "source_class_name": source_taxonomy[source_id], "reason": reason}
+                for source_id, reason in sorted(excluded.items())
+            ],
+            "unmapped_source_classes": [
+                {
+                    "source_class_id": source_id,
+                    "source_class_name": source_taxonomy[source_id],
+                    "reason": unmapped.get(source_id, "No explicit source-taxonomy decision was supplied."),
+                }
+                for source_id in source_taxonomy
+                if source_id not in mappings and source_id not in excluded
+            ],
+        },
+        "totals": totals,
+        "annotation_counts_by_source_class": [
+            {"id": source_id, "name": source_taxonomy[source_id], "count": source_counts[source_id]}
+            for source_id in source_taxonomy
+        ],
+        "annotation_counts_by_walkbuddy_target_class": [
+            {"id": target_id, "name": target_name, "count": target_counts[target_id]}
+            for target_id, target_name in APPROVED_TAXONOMY
+        ],
+        "image_issues": {
+            "unreadable_images": unreadable_images,
+            "samples_without_valid_annotations": samples_without_annotations,
+        },
+        "duplicates": findings,
+        "validation_errors": _sort_issues(errors),
+        "warnings": _sort_issues(warnings),
+        "quality_verdict": verdict,
+        "limitations": [
+            "A passing inspection does not establish legal, privacy, ethical, or dataset-fitness approval.",
+            "This inspection does not measure model quality or production readiness.",
+            "Group leakage is checked only when explicit group identifiers are supplied.",
+        ],
+    }
+    candidate: dict[str, object] | None = None
+    if generate_manifest:
+        missing = _manifest_metadata_missing(
+            metadata, source_taxonomy, mappings, excluded, unmapped, records, group_map
+        )
+        if report["quality_verdict"] == "fail":
+            missing.append("a passing dataset-quality inspection")
+        if missing:
+            report["candidate_manifest"] = {
+                "requested": True,
+                "generated": False,
+                "missing_requirements": sorted(set(missing)),
+            }
+        else:
+            assert metadata is not None and group_map is not None
+            candidate = _candidate_manifest(
+                report, metadata, source_taxonomy, mappings, excluded, unmapped, records, group_map
+            )
+            manifest_issues = manifest_validator.validate_manifest(candidate)
+            if manifest_issues:
+                report["candidate_manifest"] = {
+                    "requested": True,
+                    "generated": False,
+                    "missing_requirements": [
+                        f"generated manifest validation: {issue.location}: {issue.message}"
+                        for issue in manifest_issues
+                    ],
+                }
+                candidate = None
+            else:
+                report["candidate_manifest"] = {"requested": True, "generated": True}
+    else:
+        report["candidate_manifest"] = {"requested": False, "generated": False}
+    return report, candidate
+
+
+def _markdown_table(rows: Sequence[Sequence[object]], headers: Sequence[str]) -> list[str]:
+    lines = ["| " + " | ".join(headers) + " |", "| " + " | ".join("---" for _ in headers) + " |"]
+    lines.extend("| " + " | ".join(str(value) for value in row) + " |" for row in rows)
+    return lines
+
+
+def render_markdown_report(report: Mapping[str, object]) -> str:
+    totals = report["totals"]
+    assert isinstance(totals, Mapping)
+    lines = [
+        "# Candidate dataset quality report",
+        "",
+        f"Tool: `{report['tool']['name']}` {report['tool']['version']}.",  # type: ignore[index]
+        f"Execution time (runtime metadata): {report['execution']['time_utc']}."  # type: ignore[index]
+        "",
+        "## Quality verdict",
+        "",
+        f"`{report['quality_verdict']}`. The verdict is `fail` when validation errors exist, "
+        "`pass_with_warnings` when there are no errors but warnings exist, and `pass` otherwise.",
+        "",
+        "## Totals",
+        "",
+    ]
+    lines.extend(
+        _markdown_table(
+            [(key.replace("_", " "), value) for key, value in totals.items()], ["Measure", "Value"]
+        )
+    )
+    lines.extend(["", "## Split inspection", ""])
+    split_rows = []
+    for name, split in report["splits"].items():  # type: ignore[index]
+        split_rows.append((name, split["image_count"], split["label_file_count"], split["invalid_annotation_count"]))
+    lines.extend(_markdown_table(split_rows, ["Split", "Images", "Label files", "Invalid label rows"]))
+    lines.extend(["", "## Source class distribution", ""])
+    lines.extend(
+        _markdown_table(
+            [(item["id"], item["name"], item["count"]) for item in report["annotation_counts_by_source_class"]],  # type: ignore[index]
+            ["Source ID", "Class", "Annotations"],
+        )
+    )
+    lines.extend(["", "## WalkBuddy target distribution", ""])
+    lines.extend(
+        _markdown_table(
+            [(item["id"], item["name"], item["count"]) for item in report["annotation_counts_by_walkbuddy_target_class"]],  # type: ignore[index]
+            ["Target ID", "Class", "Mapped annotations"],
+        )
+    )
+    for heading, values in (("Validation errors", report["validation_errors"]), ("Warnings", report["warnings"])):
+        lines.extend(["", f"## {heading}", ""])
+        if values:
+            lines.extend(f"- `{value['location']}`: {value['message']}" for value in values)  # type: ignore[index]
+        else:
+            lines.append("- None.")
+    lines.extend(["", "## Limitations", ""])
+    lines.extend(f"- {limitation}" for limitation in report["limitations"])  # type: ignore[index]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_outputs(
+    report: Mapping[str, object],
+    candidate_manifest: Mapping[str, object] | None,
+    output_directory: Path,
+    dataset_root: Path,
+) -> list[Path]:
+    resolved_output = output_directory.resolve()
+    try:
+        resolved_output.relative_to(dataset_root.resolve())
+    except ValueError:
+        pass
+    else:
+        raise CandidateInspectionError("Output directory must be outside the supplied dataset root.")
+    resolved_output.mkdir(parents=True, exist_ok=True)
+    json_path = resolved_output / "dataset_quality_report.json"
+    markdown_path = resolved_output / "dataset_quality_report.md"
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown_report(report), encoding="utf-8")
+    paths = [json_path, markdown_path]
+    if candidate_manifest is not None:
+        manifest_path = resolved_output / "candidate_manifest.json"
+        manifest_path.write_text(json.dumps(candidate_manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        paths.append(manifest_path)
+    return paths
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only YOLO candidate-dataset quality inspection for the WalkBuddy taxonomy."
+    )
+    parser.add_argument("--dataset-root", required=True, type=Path, help="Controlled local root containing the dataset.")
+    parser.add_argument("--dataset-yaml", required=True, type=Path, help="Local YOLO dataset YAML file.")
+    parser.add_argument("--output-dir", required=True, type=Path, help="Directory outside the dataset root for generated reports.")
+    parser.add_argument("--metadata", type=Path, help="Optional reviewed metadata JSON or YAML for mapping and manifest generation.")
+    parser.add_argument("--group-map", type=Path, help="Optional JSON or YAML map of relative image paths to explicit group IDs.")
+    parser.add_argument("--skip-image-decode", action="store_true", help="Do not decode images with Pillow.")
+    parser.add_argument("--skip-checksums", action="store_true", help="Do not calculate SHA-256 image checksums.")
+    parser.add_argument("--generate-manifest", action="store_true", help="Write candidate_manifest.json only when reviewed metadata is complete.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        report, candidate = inspect_dataset(
+            args.dataset_root,
+            args.dataset_yaml,
+            metadata_path=args.metadata,
+            group_map_path=args.group_map,
+            decode_images=not args.skip_image_decode,
+            checksums=not args.skip_checksums,
+            generate_manifest=args.generate_manifest,
+        )
+        paths = write_outputs(report, candidate, args.output_dir, args.dataset_root)
+    except CandidateInspectionError as exc:
+        print(f"Candidate dataset inspection failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Candidate dataset inspection verdict: {report['quality_verdict']}")
+    print("Generated: " + ", ".join(str(path) for path in paths))
+    return 0 if report["quality_verdict"] != "fail" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2><p>Adds read-only candidate dataset inspection tooling for the WalkBuddy navigation-model pipeline.</p><p>The new CLI inspects local YOLO-format datasets, validates annotation quality, detects duplicates and split leakage, reports class mappings, and can generate a candidate manifest compatible with the existing dataset-manifest validator.</p><h2>Changes</h2><ul><li><p>adds <code inline="">ML_side/tools/inspect_candidate_dataset.py</code>;</p></li><li><p>adds comprehensive tests in <code inline="">ML_side/tests/test_inspect_candidate_dataset.py</code>;</p></li><li><p>updates the dataset README with usage, supported layouts, validation rules, report outputs and limitations;</p></li><li><p>supports <code inline="">train</code>, <code inline="">val</code>/<code inline="">validation</code>, and optional <code inline="">test</code> dataset splits;</p></li><li><p>validates YOLO detection labels;</p></li><li><p>reports missing, orphaned and empty labels;</p></li><li><p>detects malformed annotations and invalid bounding boxes;</p></li><li><p>detects duplicate image checksums and cross-split duplicates;</p></li><li><p>supports explicitly configured group and sequence leakage checks;</p></li><li><p>validates source-to-WalkBuddy class mappings;</p></li><li><p>distinguishes mapped, excluded and unmapped source classes;</p></li><li><p>generates deterministic JSON and Markdown quality reports;</p></li><li><p>optionally generates a candidate dataset manifest when complete reviewed metadata is supplied;</p></li><li><p>validates generated manifests using the existing manifest validator.</p></li></ul><h2>Approved WalkBuddy taxonomy</h2>
ID | Class
-- | --
0 | person
1 | stairs
2 | door
3 | chair
4 | table
5 | pole
6 | bicycle
7 | vehicle

<h2>Quality checks</h2><p>The inspection tool reports:</p><ul><li><p>image, label and annotation totals by split;</p></li><li><p>source and WalkBuddy target-class distributions;</p></li><li><p>missing labels;</p></li><li><p>orphan labels;</p></li><li><p>empty label files;</p></li><li><p>malformed YOLO rows;</p></li><li><p>non-numeric or non-finite values;</p></li><li><p>invalid source class IDs;</p></li><li><p>zero or negative box dimensions;</p></li><li><p>boxes outside normalised YOLO bounds;</p></li><li><p>unreadable or corrupt images;</p></li><li><p>duplicate images;</p></li><li><p>duplicate images across splits;</p></li><li><p>configured group or sequence leakage;</p></li><li><p>excluded and unmapped source classes;</p></li><li><p>unsafe paths and symlink escapes.</p></li></ul><h2>Verdicts</h2><p>The generated reports use:</p><ul><li><p><code inline="">pass</code></p></li><li><p><code inline="">pass_with_warnings</code></p></li><li><p><code inline="">fail</code></p></li></ul><p>Serious issues such as malformed annotations, invalid mappings, corrupt images, unsafe paths, missing required splits, duplicate images across splits or group leakage result in a failing inspection.</p><h2>Candidate manifest generation</h2><p>A candidate manifest is generated only when:</p><ul><li><p>all required source, version, licence and review metadata is supplied;</p></li><li><p>class mappings are valid;</p></li><li><p>required group IDs are complete;</p></li><li><p>the dataset inspection does not fail;</p></li><li><p>the generated manifest passes the existing manifest validator.</p></li></ul><p>The tool does not fabricate missing source, licence, reviewer or approval information.</p><h2>Verification</h2><ul><li><p>focused candidate-inspection tests: 38 passed;</p></li><li><p>complete ML-side test suite: 107 passed;</p></li><li><p>Python syntax compilation passed;</p></li><li><p>CLI help passed;</p></li><li><p>valid and invalid fixture checks passed;</p></li><li><p>generated candidate manifest passed the existing validator;</p></li><li><p>incomplete metadata correctly prevented manifest generation;</p></li><li><p><code inline="">git diff --check</code> passed.</p></li></ul><p>The complete ML suite was run with:</p><pre><code class="language-powershell">$env:PYTHONPATH = (Resolve-Path ML_side).Path
python -m pytest ML_side\tests -q
</code></pre><p>This is required because an existing depth-estimator test imports directly from <code inline="">ML_side</code>, and the repository does not currently provide a shared pytest path configuration.</p><h2>Scope boundaries</h2><p>This pull request does not:</p><ul><li><p>download or modify datasets;</p></li><li><p>add raw images or labels;</p></li><li><p>train a model;</p></li><li><p>modify model weights;</p></li><li><p>change the production backend;</p></li><li><p>modify frontend or unrelated features;</p></li><li><p>perform network requests;</p></li><li><p>establish legal, privacy or ethical approval;</p></li><li><p>prove dataset fitness or model quality.</p></li></ul><h2>Known limitations</h2><ul><li><p>only standard YOLO object-detection rows are supported;</p></li><li><p>segmentation, pose and oriented-box formats are not supported;</p></li><li><p>duplicate detection identifies exact file matches rather than visually similar images;</p></li><li><p>group leakage is checked only when group information or an explicit grouping rule is provided;</p></li><li><p>dataset inspection does not replace human review of licences, privacy, ethics or domain suitability.</p></li></ul><h2>Follow-up</h2><ul><li><p>run the inspector against the selected real candidate datasets;</p></li><li><p>record exact source, version and licence metadata;</p></li><li><p>review class distributions and quality failures;</p></li><li><p>produce the first controlled candidate dataset manifest;</p></li><li><p>create the first versioned MVP dataset release;</p></li><li><p>implement the reproducible training pipeline.</p></li></ul></body></html><!--EndFragment-->
</body>
</html>