### PR TITLE
Add reproducible navigation training pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ ML_side/data/val_dataset/
 ML_side/models/*
 !ML_side/models/README.md
 ML_side/evaluation_results/
+ML_side/artifacts/
 
 software_side/walkbuddy_reactNative/frontend_reactNative/package-lock.json
 software_side.zip

--- a/ML_side/config/training_navigation_mvp.yaml
+++ b/ML_side/config/training_navigation_mvp.yaml
@@ -1,0 +1,28 @@
+# Template only: replace with reviewed local inputs before real training.
+schema_version: "1.0.0"
+experiment_name: "navigation-mvp-candidate"
+dataset:
+  manifest_path: "ML_side/datasets/sample_manifest.json"
+  yaml_path: "dataset.yaml"
+  inspection_report_path: null
+  stage: "candidate"
+model:
+  # Exactly one local path is required. Neither field may be a URL or model identifier.
+  architecture_path: "ML_side/training/local_navigation_architecture.yaml"
+  initial_weights_path: null
+training:
+  epochs: 100
+  image_size: 640
+  batch_size: 16
+  device: "cpu"
+  workers: 2
+  seed: 42
+  optimizer: "AdamW"
+  learning_rate: 0.001
+  confidence: 0.001
+  iou: 0.7
+  deterministic: true
+  resume_behavior: "never"
+output:
+  root: "ML_side/artifacts/navigation_mvp"
+notes: "Template only. A reviewed approved manifest, local dataset, and local model file are required."

--- a/ML_side/tests/test_train_navigation_model.py
+++ b/ML_side/tests/test_train_navigation_model.py
@@ -1,0 +1,385 @@
+"""Local-only tests for the controlled navigation-model training preflight."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ML_SIDE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ML_SIDE_DIR / "training"))
+sys.path.insert(0, str(ML_SIDE_DIR / "tools"))
+
+import train_navigation_model as training
+
+
+SAMPLE_MANIFEST = ML_SIDE_DIR / "datasets" / "sample_manifest.json"
+
+
+def write_yaml(path: Path, names: list[str] | None = None) -> Path:
+    names = names or [name for _, name in training.manifest_validator.APPROVED_TAXONOMY]
+    path.write_text(
+        "path: .\ntrain: train/images\nval: validation/images\ntest: test/images\nnames:\n"
+        + "".join(f"  {index}: {name}\n" for index, name in enumerate(names)),
+        encoding="utf-8",
+    )
+    return path
+
+
+def create_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    repository = tmp_path / "repository"
+    dataset_root = tmp_path / "dataset"
+    repository.mkdir()
+    dataset_root.mkdir()
+    manifest = json.loads(SAMPLE_MANIFEST.read_text(encoding="utf-8"))
+    manifest["dataset"]["release_decision"] = "approved_for_training"
+    manifest["licence"]["review_decision"] = "approved"
+    (repository / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    for split in manifest["splits"].values():
+        for sample in split["samples"]:
+            for field in ("image_path", "label_path"):
+                value = sample.get(field)
+                if value:
+                    target = dataset_root / value
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_text("fixture", encoding="utf-8")
+    write_yaml(dataset_root / "dataset.yaml")
+    (repository / "architecture.yaml").write_text("nc: 8\n", encoding="utf-8")
+    config = {
+        "schema_version": "1.0.0",
+        "experiment_name": "Navigation MVP Test",
+        "dataset": {"manifest_path": "manifest.json", "yaml_path": "dataset.yaml", "inspection_report_path": None, "stage": "approved_for_internal_training"},
+        "model": {"architecture_path": "architecture.yaml", "initial_weights_path": None},
+        "training": {"epochs": 2, "image_size": 640, "batch_size": 2, "device": "cpu", "workers": 1, "seed": 17, "optimizer": "AdamW", "learning_rate": 0.001, "confidence": 0.001, "iou": 0.7, "deterministic": True, "resume_behavior": "never"},
+        "output": {"root": "artifacts/navigation_mvp"},
+        "notes": "Fictional test-only configuration.",
+    }
+    config_path = repository / "training.yaml"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    return repository, dataset_root, config_path
+
+
+def load_plan(repository: Path, dataset_root: Path, config_path: Path, **kwargs: object) -> training.TrainingPlan:
+    return training.load_training_plan(config_path, dataset_root_override=dataset_root, repository_root=repository, **kwargs)
+
+
+def config_data(config_path: Path) -> dict[str, object]:
+    return json.loads(config_path.read_text(encoding="utf-8"))
+
+
+def save_config(config_path: Path, config: dict[str, object]) -> None:
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+
+def test_valid_dry_run_succeeds_without_trainer_or_artifacts(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    plan = load_plan(repository, dataset_root, config_path)
+
+    result = training.dry_run(plan)
+
+    assert result["status"] == "dry_run_valid"
+    assert not plan.run_directory.exists()
+    assert result["plan"]["dataset_root"] == "externally supplied local root"  # type: ignore[index]
+
+
+def test_dry_run_does_not_invoke_trainer(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    plan = load_plan(repository, dataset_root, config_path)
+
+    assert training.dry_run(plan)["status"] == "dry_run_valid"
+    assert not plan.run_directory.exists()
+
+
+def test_dry_run_does_not_require_ultralytics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    monkeypatch.setitem(sys.modules, "ultralytics", None)
+
+    assert training.dry_run(load_plan(repository, dataset_root, config_path))["status"] == "dry_run_valid"
+
+
+def test_cli_valid_fictional_dry_run_does_not_write_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    monkeypatch.setattr(training, "REPOSITORY_ROOT", repository)
+
+    assert training.main(["--config", str(config_path), "--dataset-root", str(dataset_root), "--dry-run"]) == 0
+    assert '"status": "dry_run_valid"' in capsys.readouterr().out
+    assert not (repository / "artifacts").exists()
+
+
+def test_invalid_manifest_fails(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    manifest = json.loads((repository / "manifest.json").read_text(encoding="utf-8"))
+    del manifest["dataset"]["name"]
+    (repository / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(training.TrainingPipelineError, match="manifest validation failed"):
+        load_plan(repository, dataset_root, config_path)
+
+
+def test_wrong_dataset_yaml_taxonomy_fails(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    write_yaml(dataset_root / "dataset.yaml", ["person", "stairs", "door", "chair", "table", "pole", "bicycle", "wrong"])
+
+    with pytest.raises(training.TrainingPipelineError, match="taxonomy"):
+        load_plan(repository, dataset_root, config_path)
+
+
+@pytest.mark.parametrize("decision, expected", [("rejected", "rejected"), ("draft", "not approved"), ("under_review", "not approved")])
+def test_ineligible_manifest_release_status_fails(tmp_path: Path, decision: str, expected: str) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    manifest = json.loads((repository / "manifest.json").read_text(encoding="utf-8"))
+    manifest["dataset"]["release_decision"] = decision
+    (repository / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(training.TrainingPipelineError, match=expected):
+        load_plan(repository, dataset_root, config_path)
+
+
+@pytest.mark.parametrize("stage", ["candidate", "in_review", "rejected"])
+def test_ineligible_training_stage_fails(tmp_path: Path, stage: str) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    config = config_data(config_path)
+    config["dataset"]["stage"] = stage  # type: ignore[index]
+    save_config(config_path, config)
+
+    with pytest.raises(training.TrainingPipelineError, match="not eligible"):
+        load_plan(repository, dataset_root, config_path)
+
+
+def test_ineligible_licence_review_status_fails(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    manifest = json.loads((repository / "manifest.json").read_text(encoding="utf-8"))
+    manifest["licence"]["review_decision"] = "conditional"
+    (repository / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(training.TrainingPipelineError, match="licence review"):
+        load_plan(repository, dataset_root, config_path)
+
+
+def test_missing_yaml_and_local_model_fail(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    (dataset_root / "dataset.yaml").unlink()
+    with pytest.raises(training.TrainingPipelineError, match="dataset YAML path"):
+        load_plan(repository, dataset_root, config_path)
+    write_yaml(dataset_root / "dataset.yaml")
+    (repository / "architecture.yaml").unlink()
+    with pytest.raises(training.TrainingPipelineError, match="model architecture"):
+        load_plan(repository, dataset_root, config_path)
+
+
+@pytest.mark.parametrize("path", ["https://example.invalid/model.pt", "../outside.pt", r"C:\\outside.pt", "yolov8n.pt"])
+def test_remote_identifier_urls_and_unsafe_model_paths_fail(tmp_path: Path, path: str) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    config = config_data(config_path)
+    config["model"]["architecture_path"] = path  # type: ignore[index]
+    save_config(config_path, config)
+
+    with pytest.raises(training.TrainingPipelineError):
+        load_plan(repository, dataset_root, config_path)
+
+
+def test_dataset_yaml_traversal_and_output_escape_fail(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    config = config_data(config_path)
+    config["dataset"]["yaml_path"] = "../dataset.yaml"  # type: ignore[index]
+    save_config(config_path, config)
+    with pytest.raises(training.TrainingPipelineError, match="dataset YAML path"):
+        load_plan(repository, dataset_root, config_path)
+    config["dataset"]["yaml_path"] = "dataset.yaml"  # type: ignore[index]
+    config["output"]["root"] = "../outside"  # type: ignore[index]
+    save_config(config_path, config)
+    with pytest.raises(training.TrainingPipelineError, match="output root"):
+        load_plan(repository, dataset_root, config_path)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), True])
+def test_nonfinite_or_boolean_numeric_thresholds_fail(tmp_path: Path, value: object) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    config = config_data(config_path)
+    config["training"]["confidence"] = value  # type: ignore[index]
+    save_config(config_path, config)
+
+    with pytest.raises(training.TrainingPipelineError, match="confidence"):
+        load_plan(repository, dataset_root, config_path)
+
+
+def test_unknown_configuration_field_and_manifest_yaml_split_mismatch_fail(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    config = config_data(config_path)
+    config["training"]["unexpected"] = "ignored-before-hardening"  # type: ignore[index]
+    save_config(config_path, config)
+    with pytest.raises(training.TrainingPipelineError, match="unsupported field"):
+        load_plan(repository, dataset_root, config_path)
+    config["training"].pop("unexpected")  # type: ignore[index]
+    save_config(config_path, config)
+    write_yaml(dataset_root / "dataset.yaml")
+    (dataset_root / "dataset.yaml").write_text(
+        (dataset_root / "dataset.yaml").read_text(encoding="utf-8").replace("train: train/images", "train: validation/images"),
+        encoding="utf-8",
+    )
+    with pytest.raises(training.TrainingPipelineError, match="outside the dataset YAML train"):
+        load_plan(repository, dataset_root, config_path)
+
+
+def test_failing_inspection_evidence_blocks_training(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    (dataset_root / "inspection.json").write_text('{"quality_verdict":"fail"}', encoding="utf-8")
+    config = config_data(config_path)
+    config["dataset"]["inspection_report_path"] = "inspection.json"  # type: ignore[index]
+    save_config(config_path, config)
+
+    with pytest.raises(training.TrainingPipelineError, match="failing quality verdict"):
+        load_plan(repository, dataset_root, config_path)
+
+
+def test_nonfailing_inspection_evidence_is_accepted(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    (dataset_root / "inspection.json").write_text('{"quality_verdict":"pass_with_warnings"}', encoding="utf-8")
+    config = config_data(config_path)
+    config["dataset"]["inspection_report_path"] = "inspection.json"  # type: ignore[index]
+    save_config(config_path, config)
+
+    assert load_plan(repository, dataset_root, config_path).run_id
+
+
+def test_dataset_root_is_not_accepted_from_committed_configuration(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    config = config_data(config_path)
+    config["dataset"]["root"] = str(dataset_root)
+    save_config(config_path, config)
+
+    with pytest.raises(training.TrainingPipelineError, match="unsupported field"):
+        training.load_training_plan(config_path, repository_root=repository)
+
+
+def test_stable_run_id_checksums_and_seed(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    first = load_plan(repository, dataset_root, config_path)
+    second = load_plan(repository, dataset_root, config_path)
+
+    assert first.run_id == second.run_id
+    assert first.config_checksum == second.config_checksum
+    assert training.trainer_arguments(first)["seed"] == 17
+
+
+def test_changed_configuration_changes_the_run_identity(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    first = load_plan(repository, dataset_root, config_path)
+    config = config_data(config_path)
+    config["training"]["epochs"] = 3  # type: ignore[index]
+    save_config(config_path, config)
+    second = load_plan(repository, dataset_root, config_path)
+
+    assert first.config_checksum != second.config_checksum
+    assert first.run_id != second.run_id
+
+
+def test_existing_local_initial_weights_are_accepted(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    (repository / "initial.pt").write_bytes(b"fictional local weights")
+    config = config_data(config_path)
+    config["model"] = {"architecture_path": None, "initial_weights_path": "initial.pt"}
+    save_config(config_path, config)
+
+    assert load_plan(repository, dataset_root, config_path).model_kind == "initial_weights"
+
+
+def test_existing_run_is_protected(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    plan = load_plan(repository, dataset_root, config_path)
+    plan.run_directory.mkdir(parents=True)
+
+    with pytest.raises(training.TrainingPipelineError, match="already exists"):
+        load_plan(repository, dataset_root, config_path)
+
+
+def test_existing_run_can_only_resume_with_explicit_policy_and_flag(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    config = config_data(config_path)
+    config["training"]["resume_behavior"] = "allow"  # type: ignore[index]
+    save_config(config_path, config)
+    plan = load_plan(repository, dataset_root, config_path)
+    plan.run_directory.mkdir(parents=True)
+
+    resumed = load_plan(repository, dataset_root, config_path, allow_existing_run=True)
+    assert resumed.run_directory.exists()
+
+
+def test_trainer_arguments_match_resolved_config(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    plan = load_plan(repository, dataset_root, config_path, overrides={"epochs": 3, "batch_size": 4})
+    arguments = training.trainer_arguments(plan)
+
+    assert arguments["epochs"] == 3
+    assert arguments["batch"] == 4
+    assert arguments["data"] == str(dataset_root / "dataset.yaml")
+    assert arguments["cache"] is False
+
+
+def test_successful_mocked_training_writes_sanitised_metadata(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    plan = load_plan(repository, dataset_root, config_path)
+    called: list[str] = []
+
+    assert training.run_training(plan, lambda received: called.append(received.run_id) or {"ok": True}) == {"ok": True}
+    metadata = json.loads((plan.run_directory / "run_metadata.json").read_text(encoding="utf-8"))
+
+    assert called == [plan.run_id]
+    assert metadata["status"] == "succeeded"
+    assert metadata["manifest_checksum_sha256"] == plan.manifest_checksum
+    assert metadata["dataset_release"]["source_version"] == "fictional-source-v1.0"
+    assert str(dataset_root) not in json.dumps(metadata)
+    assert "environ" not in json.dumps(metadata).casefold()
+
+
+def test_failed_mocked_training_records_failure_and_preserves_partial_output(tmp_path: Path) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    plan = load_plan(repository, dataset_root, config_path)
+
+    def failed_trainer(_: training.TrainingPlan) -> object:
+        (plan.run_directory / "partial.txt").write_text("partial", encoding="utf-8")
+        raise RuntimeError("fictional trainer failure")
+
+    with pytest.raises(training.TrainingPipelineError, match="fictional trainer failure"):
+        training.run_training(plan, failed_trainer)
+    metadata = json.loads((plan.run_directory / "run_metadata.json").read_text(encoding="utf-8"))
+
+    assert metadata["status"] == "failed"
+    assert "RuntimeError" in metadata["failure_summary"]
+    assert (plan.run_directory / "partial.txt").is_file()
+
+
+def test_cli_errors_do_not_show_traceback_and_help_succeeds(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exit_result:
+        training.main(["--help"])
+    assert exit_result.value.code == 0
+    assert "--confirm-training" in capsys.readouterr().out
+    assert training.main(["--config", str(tmp_path / "missing.yaml"), "--dry-run"]) == 1
+    assert "Traceback" not in capsys.readouterr().err
+
+
+def test_cli_conflicting_confirmation_flags_fail_without_trainer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    monkeypatch.setattr(training, "REPOSITORY_ROOT", repository)
+
+    assert training.main(["--config", str(config_path), "--dataset-root", str(dataset_root), "--dry-run", "--confirm-training"]) == 1
+    assert "cannot be used together" in capsys.readouterr().err
+
+
+def test_missing_confirmation_blocks_trainer_invocation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+    monkeypatch.setattr(training, "REPOSITORY_ROOT", repository)
+    monkeypatch.setattr(training, "default_trainer", lambda _: (_ for _ in ()).throw(AssertionError("must not run")))
+
+    assert training.main(["--config", str(config_path), "--dataset-root", str(dataset_root)]) == 1
+    assert "requires --confirm-training" in capsys.readouterr().err
+    assert not (repository / "artifacts").exists()

--- a/ML_side/training/README.md
+++ b/ML_side/training/README.md
@@ -1,0 +1,54 @@
+# Controlled navigation-model training
+
+`train_navigation_model.py` is the local-only foundation for a future WalkBuddy navigation-model candidate. It does not establish model quality, legal approval, privacy compliance, or production readiness.
+
+## Inputs and eligibility
+
+Start from [`../config/training_navigation_mvp.yaml`](../config/training_navigation_mvp.yaml), then use a reviewed local copy. The configuration must reference a repository-relative manifest and local model architecture (`.yaml`/`.yml`) or initial weights (`.pt`), never a URL or a bare Ultralytics model identifier. Exactly one model source is required.
+
+The manifest must pass the bundled validator with `--check-files` semantics, use the approved eight-class taxonomy, have `dataset.release_decision: approved_for_training`, and record an approved licence review that permits machine-learning use. Of the manifest decisions, only `approved_for_training` is accepted; `draft`, `under_review`, `rejected`, `retired`, and `example_only` are rejected. The configuration stage must be `approved_for_internal_training` or `released`; `candidate`, `in_review`, and `rejected` are deliberately ineligible. The YOLO YAML must use the exact same ordered taxonomy and physically contain each manifest sample beneath its declared split. If an inspection report is supplied, its verdict must not be `fail`.
+
+The versioned configuration records the experiment name; manifest/YAML references; explicit stage; exactly one local model source; epochs, image size, batch, device, workers, seed, optimiser, learning rate, confidence, IoU, deterministic preference, resume behaviour, output root, and notes. Unknown fields are rejected. Epochs, image size, batch, workers, and seed are positive non-boolean integers; learning rate, confidence, and IoU are finite non-negative numbers. Device values are deliberately limited to `cpu`, `auto`, `mps`, `cuda`, `cuda:<index>`, or a numeric GPU index. Dataset roots are intentionally supplied at execution with `--dataset-root` rather than committed.
+
+## Dry run
+
+Use an existing controlled local dataset root. The root is not recorded in output metadata.
+
+```powershell
+python .\ML_side\training\train_navigation_model.py `
+  --config .\ML_side\config\training_navigation_mvp.yaml `
+  --dataset-root D:\controlled-datasets\navigation-mvp-v1 `
+  --dry-run
+```
+
+A dry run validates configuration, manifest, local dataset files, YAML, model file, eligibility, output safety, and any inspection evidence. It creates no run directory, weights, or trainer output and never imports or invokes Ultralytics.
+
+## Explicit real training
+
+Real training is blocked unless `--confirm-training` is supplied; combining it with `--dry-run` is rejected. It uses only an existing local model path, sets `YOLO_OFFLINE=true` and disables Weights & Biases mode before the trainer is imported, and does not download datasets or weights. A remote URL, URI, traversal attempt, absolute path in the committed configuration, or missing local file fails preflight. These safeguards do not claim to prove that every future Ultralytics version suppresses all telemetry.
+
+```powershell
+python .\ML_side\training\train_navigation_model.py `
+  --config .\local-training-navigation-mvp.yaml `
+  --dataset-root D:\controlled-datasets\navigation-mvp-v1 `
+  --confirm-training
+```
+
+The harmless `--epochs`, `--batch-size`, `--device`, `--workers`, and repository-relative `--output-root` overrides are recorded in the resolved plan. Existing run directories are protected unless `--allow-existing-run` and the configured resume policy permit reuse.
+
+## Artifacts and reproducibility
+
+Real runs write ignored artifacts under `ML_side/artifacts/navigation_mvp/<run-id>/`: `run_metadata.json`, `resolved_training_config.json`, `dataset_reference.json`, `training_summary.md`, and any trainer output. Metadata files are replaced atomically where supported. Metadata records checksums, the fixed taxonomy, dataset release stage/version, Git commit/dirty state, seed, parameters, package versions, Python/OS information, status, and failure summary. It deliberately omits the absolute dataset root, credentials, and environment dumps. A trainer failure is recorded as failed and leaves partial trainer output for investigation; it is never marked successful.
+
+The run ID is stable for unchanged configuration, manifest, dataset YAML, and local model file checksums. A completed run is therefore not silently overwritten.
+
+## Verification
+
+```powershell
+$env:PYTHONPATH = (Resolve-Path .\ML_side).Path
+python -m pytest .\ML_side\tests\test_train_navigation_model.py -q
+python -m pytest .\ML_side\tests -q
+python .\ML_side\training\train_navigation_model.py --help
+```
+
+Keep datasets, weight files, and generated artifacts in controlled external storage. Dataset inspection precedes this pipeline; formal evaluation of a trained candidate remains a separate later step.

--- a/ML_side/training/train_navigation_model.py
+++ b/ML_side/training/train_navigation_model.py
@@ -1,0 +1,611 @@
+"""Controlled, local-only training entry point for a WalkBuddy YOLO candidate.
+
+Dry runs never import Ultralytics or invoke a trainer.  Real training requires
+an explicit confirmation and an existing local architecture or checkpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import re
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+TOOLS_DIRECTORY = Path(__file__).resolve().parents[1] / "tools"
+if str(TOOLS_DIRECTORY) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIRECTORY))
+
+import validate_dataset_manifest as manifest_validator
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+TOOL_VERSION = "1.0.0"
+ELIGIBLE_STAGES = frozenset({"approved_for_internal_training", "released"})
+ALL_STAGES = frozenset(
+    {"candidate", "in_review", "approved_for_internal_training", "rejected", "released"}
+)
+RESUME_BEHAVIOURS = frozenset({"never", "allow", "require"})
+
+
+class TrainingPipelineError(Exception):
+    """Raised for an ordinary configuration or preflight failure."""
+
+
+@dataclass(frozen=True)
+class TrainingPlan:
+    config: dict[str, object]
+    repository_root: Path
+    dataset_root: Path
+    manifest_path: Path
+    dataset_yaml_path: Path
+    model_path: Path
+    model_kind: str
+    output_root: Path
+    run_id: str
+    run_directory: Path
+    config_checksum: str
+    manifest_checksum: str
+    dataset_yaml_checksum: str
+    model_checksum: str
+    dataset_id: str
+    dataset_source_version: str
+    manifest_release_decision: str
+    git_commit: str | None
+    git_dirty: bool | None
+
+
+def _load_yaml(path: Path, label: str) -> dict[str, object]:
+    try:
+        import yaml
+    except ImportError as exc:
+        raise TrainingPipelineError(f"{label} requires PyYAML; no dependency was installed.") from exc
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8-sig"))
+    except FileNotFoundError as exc:
+        raise TrainingPipelineError(f"{label} is missing: {path}") from exc
+    except OSError as exc:
+        raise TrainingPipelineError(f"{label} could not be read: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise TrainingPipelineError(f"{label} is not valid YAML: {path}") from exc
+    if not isinstance(data, dict):
+        raise TrainingPipelineError(f"{label} root must be an object: {path}")
+    return data
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_relative(value: object, label: str) -> str:
+    safe, reason = manifest_validator._is_safe_relative_path(value)
+    if not safe:
+        raise TrainingPipelineError(f"{label} {reason or 'must be a safe relative path.'}")
+    assert isinstance(value, str)
+    if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", value.strip()):
+        raise TrainingPipelineError(f"{label} must not be a URL or URI.")
+    return value.strip()
+
+
+def _resolve_under(root: Path, raw_path: object, label: str) -> Path:
+    relative = _safe_relative(raw_path, label)
+    resolved = manifest_validator._resolve_dataset_reference(root.resolve(), relative)
+    if resolved is None:
+        raise TrainingPipelineError(f"{label} resolves outside its controlled root.")
+    return resolved
+
+
+def _mapping(config: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = config.get(key)
+    if not isinstance(value, Mapping):
+        raise TrainingPipelineError(f"configuration field {key!r} must be an object.")
+    return value
+
+
+def _only_fields(config: Mapping[str, object], label: str, allowed: set[str]) -> None:
+    unknown = sorted(set(config) - allowed)
+    if unknown:
+        raise TrainingPipelineError(f"{label} contains unsupported field(s): {', '.join(unknown)}.")
+
+
+def _required_string(config: Mapping[str, object], key: str) -> str:
+    value = config.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise TrainingPipelineError(f"configuration field {key!r} must be a non-empty string.")
+    return value.strip()
+
+
+def _require_positive_int(value: object, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise TrainingPipelineError(f"{label} must be a positive integer.")
+    return value
+
+
+def _require_number(value: object, label: str, *, minimum: float = 0.0) -> float:
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(float(value))
+        or float(value) < minimum
+    ):
+        raise TrainingPipelineError(f"{label} must be a number greater than or equal to {minimum}.")
+    return float(value)
+
+
+def _package_versions() -> dict[str, str]:
+    versions: dict[str, str] = {}
+    for package in ("ultralytics", "torch", "PyYAML"):
+        try:
+            versions[package] = version(package)
+        except PackageNotFoundError:
+            versions[package] = "unavailable"
+    return versions
+
+
+def _git_metadata(repository_root: Path) -> tuple[str | None, bool | None]:
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repository_root, text=True, capture_output=True, timeout=5
+        )
+        status = subprocess.run(
+            ["git", "status", "--porcelain"], cwd=repository_root, text=True, capture_output=True, timeout=5
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None, None
+    if commit.returncode != 0 or status.returncode != 0:
+        return None, None
+    return commit.stdout.strip() or None, bool(status.stdout.strip())
+
+
+def _normalise_experiment_name(value: str) -> str:
+    normalised = re.sub(r"[^a-z0-9]+", "-", value.casefold()).strip("-")
+    if not normalised:
+        raise TrainingPipelineError("experiment_name must contain at least one letter or number.")
+    return normalised
+
+
+def _target_taxonomy_from_yaml(dataset_yaml: Mapping[str, object]) -> list[tuple[int, str]]:
+    names = dataset_yaml.get("names")
+    if isinstance(names, list):
+        result = list(enumerate(names))
+    elif isinstance(names, Mapping):
+        result = []
+        for raw_id, name in names.items():
+            if isinstance(raw_id, bool):
+                raise TrainingPipelineError("dataset YAML names contains a boolean class ID.")
+            try:
+                class_id = int(raw_id)
+            except (TypeError, ValueError) as exc:
+                raise TrainingPipelineError("dataset YAML names contains a non-integer class ID.") from exc
+            result.append((class_id, name))
+        result.sort(key=lambda item: item[0])
+    else:
+        raise TrainingPipelineError("dataset YAML must define names as a list or ID-to-name object.")
+    if any(not isinstance(class_id, int) or not isinstance(name, str) or not name.strip() for class_id, name in result):
+        raise TrainingPipelineError("dataset YAML names must contain non-empty string class names.")
+    return [(class_id, name.strip()) for class_id, name in result]
+
+
+def _validate_dataset_paths(dataset_root: Path, dataset_yaml: Mapping[str, object]) -> None:
+    yaml_root = _resolve_under(dataset_root, dataset_yaml.get("path", "."), "dataset YAML path")
+    if not yaml_root.is_dir():
+        raise TrainingPipelineError("dataset YAML path does not resolve to an existing local directory.")
+    for canonical, aliases in (("train", ("train",)), ("validation", ("validation", "val"))):
+        value = next((dataset_yaml[key] for key in aliases if key in dataset_yaml), None)
+        if value is None:
+            raise TrainingPipelineError(f"dataset YAML must define the {canonical} split.")
+        split_path = _resolve_under(yaml_root, value, f"dataset YAML {canonical} path")
+        if not split_path.is_dir():
+            raise TrainingPipelineError(f"dataset YAML {canonical} split directory is missing.")
+    if "test" in dataset_yaml:
+        test_path = _resolve_under(yaml_root, dataset_yaml["test"], "dataset YAML test path")
+        if not test_path.is_dir():
+            raise TrainingPipelineError("dataset YAML test split directory is missing.")
+
+
+def _split_directories(dataset_root: Path, dataset_yaml: Mapping[str, object]) -> dict[str, Path]:
+    yaml_root = _resolve_under(dataset_root, dataset_yaml.get("path", "."), "dataset YAML path")
+    directories: dict[str, Path] = {}
+    for canonical, aliases in (("train", ("train",)), ("validation", ("validation", "val")), ("test", ("test",))):
+        value = next((dataset_yaml[key] for key in aliases if key in dataset_yaml), None)
+        if value is not None:
+            directories[canonical] = _resolve_under(yaml_root, value, f"dataset YAML {canonical} path")
+    return directories
+
+
+def _validate_manifest_matches_yaml_splits(
+    manifest: Mapping[str, object], dataset_root: Path, dataset_yaml: Mapping[str, object]
+) -> None:
+    directories = _split_directories(dataset_root, dataset_yaml)
+    for split_name, _, sample in manifest_validator._iter_samples(manifest):
+        image_path = sample.get("image_path")
+        if not isinstance(image_path, str):
+            continue
+        resolved_image = manifest_validator._resolve_dataset_reference(dataset_root, image_path)
+        expected_directory = directories.get(split_name)
+        if resolved_image is None or expected_directory is None:
+            raise TrainingPipelineError("manifest and dataset YAML do not define matching controlled split paths.")
+        try:
+            resolved_image.relative_to(expected_directory)
+        except ValueError as exc:
+            raise TrainingPipelineError(
+                f"manifest sample {image_path!r} is outside the dataset YAML {split_name} split directory."
+            ) from exc
+
+
+def _manifest_eligibility(manifest: Mapping[str, object], stage: str) -> None:
+    dataset = manifest.get("dataset")
+    if not isinstance(dataset, Mapping):
+        raise TrainingPipelineError("manifest dataset metadata is missing.")
+    release_decision = dataset.get("release_decision")
+    if release_decision == "rejected":
+        raise TrainingPipelineError("manifest release decision is rejected; training is forbidden.")
+    if release_decision != "approved_for_training":
+        raise TrainingPipelineError(
+            "manifest release decision is not approved_for_training; draft, under-review, retired, and example-only datasets are ineligible."
+        )
+    if stage not in ELIGIBLE_STAGES:
+        raise TrainingPipelineError(
+            f"dataset stage {stage!r} is not eligible; only approved_for_internal_training or released may train."
+        )
+    licence = manifest.get("licence")
+    if not isinstance(licence, Mapping):
+        raise TrainingPipelineError("manifest licence review metadata is missing.")
+    if licence.get("review_decision") != "approved" or licence.get("machine_learning_use_permitted") is not True:
+        raise TrainingPipelineError("manifest licence review is not approved for machine-learning training.")
+
+
+def _inspection_evidence(dataset_root: Path, raw_path: object | None) -> None:
+    if raw_path is None:
+        return
+    report_path = _resolve_under(dataset_root, raw_path, "dataset inspection report path")
+    try:
+        report = json.loads(report_path.read_text(encoding="utf-8-sig"))
+    except FileNotFoundError as exc:
+        raise TrainingPipelineError("dataset inspection report is missing.") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TrainingPipelineError("dataset inspection report is unreadable or invalid JSON.") from exc
+    if not isinstance(report, Mapping) or report.get("quality_verdict") == "fail":
+        raise TrainingPipelineError("dataset inspection evidence has a failing quality verdict.")
+
+
+def _writable_output_root(output_root: Path) -> None:
+    existing = output_root
+    while not existing.exists() and existing.parent != existing:
+        existing = existing.parent
+    if not existing.is_dir() or not os.access(existing, os.W_OK):
+        raise TrainingPipelineError("output root parent is not writable.")
+
+
+def load_training_plan(
+    config_path: Path,
+    *,
+    dataset_root_override: Path | None = None,
+    output_root_override: str | None = None,
+    overrides: Mapping[str, object] | None = None,
+    allow_existing_run: bool = False,
+    repository_root: Path = REPOSITORY_ROOT,
+) -> TrainingPlan:
+    """Load a local configuration and complete all non-training preflight checks."""
+    repository_root = repository_root.resolve()
+    config = _load_yaml(config_path, "Training configuration")
+    _only_fields(config, "training configuration", {"schema_version", "experiment_name", "dataset", "model", "training", "output", "notes"})
+    if config.get("schema_version") != "1.0.0":
+        raise TrainingPipelineError("configuration schema_version must be '1.0.0'.")
+    if overrides:
+        training = dict(_mapping(config, "training"))
+        training.update(overrides)
+        config["training"] = training
+    experiment_name = _normalise_experiment_name(_required_string(config, "experiment_name"))
+    dataset_config = _mapping(config, "dataset")
+    model_config = _mapping(config, "model")
+    training_config = _mapping(config, "training")
+    output_config = _mapping(config, "output")
+    _only_fields(dataset_config, "dataset configuration", {"manifest_path", "yaml_path", "inspection_report_path", "stage"})
+    _only_fields(model_config, "model configuration", {"architecture_path", "initial_weights_path"})
+    _only_fields(training_config, "training configuration", {"epochs", "image_size", "batch_size", "device", "workers", "seed", "optimizer", "learning_rate", "confidence", "iou", "deterministic", "resume_behavior"})
+    _only_fields(output_config, "output configuration", {"root"})
+    stage = _required_string(dataset_config, "stage")
+    if stage not in ALL_STAGES:
+        raise TrainingPipelineError(f"dataset stage must be one of {sorted(ALL_STAGES)!r}.")
+    manifest_path = _resolve_under(repository_root, dataset_config.get("manifest_path"), "manifest path")
+    if not manifest_path.is_file():
+        raise TrainingPipelineError("manifest path does not identify an existing local file.")
+    if dataset_root_override is None:
+        raise TrainingPipelineError("an existing local --dataset-root is required for training preflight.")
+    dataset_root = dataset_root_override.resolve()
+    if not dataset_root.is_dir():
+        raise TrainingPipelineError("an existing local --dataset-root is required for training preflight.")
+    dataset_yaml_path = _resolve_under(dataset_root, dataset_config.get("yaml_path"), "dataset YAML path")
+    if not dataset_yaml_path.is_file():
+        raise TrainingPipelineError("dataset YAML path does not identify an existing local file.")
+    architecture = model_config.get("architecture_path")
+    initial_weights = model_config.get("initial_weights_path")
+    if bool(architecture) == bool(initial_weights):
+        raise TrainingPipelineError("model must specify exactly one local architecture_path or initial_weights_path.")
+    model_kind, raw_model_path = ("architecture", architecture) if architecture else ("initial_weights", initial_weights)
+    model_path = _resolve_under(repository_root, raw_model_path, f"model {model_kind} path")
+    if model_path.suffix.casefold() not in {".pt", ".yaml", ".yml"}:
+        raise TrainingPipelineError("model path must be a local .pt, .yaml, or .yml file; remote model identifiers are forbidden.")
+    if not model_path.is_file():
+        raise TrainingPipelineError("local model architecture or initial weights file is missing.")
+    output_raw = output_root_override or output_config.get("root")
+    output_root = _resolve_under(repository_root, output_raw, "output root")
+    try:
+        output_root.relative_to(dataset_root)
+    except ValueError:
+        pass
+    else:
+        raise TrainingPipelineError("output root must not be inside the supplied dataset root.")
+    _writable_output_root(output_root)
+    for key in ("epochs", "image_size", "batch_size", "workers", "seed"):
+        _require_positive_int(training_config.get(key), f"training {key}")
+    device = _required_string(training_config, "device")
+    if re.fullmatch(r"(?:cpu|auto|mps|cuda(?::[0-9]+)?|[0-9]+)", device.casefold()) is None:
+        raise TrainingPipelineError("training device must be cpu, auto, mps, cuda, cuda:<index>, or a numeric GPU index.")
+    _required_string(training_config, "optimizer")
+    _require_number(training_config.get("learning_rate"), "training learning_rate", minimum=0.0)
+    _require_number(training_config.get("confidence"), "training confidence", minimum=0.0)
+    _require_number(training_config.get("iou"), "training iou", minimum=0.0)
+    if not isinstance(training_config.get("deterministic"), bool):
+        raise TrainingPipelineError("training deterministic must be a boolean.")
+    resume_behaviour = _required_string(training_config, "resume_behavior")
+    if resume_behaviour not in RESUME_BEHAVIOURS:
+        raise TrainingPipelineError(f"training resume_behavior must be one of {sorted(RESUME_BEHAVIOURS)!r}.")
+    if not isinstance(config.get("notes"), str):
+        raise TrainingPipelineError("configuration notes must be a string.")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8-sig"))
+    except json.JSONDecodeError as exc:
+        raise TrainingPipelineError("manifest is not valid JSON.") from exc
+    if not isinstance(manifest, Mapping):
+        raise TrainingPipelineError("manifest root must be an object.")
+    manifest_issues = manifest_validator.validate_manifest(manifest, dataset_root=dataset_root, check_files=True)
+    if manifest_issues:
+        first = manifest_issues[0]
+        raise TrainingPipelineError(f"manifest validation failed: {first.location}: {first.message}")
+    _manifest_eligibility(manifest, stage)
+    manifest_dataset = manifest.get("dataset")
+    assert isinstance(manifest_dataset, Mapping)
+    dataset_yaml = _load_yaml(dataset_yaml_path, "Dataset YAML")
+    _validate_dataset_paths(dataset_root, dataset_yaml)
+    if _target_taxonomy_from_yaml(dataset_yaml) != list(manifest_validator.APPROVED_TAXONOMY):
+        raise TrainingPipelineError("dataset YAML taxonomy must exactly match the approved WalkBuddy IDs, names, and order.")
+    _validate_manifest_matches_yaml_splits(manifest, dataset_root, dataset_yaml)
+    _inspection_evidence(dataset_root, dataset_config.get("inspection_report_path"))
+    config_checksum = _sha256(config_path)
+    manifest_checksum = _sha256(manifest_path)
+    yaml_checksum = _sha256(dataset_yaml_path)
+    model_checksum = _sha256(model_path)
+    run_id = f"{experiment_name}-{hashlib.sha256((config_checksum + manifest_checksum + yaml_checksum + model_checksum).encode()).hexdigest()[:12]}"
+    run_directory = output_root / run_id
+    metadata_path = run_directory / "run_metadata.json"
+    if run_directory.exists() and not allow_existing_run:
+        raise TrainingPipelineError("run directory already exists; explicit --allow-existing-run is required.")
+    if run_directory.exists() and resume_behaviour == "never":
+        raise TrainingPipelineError("resume_behavior=never forbids an existing run directory.")
+    if not run_directory.exists() and resume_behaviour == "require":
+        raise TrainingPipelineError("resume_behavior=require needs an existing run directory.")
+    if metadata_path.exists() and not allow_existing_run:
+        raise TrainingPipelineError("existing completed or partial run metadata is protected from overwrite.")
+    commit, dirty = _git_metadata(repository_root)
+    return TrainingPlan(
+        config=config,
+        repository_root=repository_root,
+        dataset_root=dataset_root,
+        manifest_path=manifest_path,
+        dataset_yaml_path=dataset_yaml_path,
+        model_path=model_path,
+        model_kind=model_kind,
+        output_root=output_root,
+        run_id=run_id,
+        run_directory=run_directory,
+        config_checksum=config_checksum,
+        manifest_checksum=manifest_checksum,
+        dataset_yaml_checksum=yaml_checksum,
+        model_checksum=model_checksum,
+        dataset_id=str(manifest_dataset["id"]),
+        dataset_source_version=str(manifest_dataset["source_version"]),
+        manifest_release_decision=str(manifest_dataset["release_decision"]),
+        git_commit=commit,
+        git_dirty=dirty,
+    )
+
+
+def _sanitised_plan(plan: TrainingPlan) -> dict[str, object]:
+    data = asdict(plan)
+    for key in ("repository_root", "dataset_root", "manifest_path", "dataset_yaml_path", "model_path", "output_root", "run_directory"):
+        data.pop(key, None)
+    data["manifest_path"] = plan.manifest_path.relative_to(plan.repository_root).as_posix()
+    data["model_path"] = plan.model_path.relative_to(plan.repository_root).as_posix()
+    data["output_location"] = plan.run_directory.relative_to(plan.repository_root).as_posix()
+    data["dataset_yaml_path"] = _safe_relative(plan.config["dataset"]["yaml_path"], "dataset YAML path")  # type: ignore[index]
+    data["dataset_root"] = "externally supplied local root"
+    return data
+
+
+def trainer_arguments(plan: TrainingPlan) -> dict[str, object]:
+    training = _mapping(plan.config, "training")
+    return {
+        "data": str(plan.dataset_yaml_path),
+        "epochs": training["epochs"],
+        "imgsz": training["image_size"],
+        "batch": training["batch_size"],
+        "device": training["device"],
+        "workers": training["workers"],
+        "seed": training["seed"],
+        "optimizer": training["optimizer"],
+        "lr0": training["learning_rate"],
+        "conf": training["confidence"],
+        "iou": training["iou"],
+        "deterministic": training["deterministic"],
+        "resume": _required_string(training, "resume_behavior") == "require",
+        "project": str(plan.output_root),
+        "name": plan.run_id,
+        "exist_ok": True,
+        "cache": False,
+    }
+
+
+def _metadata_trainer_arguments(plan: TrainingPlan) -> dict[str, object]:
+    arguments = trainer_arguments(plan)
+    arguments["data"] = _safe_relative(plan.config["dataset"]["yaml_path"], "dataset YAML path")  # type: ignore[index]
+    arguments["project"] = plan.output_root.relative_to(plan.repository_root).as_posix()
+    return arguments
+
+
+def dry_run(plan: TrainingPlan) -> dict[str, object]:
+    """Return a sanitised plan without creating artifacts or importing a trainer."""
+    return {"status": "dry_run_valid", "plan": _sanitised_plan(plan)}
+
+
+def _run_metadata(plan: TrainingPlan, status: str, *, started_at: str, completed_at: str | None = None, failure: str | None = None) -> dict[str, object]:
+    dataset = _mapping(plan.config, "dataset")
+    return {
+        "tool": {"name": "train_navigation_model", "version": TOOL_VERSION},
+        "run_id": plan.run_id,
+        "status": status,
+        "started_at_utc": started_at,
+        "completed_at_utc": completed_at,
+        "git_commit": plan.git_commit,
+        "git_dirty": plan.git_dirty,
+        "configuration_checksum_sha256": plan.config_checksum,
+        "manifest_checksum_sha256": plan.manifest_checksum,
+        "dataset_yaml_checksum_sha256": plan.dataset_yaml_checksum,
+        "model_checksum_sha256": plan.model_checksum,
+        "model_kind": plan.model_kind,
+        "dataset_release": {
+            "id": plan.dataset_id,
+            "source_version": plan.dataset_source_version,
+            "manifest_release_decision": plan.manifest_release_decision,
+            "stage": dataset["stage"],
+        },
+        "approved_taxonomy": [{"id": class_id, "name": name} for class_id, name in manifest_validator.APPROVED_TAXONOMY],
+        "python_version": platform.python_version(),
+        "package_versions": _package_versions(),
+        "operating_system": platform.platform(),
+        "random_seed": _mapping(plan.config, "training")["seed"],
+        "resolved_parameters": _metadata_trainer_arguments(plan),
+        "output_location": plan.run_directory.relative_to(plan.repository_root).as_posix(),
+        "failure_summary": failure,
+    }
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as temporary:
+        temporary.write(content)
+        temporary_path = Path(temporary.name)
+    temporary_path.replace(path)
+
+
+def _write_run_files(plan: TrainingPlan, metadata: Mapping[str, object]) -> None:
+    plan.run_directory.mkdir(parents=True, exist_ok=True)
+    _atomic_write(plan.run_directory / "run_metadata.json", json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+    _atomic_write(plan.run_directory / "resolved_training_config.json", json.dumps(plan.config, indent=2, sort_keys=True) + "\n")
+    _atomic_write(plan.run_directory / "dataset_reference.json",
+        json.dumps(
+            {
+                "manifest_path": plan.manifest_path.relative_to(plan.repository_root).as_posix(),
+                "manifest_checksum_sha256": plan.manifest_checksum,
+                "dataset_id": plan.dataset_id,
+                "dataset_source_version": plan.dataset_source_version,
+                "manifest_release_decision": plan.manifest_release_decision,
+                "dataset_yaml_path": _safe_relative(plan.config["dataset"]["yaml_path"], "dataset YAML path"),  # type: ignore[index]
+                "dataset_yaml_checksum_sha256": plan.dataset_yaml_checksum,
+                "dataset_root": "externally supplied local root",
+            }, indent=2, sort_keys=True
+        ) + "\n",
+    )
+    _atomic_write(plan.run_directory / "training_summary.md",
+        f"# Navigation model training run\n\nRun ID: `{plan.run_id}`\n\nStatus: `{metadata['status']}`\n",
+    )
+
+
+def default_trainer(plan: TrainingPlan) -> object:
+    """Invoke Ultralytics only for explicitly confirmed real training."""
+    os.environ.setdefault("YOLO_OFFLINE", "true")
+    os.environ.setdefault("WANDB_MODE", "disabled")
+    try:
+        from ultralytics import YOLO
+    except ImportError as exc:
+        raise TrainingPipelineError("Ultralytics is unavailable; real training cannot start.") from exc
+    model = YOLO(str(plan.model_path))
+    return model.train(**trainer_arguments(plan))
+
+
+def run_training(plan: TrainingPlan, trainer: Callable[[TrainingPlan], object] | None = None) -> object:
+    """Write reproducibility metadata and invoke an injected or real trainer."""
+    started = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    running = _run_metadata(plan, "running", started_at=started)
+    _write_run_files(plan, running)
+    try:
+        result = (trainer or default_trainer)(plan)
+    except Exception as exc:
+        completed = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        failed = _run_metadata(plan, "failed", started_at=started, completed_at=completed, failure=f"{type(exc).__name__}: {exc}")
+        _write_run_files(plan, failed)
+        raise TrainingPipelineError(f"training failed: {type(exc).__name__}: {exc}") from exc
+    completed = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    succeeded = _run_metadata(plan, "succeeded", started_at=started, completed_at=completed)
+    _write_run_files(plan, succeeded)
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Controlled local-only WalkBuddy navigation-model training.")
+    parser.add_argument("--config", required=True, type=Path, help="Versioned training configuration YAML.")
+    parser.add_argument("--dataset-root", type=Path, help="Existing controlled local dataset root.")
+    parser.add_argument("--output-root", help="Safe repository-relative artifact root override.")
+    parser.add_argument("--epochs", type=int, help="Harmless epoch-count override recorded in metadata.")
+    parser.add_argument("--batch-size", type=int, help="Harmless batch-size override recorded in metadata.")
+    parser.add_argument("--device", help="Device override recorded in metadata.")
+    parser.add_argument("--workers", type=int, help="Worker-count override recorded in metadata.")
+    parser.add_argument("--dry-run", action="store_true", help="Validate and print the plan without writing artifacts or invoking a trainer.")
+    parser.add_argument("--confirm-training", action="store_true", help="Explicitly allow a real local trainer invocation.")
+    parser.add_argument("--allow-existing-run", action="store_true", help="Allow the configured resume policy to use an existing run directory.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    overrides = {key: value for key, value in {"epochs": args.epochs, "batch_size": args.batch_size, "device": args.device, "workers": args.workers}.items() if value is not None}
+    try:
+        if args.dry_run and args.confirm_training:
+            raise TrainingPipelineError("--dry-run and --confirm-training cannot be used together.")
+        plan = load_training_plan(
+            args.config,
+            dataset_root_override=args.dataset_root,
+            output_root_override=args.output_root,
+            overrides=overrides,
+            allow_existing_run=args.allow_existing_run,
+            repository_root=REPOSITORY_ROOT,
+        )
+        if args.dry_run:
+            print(json.dumps(dry_run(plan), indent=2, sort_keys=True))
+            return 0
+        if not args.confirm_training:
+            raise TrainingPipelineError("real training requires --confirm-training; use --dry-run for preflight only.")
+        run_training(plan)
+    except TrainingPipelineError as exc:
+        print(f"Navigation training preflight failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Navigation training completed: {plan.run_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2><p>Adds a reproducible, local-only training foundation for future WalkBuddy navigation-model experiments.</p><p>The pipeline performs controlled preflight validation, requires explicitly approved dataset metadata, prevents implicit dataset or model downloads, supports safe dry runs, and records reproducibility information for confirmed training runs.</p><p>No real model training was performed as part of this pull request.</p><h2>Changes</h2><ul><li><p>adds <code inline="">ML_side/config/training_navigation_mvp.yaml</code>;</p></li><li><p>adds <code inline="">ML_side/training/train_navigation_model.py</code>;</p></li><li><p>adds training documentation in <code inline="">ML_side/training/README.md</code>;</p></li><li><p>adds comprehensive tests in <code inline="">ML_side/tests/test_train_navigation_model.py</code>;</p></li><li><p>narrowly ignores generated <code inline="">ML_side/artifacts/</code> output;</p></li><li><p>reuses the existing dataset-manifest validator and approved WalkBuddy taxonomy;</p></li><li><p>validates manifest, dataset YAML, licence-review and training-stage eligibility;</p></li><li><p>requires local model architecture or initial-weight files;</p></li><li><p>supports full validation through <code inline="">--dry-run</code>;</p></li><li><p>requires explicit <code inline="">--confirm-training</code> before trainer invocation;</p></li><li><p>records reproducibility metadata for real runs;</p></li><li><p>preserves failed-run metadata and partial output for diagnosis.</p></li></ul><h2>Approved taxonomy</h2>
ID | Class
-- | --
0 | person
1 | stairs
2 | door
3 | chair
4 | table
5 | pole
6 | bicycle
7 | vehicle

<h2>Training eligibility</h2><p>Real training is permitted only when all preflight requirements pass.</p><p>Accepted manifest release:</p><pre><code class="language-text">approved_for_training
</code></pre><p>Accepted manifest licence review:</p><pre><code class="language-text">review_decision: approved
machine_learning_use_permitted: true
</code></pre><p>Accepted training configuration stages:</p><pre><code class="language-text">approved_for_internal_training
released
</code></pre><p>Rejected manifest releases include:</p><pre><code class="language-text">draft
under_review
rejected
retired
example_only
</code></pre><p>Rejected configuration stages include:</p><pre><code class="language-text">candidate
in_review
rejected
</code></pre><p>Structural validity alone does not establish legal, privacy, ethical or production approval.</p><h2>Dry-run behaviour</h2><p>A dry run:</p><ul><li><p>validates the training configuration;</p></li><li><p>validates the dataset manifest;</p></li><li><p>checks taxonomy and dataset-YAML agreement;</p></li><li><p>verifies dataset eligibility;</p></li><li><p>resolves and checks controlled local paths;</p></li><li><p>verifies the local architecture or weight file;</p></li><li><p>displays the resolved training plan;</p></li><li><p>does not import Ultralytics;</p></li><li><p>does not load a model;</p></li><li><p>does not invoke a trainer;</p></li><li><p>does not create run artifacts;</p></li><li><p>performs no network access.</p></li></ul><p><code inline="">--dry-run</code> and <code inline="">--confirm-training</code> cannot be supplied together.</p><h2>Network and model safety</h2><p>The pipeline:</p><ul><li><p>rejects HTTP, HTTPS and other remote URLs;</p></li><li><p>rejects URI-based model sources;</p></li><li><p>rejects remote-resolvable model identifiers;</p></li><li><p>requires an existing local <code inline="">.pt</code>, <code inline="">.yaml</code> or <code inline="">.yml</code> model file;</p></li><li><p>rejects traversal and unsafe absolute configuration paths;</p></li><li><p>performs no dataset or model downloads;</p></li><li><p>performs no package installation;</p></li><li><p>imports Ultralytics only after explicit real-training confirmation;</p></li><li><p>sets offline and disabled telemetry defaults before that import.</p></li></ul><p>The pipeline cannot guarantee the future behaviour of third-party telemetry implementations, but it does not intentionally initiate network access.</p><h2>Reproducibility metadata</h2><p>Confirmed real runs record:</p><ul><li><p>run identifier;</p></li><li><p>UTC timestamps;</p></li><li><p>run status;</p></li><li><p>Git commit;</p></li><li><p>dirty working-tree state;</p></li><li><p>configuration checksum;</p></li><li><p>manifest checksum;</p></li><li><p>dataset-YAML checksum;</p></li><li><p>architecture or initial-weight checksum;</p></li><li><p>dataset version and release information;</p></li><li><p>approved taxonomy;</p></li><li><p>Python and relevant package versions;</p></li><li><p>operating-system information;</p></li><li><p>random seed;</p></li><li><p>sanitised trainer arguments;</p></li><li><p>training failure information where applicable.</p></li></ul><p>Metadata excludes:</p><ul><li><p>credentials and tokens;</p></li><li><p>complete environment-variable dumps;</p></li><li><p>unnecessary absolute dataset paths;</p></li><li><p>private dataset contents;</p></li><li><p>personal information.</p></li></ul><h2>Output safety</h2><p>Generated run output is written beneath:</p><pre><code class="language-text">ML_side/artifacts/
</code></pre><p>The pipeline:</p><ul><li><p>prevents artifact output beneath the supplied dataset root;</p></li><li><p>protects existing completed runs;</p></li><li><p>writes metadata and reports atomically where supported;</p></li><li><p>records success only after trainer completion;</p></li><li><p>preserves failed-run information for diagnosis;</p></li><li><p>does not commit model weights or generated run output.</p></li></ul><h2>Verification</h2><ul><li><p>focused training-pipeline tests: <strong>37 passed</strong>;</p></li><li><p>complete ML-side test suite: <strong>144 passed</strong>;</p></li><li><p>Python syntax compilation passed;</p></li><li><p>CLI help passed;</p></li><li><p>valid fictional dry-run passed;</p></li><li><p>invalid eligibility and path cases passed;</p></li><li><p>missing confirmation correctly blocked training;</p></li><li><p>mocked successful training passed;</p></li><li><p>mocked failed training passed;</p></li><li><p>generated artifact ignore rule verified;</p></li><li><p><code inline="">git diff --check</code> passed.</p></li></ul><p>The complete ML suite was run with:</p><pre><code class="language-powershell">$env:PYTHONPATH = (Resolve-Path ML_side).Path
python -m pytest ML_side\tests -q
</code></pre><h2>Scope boundaries</h2><p>This pull request does not:</p><ul><li><p>train a real model;</p></li><li><p>download datasets;</p></li><li><p>download model weights;</p></li><li><p>add raw images or labels;</p></li><li><p>modify the existing <code inline="">best.pt</code>;</p></li><li><p>change production-backend behaviour;</p></li><li><p>modify frontend functionality;</p></li><li><p>install packages;</p></li><li><p>claim model accuracy, safety or production readiness.</p></li></ul><h2>Remaining limitation</h2><p>Real Ultralytics training and third-party offline or telemetry behaviour were intentionally not runtime-tested. The real training path should be smoke-tested later using an approved local dataset release, local model configuration and controlled environment.</p><h2>Follow-up</h2><ul><li><p>inspect and approve a real candidate dataset;</p></li><li><p>generate its validated candidate manifest;</p></li><li><p>promote it to <code inline="">approved_for_training</code>;</p></li><li><p>run the training pipeline dry run;</p></li><li><p>perform a small controlled real-training smoke test;</p></li><li><p>train the first navigation candidate;</p></li><li><p>evaluate it against the inherited baseline;</p></li><li><p>integrate only after formal review.</p></li></ul></body></html><!--EndFragment-->
</body>
</html>