### PR TITLE
Add controlled navigation dataset release builder

### DIFF
--- a/ML_side/config/dataset_release.example.json
+++ b/ML_side/config/dataset_release.example.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "1.0.0",
+  "source_taxonomy": [
+    { "id": 0, "name": "fictional-pedestrian" },
+    { "id": 1, "name": "fictional-ceiling" }
+  ],
+  "class_mapping": [
+    {
+      "source_class_id": 0,
+      "target_class_id": 0,
+      "target_class_name": "person",
+      "mapping_rationale": "Fictional reviewed semantic-equivalence example only."
+    }
+  ],
+  "excluded_source_classes": [
+    {
+      "source_class_id": 1,
+      "reason": "Fictional example class outside the approved WalkBuddy taxonomy."
+    }
+  ],
+  "unmapped_source_classes": [],
+  "empty_image_policy": "retain_negative",
+  "release_metadata": {
+    "dataset": {
+      "id": "example-navigation-release",
+      "name": "Fictional canonical navigation release example",
+      "source_version": "fictional-release-v1",
+      "description": "Fictional metadata-only release-builder configuration.",
+      "release_date": "2026-08-05"
+    },
+    "source_provenance": {
+      "source_reference": "example://walkbuddy/fictional-source",
+      "accessed_on": "2026-08-05",
+      "original_source": "Fictional source for documentation and tests only.",
+      "publisher": "Example dataset steward"
+    },
+    "licence": {
+      "name": "Fictional example licence",
+      "evidence_reference": "example://walkbuddy/fictional-licence",
+      "machine_learning_use_permitted": true,
+      "modification_permitted": true,
+      "redistribution_permitted": false,
+      "attribution_required": true,
+      "attribution_requirements": "Fictional attribution instruction.",
+      "restrictions": "Example only.",
+      "reviewer": "Example reviewer",
+      "review_date": "2026-08-05",
+      "review_decision": "approved"
+    },
+    "storage_release": {
+      "authoritative_storage_reference": "example://walkbuddy/controlled-fictional-release",
+      "git_safe_metadata_only": true,
+      "release_version": "overwritten-by-cli"
+    },
+    "quality_review_status": "not_reviewed",
+    "known_limitations": [
+      "This is fictional mapping metadata and does not approve a dataset or release."
+    ]
+  }
+}

--- a/ML_side/datasets/README.md
+++ b/ML_side/datasets/README.md
@@ -156,4 +156,48 @@ python .\ML_side\tools\inspect_candidate_dataset.py `
   --generate-manifest
 ```
 
-The reports are `dataset_quality_report.json` and `dataset_quality_report.md`; apart from isolated execution-time metadata, their ordering is deterministic for unchanged input. Keep raw images, labels, review evidence, and generated reports in controlled external storage rather than Git. After appropriate independent review, the resulting candidate manifest can feed a future controlled training workflow; this tool itself does not perform training or select a model.
+The reports are `dataset_quality_report.json` and `dataset_quality_report.md`; apart from isolated execution-time metadata, their ordering is deterministic for unchanged input. They record both `dataset_identity` and `dataset_source_version` when reviewed metadata is supplied. Reports generated before that source-version field was added must be regenerated before they can be used by the release builder. Keep raw images, labels, review evidence, and generated reports in controlled external storage rather than Git. After appropriate independent review, the resulting candidate manifest can feed a future controlled training workflow; this tool itself does not perform training or select a model.
+
+## Build a controlled canonical release
+
+`../tools/build_navigation_dataset_release.py` is the controlled bridge from an inspected local YOLO candidate to a copied, versioned WalkBuddy release. It uses the exact approved taxonomy above, rewrites only included label class IDs, and never infers semantic equivalence from source class names. It reads the source dataset, source manifest, inspection report, and reviewed mapping configuration without changing them; the release output must be a controlled external directory, outside both the source root and this Git repository.
+
+Start from [`../config/dataset_release.example.json`](../config/dataset_release.example.json). It is fictional metadata, not a real mapping or approval. Its `source_taxonomy` must exactly match the source YOLO YAML, including class ID, spelling, case, and order. Every source class must have exactly one explicit decision: a mapping to the matching approved ID/name pair, an excluded decision with a reason, or an unresolved decision. Unresolved classes block release creation. Unknown fields, duplicate class decisions, unknown source IDs, and targets outside the approved eight classes are rejected.
+
+An excluded annotation is deliberately removed and counted. `empty_image_policy: retain_negative` retains images that become empty after exclusion with an empty YOLO label file; `exclude_image` omits those images and labels together. Images that were already empty negative samples are retained in their original split under either policy and are reported separately from exclusion-created negatives. Release name and version must be safe single path components containing only letters, numbers, dots, underscores, and hyphens.
+
+The source manifest must pass file checks, record an approved licence review that permits machine-learning use, and identify the same case-sensitive dataset ID, exact source version, and exact source taxonomy recorded by the passing inspector report. The builder rejects cross-split duplicate-image or explicit group-leakage findings, unsafe paths, symlink escapes, missing files, source-YAML/mapping taxonomy mismatch, same-stem image collisions, and an output location that overlaps the source. A structurally completed release is not legal, privacy, ethical, model-quality, safety, production, or training approval. Its generated manifest defaults to `under_review`; `approved_for_training` is accepted only when explicitly supplied metadata also records an approved ML-permitted licence review and completed quality review.
+
+Always begin with a dry run. It validates every input, plans deterministic filenames and label rows, calculates class/exclusion/split counts and checksums, and writes nothing:
+
+```powershell
+python .\ML_side\tools\build_navigation_dataset_release.py `
+  --source-root D:\controlled-datasets\candidate-navigation-v1 `
+  --source-yaml D:\controlled-datasets\candidate-navigation-v1\dataset.yaml `
+  --source-manifest D:\controlled-reports\candidate-navigation-v1\candidate_manifest.json `
+  --inspection-report D:\controlled-reports\candidate-navigation-v1\dataset_quality_report.json `
+  --mapping-config D:\controlled-review\navigation-release-mapping.json `
+  --output-root D:\controlled-datasets\releases `
+  --release-name navigation-mvp-v1 `
+  --release-version v1 `
+  --dry-run
+```
+
+On macOS or Linux, use the same local-only inputs with forward slashes and `python ML_side/tools/build_navigation_dataset_release.py`. A real copy is blocked unless `--confirm-build` is supplied; `--dry-run` and `--confirm-build` cannot be combined.
+
+```powershell
+python .\ML_side\tools\build_navigation_dataset_release.py `
+  --source-root D:\controlled-datasets\candidate-navigation-v1 `
+  --source-yaml D:\controlled-datasets\candidate-navigation-v1\dataset.yaml `
+  --source-manifest D:\controlled-reports\candidate-navigation-v1\candidate_manifest.json `
+  --inspection-report D:\controlled-reports\candidate-navigation-v1\dataset_quality_report.json `
+  --mapping-config D:\controlled-review\navigation-release-mapping.json `
+  --output-root D:\controlled-datasets\releases `
+  --release-name navigation-mvp-v1 `
+  --release-version v1 `
+  --confirm-build
+```
+
+The completed release has `images/train`, `images/val`, optional `images/test`, matching `labels` directories, a release-relative `dataset.yaml`, `release_manifest.json`, `release_build_report.json`, `release_build_report.md`, and `release_checksums.json`. Files are copied through a temporary sibling staging directory and promoted only after manifest, label, checksum, and inspector verification pass. A failed build removes that staging directory where possible and never treats it as a completed release. The JSON and Markdown reports derive from the same canonical counts and record source/released samples, mapped/excluded annotations, negatives, eligibility verification, and input/output SHA-256 checksums. `release_checksums.json` lists the substantive copied images, rewritten labels, YAML, and manifest; it intentionally does not checksum itself or the reports, avoiding recursive checksum churn. The deterministic release identity derives from the reviewed inputs, destination plan, and output label content; Git state is recorded separately and does not alter that identity. Keep releases, images, labels, reports, and any weights in controlled external storage rather than Git.
+
+After an independent reviewer explicitly promotes the generated manifest to the eligible decision, the release can be used as the local `--dataset-root` for [`../training/train_navigation_model.py`](../training/train_navigation_model.py) dry-run. Training remains a separate controlled operation; this builder neither trains a model nor establishes that the dataset is fit for one.

--- a/ML_side/tests/test_build_navigation_dataset_release.py
+++ b/ML_side/tests/test_build_navigation_dataset_release.py
@@ -1,0 +1,569 @@
+"""Temporary-fixture tests for controlled canonical YOLO release construction."""
+
+from __future__ import annotations
+
+import base64
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ML_SIDE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ML_SIDE_DIR / "tools"))
+sys.path.insert(0, str(ML_SIDE_DIR / "training"))
+
+import build_navigation_dataset_release as builder
+import inspect_candidate_dataset as inspector
+import train_navigation_model as training
+import validate_dataset_manifest as manifest_validator
+
+
+IMAGE_BYTES = base64.b64decode("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==")
+TARGETS = list(manifest_validator.APPROVED_TAXONOMY)
+
+
+def write_json(path: Path, value: object) -> Path:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def source_manifest(samples: dict[str, list[dict[str, object]]]) -> dict[str, object]:
+    return {
+        "schema_version": "1.0.0",
+        "dataset": {"id": "fictional-source", "name": "Fictional source", "source_version": "fictional-v1", "description": "Temporary fixture only.", "release_date": "2026-08-05", "release_decision": "under_review"},
+        "source_provenance": {"source_reference": "example://fictional/source", "accessed_on": "2026-08-05", "original_source": "Temporary fixture.", "publisher": "Test publisher"},
+        "licence": {"name": "Fictional licence", "evidence_reference": "example://fictional/licence", "machine_learning_use_permitted": True, "modification_permitted": True, "redistribution_permitted": False, "attribution_required": True, "attribution_requirements": "Test only.", "restrictions": "Temporary fixture.", "reviewer": "Test reviewer", "review_date": "2026-08-05", "review_decision": "approved"},
+        "taxonomy": {"target_classes": [{"id": class_id, "name": name} for class_id, name in TARGETS], "class_mappings": [{"source_class": "fictional-person", "target_class_id": 0, "target_class_name": "person", "mapping_rationale": "Fixture mapping.", "review_decision": "mapped"}], "excluded_source_classes": [{"source_class": "fictional-ceiling", "reason": "Fixture exclusion."}], "unmapped_source_classes": [], "bounding_box_coordinate_format": "normalized_xywh"},
+        "splits": {split: {"samples": samples.get(split, [])} for split in ("train", "validation", "test")},
+        "quality": {"image_count": sum(len(items) for items in samples.values()), "annotation_count": sum(item["annotation_summary"]["bounding_box_count"] for items in samples.values() for item in items), "duplicate_count": 0, "corrupt_file_count": 0, "invalid_annotation_count": 0, "excluded_sample_count": 0, "quality_review_status": "completed", "known_limitations": ["Fictional temporary fixture."]},
+        "storage_release": {"authoritative_storage_reference": "example://fictional/storage", "git_safe_metadata_only": True, "release_version": "fictional-v1"},
+    }
+
+
+def mapping_config(*, policy: str = "retain_negative") -> dict[str, object]:
+    return {
+        "schema_version": "1.0.0", "source_taxonomy": [{"id": 0, "name": "fictional-person"}, {"id": 1, "name": "fictional-ceiling"}],
+        "class_mapping": [{"source_class_id": 0, "target_class_id": 0, "target_class_name": "person", "mapping_rationale": "Explicit fixture decision."}],
+        "excluded_source_classes": [{"source_class_id": 1, "reason": "Outside fixture target taxonomy."}], "unmapped_source_classes": [], "empty_image_policy": policy,
+        "release_metadata": {
+            "dataset": {"id": "fictional-release", "name": "Fictional canonical release", "source_version": "fictional-release-v1", "description": "Temporary fixture release only.", "release_date": "2026-08-05"},
+            "source_provenance": {"source_reference": "example://fictional/source", "accessed_on": "2026-08-05", "original_source": "Temporary fixture.", "publisher": "Test publisher"},
+            "licence": {"name": "Fictional licence", "evidence_reference": "example://fictional/licence", "machine_learning_use_permitted": True, "modification_permitted": True, "redistribution_permitted": False, "attribution_required": True, "attribution_requirements": "Test only.", "restrictions": "Temporary fixture.", "reviewer": "Test reviewer", "review_date": "2026-08-05", "review_decision": "approved"},
+            "storage_release": {"authoritative_storage_reference": "example://fictional/release", "git_safe_metadata_only": True, "release_version": "overwritten"}, "quality_review_status": "not_reviewed", "known_limitations": ["Fictional test-only release."],
+        },
+    }
+
+
+def fixture(tmp_path: Path, *, policy: str = "retain_negative", include_test: bool = False) -> dict[str, Path]:
+    source_root = tmp_path / "source"
+    source_root.mkdir(parents=True)
+    records: dict[str, list[dict[str, object]]] = {"train": [], "validation": [], "test": []}
+    examples = [("train", "mapped.png", "0 0.5 0.5 0.2 0.2\n1 0.5 0.5 0.2 0.2\n"), ("train", "excluded.png", "1 0.5 0.5 0.2 0.2\n"), ("validation", "validation.png", "0 0.5 0.5 0.2 0.2\n")]
+    if include_test:
+        examples.append(("test", "test.png", "0 0.5 0.5 0.2 0.2\n"))
+    for index, (split, image_name, label) in enumerate(examples, start=1):
+        image = source_root / split / "images" / image_name
+        label_path = source_root / split / "labels" / Path(image_name).with_suffix(".txt")
+        image.parent.mkdir(parents=True, exist_ok=True)
+        label_path.parent.mkdir(parents=True, exist_ok=True)
+        image.write_bytes(IMAGE_BYTES + image_name.encode("utf-8"))
+        label_path.write_text(label, encoding="utf-8")
+        records[split].append({"sample_id": f"fixture-{split}-{index}", "image_path": image.relative_to(source_root).as_posix(), "label_path": label_path.relative_to(source_root).as_posix(), "group_id": f"fixture-group-{split}-{index}", "labelled": True, "annotation_summary": {"bounding_box_count": len([line for line in label.splitlines() if line]), "class_ids": [int(line.split()[0]) for line in label.splitlines() if line]}})
+    source_yaml = source_root / "dataset.yaml"
+    source_yaml.write_text("path: .\ntrain: train/images\nval: validation/images\n" + ("test: test/images\n" if include_test else "") + "names:\n  0: fictional-person\n  1: fictional-ceiling\n", encoding="utf-8")
+    manifest_path = write_json(tmp_path / "source_manifest.json", source_manifest(records))
+    report_path = write_json(tmp_path / "inspection.json", {"dataset_identity": "fictional-source", "dataset_source_version": "fictional-v1", "source_taxonomy": [{"id": 0, "name": "fictional-person"}, {"id": 1, "name": "fictional-ceiling"}], "quality_verdict": "pass", "validation_errors": [], "duplicates": {"cross_split_duplicate_images": [], "cross_split_group_leakage": []}})
+    mapping_path = write_json(tmp_path / "mapping.json", mapping_config(policy=policy))
+    return {"source": source_root, "yaml": source_yaml, "manifest": manifest_path, "report": report_path, "mapping": mapping_path, "output": tmp_path / "releases"}
+
+
+def plan(paths: dict[str, Path], **kwargs: object) -> builder.ReleasePlan:
+    return builder.create_release_plan(source_root=paths["source"], source_yaml_path=paths["yaml"], source_manifest_path=paths["manifest"], inspection_report_path=paths["report"], mapping_path=paths["mapping"], output_root=paths["output"], release_name="fictional-release", release_version="v1", **kwargs)
+
+
+def test_valid_dry_run_succeeds_and_creates_no_output(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    result = builder.dry_run(plan(paths))
+
+    assert result["status"] == "planned"
+    assert not paths["output"].exists()
+    assert "dataset.yaml" in result["intended_output_files"]  # type: ignore[operator]
+
+
+def test_confirmed_build_rewrites_to_exact_canonical_ids_and_keeps_source_unchanged(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    source_hash = builder._sha256(paths["source"] / "train" / "labels" / "mapped.txt")
+    source_image_hash = builder._sha256(paths["source"] / "train" / "images" / "mapped.png")
+    result = builder.build_release(plan(paths), confirm_build=True)
+    release = paths["output"] / "fictional-release" / "v1"
+
+    assert result["status"] == "completed"
+    assert (release / "labels/train/mapped.txt").read_text(encoding="utf-8") == "0 0.5 0.5 0.2 0.2\n"
+    assert builder._sha256(paths["source"] / "train" / "labels" / "mapped.txt") == source_hash
+    assert builder._sha256(paths["source"] / "train" / "images" / "mapped.png") == source_image_hash
+    generated = json.loads((release / "release_manifest.json").read_text(encoding="utf-8"))
+    assert generated["taxonomy"]["target_classes"] == [{"id": class_id, "name": name} for class_id, name in TARGETS]
+    assert generated["dataset"]["release_decision"] == "under_review"
+
+
+def test_excluded_annotations_and_retained_negative_policy_are_reported(tmp_path: Path) -> None:
+    paths = fixture(tmp_path, policy="retain_negative")
+    report = builder.build_release(plan(paths), confirm_build=True)
+    release = paths["output"] / "fictional-release" / "v1"
+
+    assert (release / "labels/train/excluded.txt").read_text(encoding="utf-8") == ""
+    assert report["counts"]["retained_negative_images"] == 1  # type: ignore[index]
+    assert report["counts"]["exclusion_created_negative_images"] == 1  # type: ignore[index]
+    assert report["counts"]["source_empty_negative_images"] == 0  # type: ignore[index]
+    assert report["counts"]["excluded_annotations_by_source_class"] == [{"id": 1, "name": "fictional-ceiling", "count": 2}]  # type: ignore[index]
+
+
+def test_exclude_empty_image_policy_removes_images_and_labels(tmp_path: Path) -> None:
+    paths = fixture(tmp_path, policy="exclude_image")
+    release_plan = plan(paths)
+
+    assert {sample.sample_id for sample in release_plan.samples} == {"fixture-train-1", "fixture-validation-3"}
+    builder.build_release(release_plan, confirm_build=True)
+    release = paths["output"] / "fictional-release" / "v1"
+    assert not (release / "images/train/excluded.png").exists()
+    assert json.loads((release / "release_manifest.json").read_text(encoding="utf-8"))["quality"]["excluded_sample_count"] == 1
+
+
+def test_original_empty_negative_is_retained_separately_from_exclusion_created_negative(tmp_path: Path) -> None:
+    paths = fixture(tmp_path, policy="exclude_image")
+    (paths["source"] / "validation/labels/validation.txt").write_text("\n", encoding="utf-8")
+
+    report = builder.build_release(plan(paths), confirm_build=True)
+    release = paths["output"] / "fictional-release" / "v1"
+
+    assert (release / "images/val/validation.png").is_file()
+    assert (release / "labels/val/validation.txt").read_text(encoding="utf-8") == ""
+    assert report["counts"]["source_empty_negative_images"] == 1  # type: ignore[index]
+    assert report["counts"]["exclusion_created_negative_images"] == 0  # type: ignore[index]
+
+
+@pytest.mark.parametrize("change, expected", [
+    (lambda mapping: mapping["unmapped_source_classes"].append({"source_class_id": 1, "reason": "Needs review."}), "duplicate or ambiguous"),
+    (lambda mapping: mapping["class_mapping"].append({"source_class_id": 1, "target_class_id": 99, "target_class_name": "unknown", "mapping_rationale": "Bad."}), "approved target"),
+    (lambda mapping: mapping["class_mapping"].append({"source_class_id": 0, "target_class_id": 0, "target_class_name": "person", "mapping_rationale": "Duplicate."}), "duplicate or ambiguous"),
+])
+def test_unresolved_unknown_target_and_duplicate_source_decisions_fail(tmp_path: Path, change: object, expected: str) -> None:
+    paths = fixture(tmp_path)
+    mapping = json.loads(paths["mapping"].read_text(encoding="utf-8"))
+    change(mapping)  # type: ignore[operator]
+    write_json(paths["mapping"], mapping)
+
+    with pytest.raises(builder.DatasetReleaseError, match=expected):
+        plan(paths)
+
+
+def test_unknown_source_annotation_and_malformed_label_fail(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    label = paths["source"] / "train" / "labels" / "mapped.txt"
+    label.write_text("2 0.5 0.5 0.2 0.2\n", encoding="utf-8")
+    with pytest.raises(builder.DatasetReleaseError, match="unknown source"):
+        plan(paths)
+    label.write_text("0 0.5 0.5 0.2\n", encoding="utf-8")
+    with pytest.raises(builder.DatasetReleaseError, match="five YOLO fields"):
+        plan(paths)
+
+
+def test_invalid_manifest_unapproved_licence_and_failing_inspection_block(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    manifest = json.loads(paths["manifest"].read_text(encoding="utf-8"))
+    manifest["licence"]["review_decision"] = "conditional"
+    write_json(paths["manifest"], manifest)
+    with pytest.raises(builder.DatasetReleaseError, match="approved licence"):
+        plan(paths)
+    manifest["licence"]["review_decision"] = "approved"
+    manifest["dataset"].pop("name")
+    write_json(paths["manifest"], manifest)
+    with pytest.raises(builder.DatasetReleaseError, match="source manifest is invalid"):
+        plan(paths)
+    paths = fixture(tmp_path / "second")
+    report = json.loads(paths["report"].read_text(encoding="utf-8"))
+    report["quality_verdict"] = "fail"
+    write_json(paths["report"], report)
+    with pytest.raises(builder.DatasetReleaseError, match="failing quality"):
+        plan(paths)
+
+
+def test_inspection_identity_version_taxonomy_and_leakage_mismatches_fail(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    report = json.loads(paths["report"].read_text(encoding="utf-8"))
+    report["dataset_identity"] = "different"
+    write_json(paths["report"], report)
+    with pytest.raises(builder.DatasetReleaseError, match="identity"):
+        plan(paths)
+    report["dataset_identity"] = "fictional-source"
+    report["dataset_source_version"] = "different"
+    write_json(paths["report"], report)
+    with pytest.raises(builder.DatasetReleaseError, match="source version"):
+        plan(paths)
+    report["dataset_source_version"] = "fictional-v1"
+    report["duplicates"]["cross_split_duplicate_images"] = [{"fixture": "duplicate"}]
+    write_json(paths["report"], report)
+    with pytest.raises(builder.DatasetReleaseError, match="split leakage"):
+        plan(paths)
+    paths = fixture(tmp_path / "taxonomy")
+    mapping = json.loads(paths["mapping"].read_text(encoding="utf-8"))
+    mapping["source_taxonomy"][0]["name"] = "different"
+    write_json(paths["mapping"], mapping)
+    with pytest.raises(builder.DatasetReleaseError, match="does not exactly match"):
+        plan(paths)
+
+
+def test_missing_new_inspection_identity_fields_require_regeneration(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    report = json.loads(paths["report"].read_text(encoding="utf-8"))
+    report.pop("dataset_source_version")
+    write_json(paths["report"], report)
+    with pytest.raises(builder.DatasetReleaseError, match="regenerate"):
+        plan(paths)
+
+
+def test_inspection_report_taxonomy_mismatch_requires_regeneration(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    report = json.loads(paths["report"].read_text(encoding="utf-8"))
+    report["source_taxonomy"][1]["name"] = "different"
+    write_json(paths["report"], report)
+    with pytest.raises(builder.DatasetReleaseError, match="source taxonomy"):
+        plan(paths)
+
+
+@pytest.mark.parametrize("unsafe", ["../outside.png", r"C:\\outside.png", r"\\server\\share\\file.png", "..%2foutside.png"])
+def test_manifest_path_traversal_absolute_unc_and_encoded_paths_fail(tmp_path: Path, unsafe: str) -> None:
+    paths = fixture(tmp_path)
+    manifest = json.loads(paths["manifest"].read_text(encoding="utf-8"))
+    manifest["splits"]["train"]["samples"][0]["image_path"] = unsafe
+    write_json(paths["manifest"], manifest)
+
+    with pytest.raises(builder.DatasetReleaseError):
+        plan(paths)
+
+
+def test_missing_files_same_stem_collision_and_output_overlap_fail(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    (paths["source"] / "train" / "labels" / "mapped.txt").unlink()
+    with pytest.raises(builder.DatasetReleaseError, match="source manifest is invalid"):
+        plan(paths)
+    paths = fixture(tmp_path / "collision")
+    manifest = json.loads(paths["manifest"].read_text(encoding="utf-8"))
+    duplicate = dict(manifest["splits"]["train"]["samples"][0])
+    duplicate["sample_id"] = "different-id"
+    duplicate["image_path"] = "train/images/mapped.jpg"
+    duplicate["label_path"] = "train/labels/mapped-duplicate.txt"
+    source_image = paths["source"] / duplicate["image_path"]
+    source_label = paths["source"] / duplicate["label_path"]
+    source_image.parent.mkdir(parents=True, exist_ok=True)
+    source_label.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(paths["source"] / "train/images/mapped.png", source_image)
+    shutil.copy2(paths["source"] / "train/labels/mapped.txt", source_label)
+    manifest["splits"]["train"]["samples"].append(duplicate)
+    manifest["quality"]["image_count"] += 1
+    manifest["quality"]["annotation_count"] += 2
+    write_json(paths["manifest"], manifest)
+    with pytest.raises(builder.DatasetReleaseError, match="same-stem"):
+        plan(paths)
+    paths = fixture(tmp_path / "overlap")
+    with pytest.raises(builder.DatasetReleaseError, match="output root"):
+        builder.create_release_plan(source_root=paths["source"], source_yaml_path=paths["yaml"], source_manifest_path=paths["manifest"], inspection_report_path=paths["report"], mapping_path=paths["mapping"], output_root=paths["source"] / "releases", release_name="fictional-release", release_version="v1")
+
+
+def test_existing_release_is_protected_and_staging_is_removed_after_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = fixture(tmp_path)
+    planned = plan(paths)
+    planned.release_root.mkdir(parents=True)
+    with pytest.raises(builder.DatasetReleaseError, match="protected"):
+        builder.build_release(planned, confirm_build=True)
+    shutil.rmtree(planned.release_root)
+    monkeypatch.setattr(builder.shutil, "copy2", lambda *_: (_ for _ in ()).throw(OSError("fixture copy failure")))
+    with pytest.raises(OSError, match="fixture copy failure"):
+        builder.build_release(plan(paths), confirm_build=True)
+    assert not list((paths["output"] / "fictional-release").glob(".*.staging-*"))
+    assert not (paths["output"] / "fictional-release" / "v1").exists()
+
+
+def test_deterministic_outputs_checksums_and_optional_test_split(tmp_path: Path) -> None:
+    paths = fixture(tmp_path / "one", include_test=True)
+    first = builder.build_release(plan(paths), confirm_build=True)
+    second_paths = fixture(tmp_path / "two", include_test=True)
+    second = builder.build_release(plan(second_paths), confirm_build=True)
+    first_root = paths["output"] / "fictional-release" / "v1"
+    second_root = second_paths["output"] / "fictional-release" / "v1"
+
+    assert first["release"]["identity_sha256"] == second["release"]["identity_sha256"]  # type: ignore[index]
+    for relative in ("dataset.yaml", "release_manifest.json", "release_checksums.json", "labels/train/mapped.txt"):
+        assert (first_root / relative).read_bytes() == (second_root / relative).read_bytes()
+    assert "test: images/test" in (first_root / "dataset.yaml").read_text(encoding="utf-8")
+    assert "nc: 8" in (first_root / "dataset.yaml").read_text(encoding="utf-8")
+
+
+def test_generated_release_passes_validator_and_existing_inspector(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    builder.build_release(plan(paths), confirm_build=True)
+    release = paths["output"] / "fictional-release" / "v1"
+    manifest = json.loads((release / "release_manifest.json").read_text(encoding="utf-8"))
+    metadata = write_json(tmp_path / "canonical-metadata.json", builder._inspection_metadata())
+    groups = write_json(tmp_path / "groups.json", {"groups": {sample["image_path"]: sample["group_id"] for split in manifest["splits"].values() for sample in split["samples"]}})
+
+    assert not manifest_validator.validate_manifest(manifest, dataset_root=release, check_files=True)
+    report, _ = inspector.inspect_dataset(release, release / "dataset.yaml", metadata_path=metadata, group_map_path=groups)
+    assert report["quality_verdict"] != "fail"
+
+
+def test_training_dry_run_is_compatible_after_explicit_reviewed_promotion(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    builder.build_release(plan(paths), confirm_build=True)
+    release = paths["output"] / "fictional-release" / "v1"
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    manifest = json.loads((release / "release_manifest.json").read_text(encoding="utf-8"))
+    manifest["dataset"]["release_decision"] = "approved_for_training"
+    write_json(repository / "manifest.json", manifest)
+    shutil.rmtree(paths["source"])
+    (repository / "architecture.yaml").write_text("nc: 8\n", encoding="utf-8")
+    config = {"schema_version": "1.0.0", "experiment_name": "Release builder test", "dataset": {"manifest_path": "manifest.json", "yaml_path": "dataset.yaml", "inspection_report_path": None, "stage": "approved_for_internal_training"}, "model": {"architecture_path": "architecture.yaml", "initial_weights_path": None}, "training": {"epochs": 1, "image_size": 32, "batch_size": 1, "device": "cpu", "workers": 1, "seed": 1, "optimizer": "AdamW", "learning_rate": 0.001, "confidence": 0.001, "iou": 0.7, "deterministic": True, "resume_behavior": "never"}, "output": {"root": "artifacts"}, "notes": "Temporary test configuration."}
+    config_path = write_json(repository / "training.json", config)
+
+    assert training.dry_run(training.load_training_plan(config_path, dataset_root_override=release, repository_root=repository))["status"] == "dry_run_valid"
+
+
+def test_group_leakage_and_actual_cross_split_checksum_leakage_block(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    report = json.loads(paths["report"].read_text(encoding="utf-8"))
+    report["duplicates"]["cross_split_group_leakage"] = [{"group_id": "shared"}]
+    write_json(paths["report"], report)
+    with pytest.raises(builder.DatasetReleaseError, match="group_leakage"):
+        plan(paths)
+    paths = fixture(tmp_path / "checksum")
+    (paths["source"] / "validation/images/validation.png").write_bytes(
+        (paths["source"] / "train/images/mapped.png").read_bytes()
+    )
+    with pytest.raises(builder.DatasetReleaseError, match="checksums reveal duplicate"):
+        plan(paths)
+
+
+def test_source_image_missing_or_orphan_label_blocks_release(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    (paths["source"] / "validation/images/validation.png").unlink()
+    with pytest.raises(builder.DatasetReleaseError, match="source manifest is invalid"):
+        plan(paths)
+    paths = fixture(tmp_path / "orphan")
+    orphan = paths["source"] / "train/labels/orphan.txt"
+    orphan.write_text("0 0.5 0.5 0.2 0.2\n", encoding="utf-8")
+    with pytest.raises(builder.DatasetReleaseError, match="orphan labels"):
+        plan(paths)
+
+
+@pytest.mark.parametrize("unsafe", ["../outside/images", r"C:\\outside\\images", r"\\server\\share\\images", "..%2foutside/images"])
+def test_source_yaml_path_escape_forms_block_release(tmp_path: Path, unsafe: str) -> None:
+    paths = fixture(tmp_path)
+    paths["yaml"].write_text(f"path: .\ntrain: {unsafe}\nval: validation/images\nnames:\n  0: fictional-person\n  1: fictional-ceiling\n", encoding="utf-8")
+    with pytest.raises(builder.DatasetReleaseError, match="source dataset YAML"):
+        plan(paths)
+
+
+def test_source_root_inside_output_root_blocks_release(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    with pytest.raises(builder.DatasetReleaseError, match="source dataset root"):
+        builder.create_release_plan(source_root=paths["source"], source_yaml_path=paths["yaml"], source_manifest_path=paths["manifest"], inspection_report_path=paths["report"], mapping_path=paths["mapping"], output_root=tmp_path, release_name="fictional-release", release_version="v1")
+
+
+@pytest.mark.parametrize("unsafe", [r"\\server\share", r"C:drive-relative", "file:///controlled/source", "https://example.invalid/source"])
+def test_nonlocal_cli_input_forms_are_rejected(tmp_path: Path, unsafe: str) -> None:
+    paths = fixture(tmp_path)
+    with pytest.raises(builder.DatasetReleaseError, match="controlled local filesystem path"):
+        builder.create_release_plan(source_root=paths["source"], source_yaml_path=paths["yaml"], source_manifest_path=paths["manifest"], inspection_report_path=paths["report"], mapping_path=paths["mapping"], output_root=Path(unsafe), release_name="fictional-release", release_version="v1")
+
+
+def test_repository_output_root_and_wrong_mapping_schema_version_are_rejected(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    with pytest.raises(builder.DatasetReleaseError, match="outside the repository"):
+        builder.create_release_plan(source_root=paths["source"], source_yaml_path=paths["yaml"], source_manifest_path=paths["manifest"], inspection_report_path=paths["report"], mapping_path=paths["mapping"], output_root=builder.REPOSITORY_ROOT / "generated-release", release_name="fictional-release", release_version="v1")
+    mapping = json.loads(paths["mapping"].read_text(encoding="utf-8"))
+    mapping["schema_version"] = "other"
+    write_json(paths["mapping"], mapping)
+    with pytest.raises(builder.DatasetReleaseError, match="schema_version"):
+        plan(paths)
+
+
+def test_symlink_escape_blocks_release_where_supported(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(IMAGE_BYTES)
+    link = paths["source"] / "train/images/mapped.png"
+    link.unlink()
+    try:
+        link.symlink_to(outside)
+    except (NotImplementedError, OSError):
+        pytest.skip("Symlink creation is unavailable in this environment.")
+    with pytest.raises(builder.DatasetReleaseError):
+        plan(paths)
+
+
+@pytest.mark.parametrize("mutation, expected", [
+    (lambda mapping: mapping["class_mapping"].pop(), "no explicit decision"),
+    (lambda mapping: mapping["class_mapping"].append({"source_class_id": 4, "target_class_id": 0, "target_class_name": "person", "mapping_rationale": "Unknown source."}), "unknown source"),
+    (lambda mapping: mapping["release_metadata"]["dataset"].pop("name"), "cannot produce a valid manifest"),
+])
+def test_mapping_completeness_unknown_source_and_invalid_release_metadata_block(tmp_path: Path, mutation: object, expected: str) -> None:
+    paths = fixture(tmp_path)
+    mapping = json.loads(paths["mapping"].read_text(encoding="utf-8"))
+    mutation(mapping)  # type: ignore[operator]
+    write_json(paths["mapping"], mapping)
+    with pytest.raises(builder.DatasetReleaseError, match=expected):
+        plan(paths)
+
+
+@pytest.mark.parametrize("target, field", [
+    ("mapping", "unexpected"),
+    ("source_taxonomy", "unexpected"),
+    ("class_mapping", "unexpected"),
+])
+def test_unknown_mapping_configuration_fields_and_whitespace_taxonomy_fail(tmp_path: Path, target: str, field: str) -> None:
+    paths = fixture(tmp_path)
+    mapping = json.loads(paths["mapping"].read_text(encoding="utf-8"))
+    if target == "mapping":
+        mapping[field] = True
+    else:
+        mapping[target][0][field] = True
+    write_json(paths["mapping"], mapping)
+    with pytest.raises(builder.DatasetReleaseError, match="unsupported field"):
+        plan(paths)
+    paths = fixture(tmp_path / "whitespace")
+    paths["yaml"].write_text("path: .\ntrain: train/images\nval: validation/images\nnames:\n  0: 'fictional-person '\n  1: fictional-ceiling\n", encoding="utf-8")
+    with pytest.raises(builder.DatasetReleaseError, match="surrounding whitespace"):
+        plan(paths)
+
+
+def test_mapping_source_taxonomy_reordering_is_rejected(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    mapping = json.loads(paths["mapping"].read_text(encoding="utf-8"))
+    mapping["source_taxonomy"].reverse()
+    write_json(paths["mapping"], mapping)
+    with pytest.raises(builder.DatasetReleaseError, match="exact ID order"):
+        plan(paths)
+
+
+def test_source_yaml_declared_class_count_must_match_named_taxonomy(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    paths["yaml"].write_text("path: .\ntrain: train/images\nval: validation/images\nnc: 3\nnames:\n  0: fictional-person\n  1: fictional-ceiling\n", encoding="utf-8")
+    with pytest.raises(builder.DatasetReleaseError, match="nc"):
+        plan(paths)
+
+
+def test_explicit_reviewed_training_status_is_preserved_without_invention(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    mapping = json.loads(paths["mapping"].read_text(encoding="utf-8"))
+    mapping["release_metadata"]["dataset"]["release_decision"] = "approved_for_training"
+    mapping["release_metadata"]["quality_review_status"] = "completed"
+    write_json(paths["mapping"], mapping)
+
+    assert builder._release_manifest(plan(paths))["dataset"]["release_decision"] == "approved_for_training"  # type: ignore[index]
+
+
+def test_approved_training_status_requires_explicit_licence_and_completed_quality_review(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    mapping = json.loads(paths["mapping"].read_text(encoding="utf-8"))
+    mapping["release_metadata"]["dataset"]["release_decision"] = "approved_for_training"
+    write_json(paths["mapping"], mapping)
+    with pytest.raises(builder.DatasetReleaseError, match="quality review"):
+        plan(paths)
+    mapping["release_metadata"]["quality_review_status"] = "completed"
+    mapping["release_metadata"]["licence"]["review_decision"] = "conditional"
+    write_json(paths["mapping"], mapping)
+    with pytest.raises(builder.DatasetReleaseError, match="licence review"):
+        plan(paths)
+
+
+def test_stale_manifest_checksum_metadata_is_not_reused(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    mapping = json.loads(paths["mapping"].read_text(encoding="utf-8"))
+    mapping["release_metadata"]["storage_release"]["manifest_checksum"] = "sha256:" + "0" * 64
+    write_json(paths["mapping"], mapping)
+
+    assert "manifest_checksum" not in builder._release_manifest(plan(paths))["storage_release"]  # type: ignore[operator]
+
+
+@pytest.mark.parametrize("label_text, expected", [
+    ("0 0.5 0.5 0 0.2\n", "out-of-bounds"),
+    ("0 nan 0.5 0.2 0.2\n", "non-finite"),
+    ("0 0.95 0.5 0.2 0.2\n", "out-of-bounds"),
+])
+def test_invalid_yolo_coordinate_forms_block_release(tmp_path: Path, label_text: str, expected: str) -> None:
+    paths = fixture(tmp_path)
+    (paths["source"] / "train/labels/mapped.txt").write_text(label_text, encoding="utf-8")
+    with pytest.raises(builder.DatasetReleaseError, match=expected):
+        plan(paths)
+
+
+def test_bom_crlf_blank_lines_and_duplicate_detection_rows_are_preserved_deterministically(tmp_path: Path) -> None:
+    paths = fixture(tmp_path)
+    label_text = "\ufeff0 0.500000 0.5 0.2 0.2\r\n\r\n0 0.250000 0.5 0.2 0.2\r\n"
+    (paths["source"] / "train/labels/mapped.txt").write_text(label_text, encoding="utf-8")
+
+    builder.build_release(plan(paths), confirm_build=True)
+
+    output = (paths["output"] / "fictional-release" / "v1/labels/train/mapped.txt").read_text(encoding="utf-8")
+    assert output == "0 0.500000 0.5 0.2 0.2\n0 0.250000 0.5 0.2 0.2\n"
+
+
+def test_interrupt_is_not_reported_as_validation_error_and_cleans_staging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = fixture(tmp_path)
+    source_image = paths["source"] / "train/images/mapped.png"
+    source_label = paths["source"] / "train/labels/mapped.txt"
+    source_hashes = (builder._sha256(source_image), builder._sha256(source_label))
+    monkeypatch.setattr(builder.shutil, "copy2", lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
+    with pytest.raises(KeyboardInterrupt):
+        builder.build_release(plan(paths), confirm_build=True)
+    assert not list((paths["output"] / "fictional-release").glob(".*.staging-*"))
+    assert (builder._sha256(source_image), builder._sha256(source_label)) == source_hashes
+
+
+def test_deterministic_machine_and_human_reports_and_checksum_records(tmp_path: Path) -> None:
+    paths = fixture(tmp_path / "one")
+    builder.build_release(plan(paths), confirm_build=True)
+    second_paths = fixture(tmp_path / "two")
+    builder.build_release(plan(second_paths), confirm_build=True)
+    first_root = paths["output"] / "fictional-release" / "v1"
+    second_root = second_paths["output"] / "fictional-release" / "v1"
+    for relative in ("release_build_report.json", "release_build_report.md", "release_checksums.json"):
+        assert (first_root / relative).read_bytes() == (second_root / relative).read_bytes()
+    checksums = json.loads((first_root / "release_checksums.json").read_text(encoding="utf-8"))
+    assert checksums["files"]["dataset.yaml"] == builder._sha256(first_root / "dataset.yaml")
+    markdown = (first_root / "release_build_report.md").read_text(encoding="utf-8")
+    assert "Source annotations" in markdown
+    assert "Input `source_manifest_sha256`" in markdown
+    assert "No failures." in markdown
+    assert not list(first_root.glob(".release_*"))
+
+
+def test_cli_fictional_dry_run_and_confirmed_build_succeed(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    paths = fixture(tmp_path)
+    arguments = ["--source-root", str(paths["source"]), "--source-yaml", str(paths["yaml"]), "--source-manifest", str(paths["manifest"]), "--inspection-report", str(paths["report"]), "--mapping-config", str(paths["mapping"]), "--output-root", str(paths["output"]), "--release-name", "fictional-release", "--release-version", "v1"]
+
+    assert builder.main([*arguments, "--dry-run"]) == 0
+    assert '"status": "planned"' in capsys.readouterr().out
+    assert not paths["output"].exists()
+    assert builder.main([*arguments, "--confirm-build"]) == 0
+    assert '"status": "completed"' in capsys.readouterr().out
+    assert (paths["output"] / "fictional-release" / "v1" / "release_manifest.json").is_file()
+
+
+def test_cli_help_confirmation_conflict_and_ordinary_errors_are_controlled(tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(SystemExit) as result:
+        builder.main(["--help"])
+    assert result.value.code == 0
+    paths = fixture(tmp_path)
+    arguments = ["--source-root", str(paths["source"]), "--source-yaml", str(paths["yaml"]), "--source-manifest", str(paths["manifest"]), "--inspection-report", str(paths["report"]), "--mapping-config", str(paths["mapping"]), "--output-root", str(paths["output"]), "--release-name", "fictional-release", "--release-version", "v1"]
+    assert builder.main([*arguments, "--dry-run", "--confirm-build"]) == 1
+    assert "Traceback" not in capsys.readouterr().err
+    assert builder.main(arguments) == 1
+    assert "requires --confirm-build" in capsys.readouterr().err
+    monkeypatch.setattr(builder, "create_release_plan", lambda **_: (_ for _ in ()).throw(KeyboardInterrupt()))
+    with pytest.raises(KeyboardInterrupt):
+        builder.main(arguments + ["--dry-run"])

--- a/ML_side/tests/test_inspect_candidate_dataset.py
+++ b/ML_side/tests/test_inspect_candidate_dataset.py
@@ -157,6 +157,11 @@ def test_valid_minimal_dataset_passes_with_explicit_mapping_and_groups(tmp_path:
     report = inspect(root, yaml_path, metadata_path=metadata_path, group_map_path=group_map_for(root))
 
     assert report["quality_verdict"] == "pass"
+    assert report["dataset_identity"] == "fictional-candidate-v1"
+    assert report["dataset_source_version"] == "fictional-v1"
+    markdown = inspector.render_markdown_report(report)
+    assert "Dataset identity: `fictional-candidate-v1`" in markdown
+    assert "Source version: `fictional-v1`" in markdown
     assert report["totals"]["image_count"] == 2  # type: ignore[index]
     assert report["annotation_counts_by_walkbuddy_target_class"][0]["count"] == 2  # type: ignore[index]
 

--- a/ML_side/tools/build_navigation_dataset_release.py
+++ b/ML_side/tools/build_navigation_dataset_release.py
@@ -1,0 +1,873 @@
+"""Build a controlled, local-only canonical WalkBuddy YOLO dataset release.
+
+The builder deliberately consumes only previously reviewed local inputs.  It
+does not infer class mappings, download data, or make a release eligible for
+training.  Its generated manifest defaults to ``under_review`` unless reviewed
+release metadata explicitly records another valid decision.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import math
+import shutil
+import subprocess
+import sys
+import uuid
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised through an ordinary CLI error
+    yaml = None  # type: ignore[assignment]
+
+YAML_ERROR = yaml.YAMLError if yaml is not None else ()
+
+import inspect_candidate_dataset as inspector
+import validate_dataset_manifest as manifest_validator
+
+
+TOOL_NAME = "build_navigation_dataset_release"
+TOOL_VERSION = "1.0.0"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_TAXONOMY = manifest_validator.APPROVED_TAXONOMY
+CANONICAL_TARGETS = manifest_validator.APPROVED_TARGETS
+SPLITS = ("train", "validation", "test")
+EMPTY_POLICIES = frozenset({"retain_negative", "exclude_image"})
+
+
+class DatasetReleaseError(Exception):
+    """Raised for a controlled release validation or construction failure."""
+
+
+@dataclass(frozen=True)
+class PlannedSample:
+    split: str
+    sample_id: str
+    group_id: str
+    source_image: Path
+    destination_image: str
+    destination_label: str
+    label_text: str
+    image_checksum: str
+    annotation_class_ids: tuple[int, ...]
+    source_empty_negative: bool
+    exclusion_created_negative: bool
+
+
+@dataclass(frozen=True)
+class ReleasePlan:
+    source_root: Path
+    source_manifest_path: Path
+    source_yaml_path: Path
+    inspection_report_path: Path
+    mapping_path: Path
+    output_root: Path
+    release_root: Path
+    release_name: str
+    release_version: str
+    empty_image_policy: str
+    source_manifest: dict[str, object]
+    mapping: dict[str, object]
+    samples: tuple[PlannedSample, ...]
+    source_counts: dict[int, int]
+    target_counts: dict[int, int]
+    excluded_counts: dict[int, int]
+    input_checksums: dict[str, str]
+    release_identity: str
+    git_commit: str | None
+    git_dirty: bool | None
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _json_text(value: object) -> str:
+    return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def _load_structured(path: Path, label: str) -> dict[str, object]:
+    if not path.is_file():
+        raise DatasetReleaseError(f"{label} is not an existing file: {path}")
+    try:
+        text = path.read_text(encoding="utf-8-sig")
+        if path.suffix.casefold() == ".json":
+            value = json.loads(text)
+        else:
+            if yaml is None:
+                raise DatasetReleaseError("PyYAML is required to read YAML release inputs.")
+            value = yaml.safe_load(text)
+    except json.JSONDecodeError as exc:
+        raise DatasetReleaseError(f"{label} is not valid JSON: {path}") from exc
+    except OSError as exc:
+        raise DatasetReleaseError(f"{label} could not be read: {path}") from exc
+    except YAML_ERROR as exc:  # type: ignore[misc]
+        raise DatasetReleaseError(f"{label} is not valid YAML: {path}") from exc
+    if not isinstance(value, dict):
+        raise DatasetReleaseError(f"{label} root must be an object: {path}")
+    return value
+
+
+def _safe_name(value: str, label: str) -> str:
+    if not value or value != value.strip() or any(character in value for character in "/\\"):
+        raise DatasetReleaseError(f"{label} must be a non-empty single path component.")
+    if value in {".", ".."} or not all(character.isalnum() or character in "._-" for character in value):
+        raise DatasetReleaseError(f"{label} may contain only letters, numbers, dots, underscores, and hyphens.")
+    return value
+
+
+def _reject_nonlocal_path(path: Path, label: str) -> None:
+    """Reject remote and drive-relative input locations before filesystem access."""
+    raw = str(path)
+    folded = raw.casefold()
+    windows_path = PureWindowsPath(raw)
+    if (
+        folded.startswith(("http://", "https://", "http:\\", "https:\\", "file:"))
+        or raw.startswith(("\\\\", "//"))
+        or (windows_path.drive.endswith(":") and len(windows_path.drive) > 2)
+        or (windows_path.drive and not windows_path.is_absolute())
+    ):
+        raise DatasetReleaseError(f"{label} must be a controlled local filesystem path, not a URL, URI, UNC, or drive-relative path.")
+
+
+def _is_beneath(root: Path, path: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _require_beneath(root: Path, path: Path, label: str) -> Path:
+    resolved = path.resolve()
+    if not _is_beneath(root, resolved):
+        raise DatasetReleaseError(f"{label} must resolve beneath the controlled source dataset root.")
+    return resolved
+
+
+def _relative_reference(root: Path, raw: object, label: str) -> Path:
+    valid, reason = manifest_validator._is_safe_relative_path(raw)
+    if not valid or not isinstance(raw, str):
+        raise DatasetReleaseError(f"{label} is unsafe: {reason or 'expected a safe relative path.'}")
+    resolved = manifest_validator._resolve_dataset_reference(root, raw)
+    if resolved is None:
+        raise DatasetReleaseError(f"{label} escapes the controlled source dataset root.")
+    return resolved
+
+
+def _mapping(value: object, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise DatasetReleaseError(f"{label} must be an object.")
+    return value
+
+
+def _list(value: object, label: str) -> list[object]:
+    if not isinstance(value, list):
+        raise DatasetReleaseError(f"{label} must be an array.")
+    return value
+
+
+def _integer(value: object, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise DatasetReleaseError(f"{label} must be a non-negative integer.")
+    return value
+
+
+def _string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise DatasetReleaseError(f"{label} must be a non-empty string.")
+    return value.strip()
+
+
+def _exact_string(value: object, label: str) -> str:
+    """Require identifiers and class names without silent whitespace normalisation."""
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise DatasetReleaseError(f"{label} must be a non-empty string without surrounding whitespace.")
+    return value
+
+
+def _only_fields(value: Mapping[str, object], label: str, allowed: set[str]) -> None:
+    unexpected = sorted(set(value) - allowed)
+    if unexpected:
+        raise DatasetReleaseError(f"{label} has unsupported field(s): {', '.join(unexpected)}.")
+
+
+def _source_taxonomy(dataset_yaml: Mapping[str, object]) -> dict[int, str]:
+    names = dataset_yaml.get("names")
+    pairs: list[tuple[int, str]] = []
+    if isinstance(names, list):
+        pairs = [(index, _exact_string(name, f"source dataset YAML names[{index}]")) for index, name in enumerate(names)]
+    elif isinstance(names, Mapping):
+        for raw_id, raw_name in names.items():
+            try:
+                class_id = int(raw_id)
+            except (TypeError, ValueError) as exc:
+                raise DatasetReleaseError("source dataset YAML names contains a non-integer class ID.") from exc
+            if isinstance(raw_id, bool):
+                raise DatasetReleaseError("source dataset YAML names contains a boolean class ID.")
+            pairs.append((_integer(class_id, "source dataset YAML class ID"), _exact_string(raw_name, "source dataset YAML class name")))
+    else:
+        raise DatasetReleaseError("source dataset YAML must define names as a list or ID-to-name object.")
+    pairs.sort(key=lambda item: item[0])
+    if [class_id for class_id, _ in pairs] != list(range(len(pairs))):
+        raise DatasetReleaseError("source dataset YAML class IDs must be contiguous and start at zero.")
+    if len({name.casefold() for _, name in pairs}) != len(pairs):
+        raise DatasetReleaseError("source dataset YAML class names must be unique.")
+    if "nc" in dataset_yaml and _integer(dataset_yaml["nc"], "source dataset YAML nc") != len(pairs):
+        raise DatasetReleaseError("source dataset YAML nc must exactly match the number of named source classes.")
+    return dict(pairs)
+
+
+def _config_source_taxonomy(mapping_config: Mapping[str, object]) -> dict[int, str]:
+    result: dict[int, str] = {}
+    configured_ids: list[int] = []
+    for index, raw_item in enumerate(_list(mapping_config.get("source_taxonomy"), "mapping source_taxonomy")):
+        item = _mapping(raw_item, f"mapping source_taxonomy[{index}]")
+        _only_fields(item, f"mapping source_taxonomy[{index}]", {"id", "name"})
+        class_id = _integer(item.get("id"), f"mapping source_taxonomy[{index}].id")
+        name = _exact_string(item.get("name"), f"mapping source_taxonomy[{index}].name")
+        if class_id in result or name.casefold() in {known.casefold() for known in result.values()}:
+            raise DatasetReleaseError("mapping source_taxonomy contains duplicate class IDs or names.")
+        result[class_id] = name
+        configured_ids.append(class_id)
+    if not result or configured_ids != list(range(len(result))):
+        raise DatasetReleaseError("mapping source_taxonomy must use contiguous IDs starting at zero in exact ID order.")
+    return dict(sorted(result.items()))
+
+
+def _class_decisions(mapping_config: Mapping[str, object], source_taxonomy: Mapping[int, str]) -> tuple[dict[int, tuple[int, str, str]], dict[int, str], dict[int, str]]:
+    mapped: dict[int, tuple[int, str, str]] = {}
+    excluded: dict[int, str] = {}
+    unresolved: dict[int, str] = {}
+    for key, target in (("class_mapping", mapped), ("excluded_source_classes", excluded), ("unmapped_source_classes", unresolved)):
+        for index, raw_item in enumerate(_list(mapping_config.get(key, []), f"mapping {key}")):
+            item = _mapping(raw_item, f"mapping {key}[{index}]")
+            _only_fields(
+                item,
+                f"mapping {key}[{index}]",
+                {"source_class_id", "target_class_id", "target_class_name", "mapping_rationale"}
+                if key == "class_mapping"
+                else {"source_class_id", "reason"},
+            )
+            source_id = _integer(item.get("source_class_id"), f"mapping {key}[{index}].source_class_id")
+            if source_id not in source_taxonomy:
+                raise DatasetReleaseError(f"mapping {key}[{index}] references unknown source class ID {source_id}.")
+            if source_id in mapped or source_id in excluded or source_id in unresolved:
+                raise DatasetReleaseError(f"source class ID {source_id} has duplicate or ambiguous mapping decisions.")
+            if key == "class_mapping":
+                target_id = _integer(item.get("target_class_id"), f"mapping class_mapping[{index}].target_class_id")
+                target_name = _exact_string(item.get("target_class_name"), f"mapping class_mapping[{index}].target_class_name")
+                rationale = _string(item.get("mapping_rationale"), f"mapping class_mapping[{index}].mapping_rationale")
+                if CANONICAL_TARGETS.get(target_id) != target_name:
+                    raise DatasetReleaseError(f"mapping class_mapping[{index}] must use an exact approved target ID/name pair.")
+                mapped[source_id] = (target_id, target_name, rationale)
+            else:
+                reason = _string(item.get("reason"), f"mapping {key}[{index}].reason")
+                target[source_id] = reason  # type: ignore[index]
+    missing = sorted(set(source_taxonomy) - set(mapped) - set(excluded) - set(unresolved))
+    if missing:
+        raise DatasetReleaseError(f"mapping has no explicit decision for source class IDs: {missing}.")
+    if unresolved:
+        raise DatasetReleaseError(f"mapping has unresolved source class IDs and cannot build a release: {sorted(unresolved)}.")
+    return mapped, excluded, unresolved
+
+
+def _parse_label(label_path: Path, source_taxonomy: Mapping[int, str], mapped: Mapping[int, tuple[int, str, str]], excluded: Mapping[int, str]) -> tuple[list[tuple[int, tuple[str, str, str, str]]], Counter[int], Counter[int]]:
+    try:
+        lines = label_path.read_text(encoding="utf-8-sig").splitlines()
+    except UnicodeDecodeError as exc:
+        raise DatasetReleaseError(f"source label is not UTF-8 text: {label_path.name}") from exc
+    except OSError as exc:
+        raise DatasetReleaseError(f"source label could not be read: {label_path.name}") from exc
+    kept: list[tuple[int, tuple[str, str, str, str]]] = []
+    source_counts: Counter[int] = Counter()
+    excluded_counts: Counter[int] = Counter()
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        values = line.split()
+        if len(values) != 5:
+            raise DatasetReleaseError(f"{label_path.name}:{line_number} must contain exactly five YOLO fields.")
+        try:
+            source_id = int(values[0])
+        except ValueError as exc:
+            raise DatasetReleaseError(f"{label_path.name}:{line_number} has a non-integer class ID.") from exc
+        if str(source_id) != values[0] or source_id not in source_taxonomy:
+            raise DatasetReleaseError(f"{label_path.name}:{line_number} references unknown source class ID {values[0]!r}.")
+        coordinates: list[float] = []
+        for coordinate in values[1:]:
+            try:
+                parsed = float(coordinate)
+            except ValueError as exc:
+                raise DatasetReleaseError(f"{label_path.name}:{line_number} contains a non-numeric coordinate.") from exc
+            if not math.isfinite(parsed):
+                raise DatasetReleaseError(f"{label_path.name}:{line_number} contains a non-finite coordinate.")
+            coordinates.append(parsed)
+        x_center, y_center, width, height = coordinates
+        if width <= 0 or height <= 0 or x_center - width / 2 < 0 or x_center + width / 2 > 1 or y_center - height / 2 < 0 or y_center + height / 2 > 1:
+            raise DatasetReleaseError(f"{label_path.name}:{line_number} has an out-of-bounds normalized YOLO bounding box.")
+        source_counts[source_id] += 1
+        if source_id in excluded:
+            excluded_counts[source_id] += 1
+            continue
+        target = mapped.get(source_id)
+        if target is None:
+            raise DatasetReleaseError(f"{label_path.name}:{line_number} refers to an unresolved source class ID {source_id}.")
+        kept.append((target[0], (values[1], values[2], values[3], values[4])))
+    return kept, source_counts, excluded_counts
+
+
+def _label_text(rows: Sequence[tuple[int, tuple[str, str, str, str]]]) -> str:
+    return "".join(f"{class_id} {' '.join(coordinates)}\n" for class_id, coordinates in rows)
+
+
+def _canonical_yaml(*, include_test: bool) -> str:
+    lines = ["path: .", "train: images/train", "val: images/val", "nc: 8", "names:"]
+    if include_test:
+        lines.insert(3, "test: images/test")
+    lines.extend(f"  {class_id}: {name}" for class_id, name in CANONICAL_TAXONOMY)
+    return "\n".join(lines) + "\n"
+
+
+def _git_metadata() -> tuple[str | None, bool | None]:
+    try:
+        commit = subprocess.run(["git", "rev-parse", "HEAD"], cwd=REPOSITORY_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False).stdout.strip()
+        dirty = bool(subprocess.run(["git", "status", "--porcelain"], cwd=REPOSITORY_ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False).stdout.strip())
+    except OSError:
+        return None, None
+    return (commit or None), dirty
+
+
+def _report_source_taxonomy(report: Mapping[str, object]) -> dict[int, str]:
+    raw_items = report.get("source_taxonomy")
+    if not isinstance(raw_items, list):
+        raise DatasetReleaseError("inspection report lacks source_taxonomy; regenerate it with the current inspector.")
+    items = _list(raw_items, "inspection report source_taxonomy")
+    taxonomy: dict[int, str] = {}
+    for index, raw_item in enumerate(items):
+        item = _mapping(raw_item, f"inspection report source_taxonomy[{index}]")
+        _only_fields(item, f"inspection report source_taxonomy[{index}]", {"id", "name"})
+        class_id = _integer(item.get("id"), f"inspection report source_taxonomy[{index}].id")
+        if class_id in taxonomy:
+            raise DatasetReleaseError("inspection report source_taxonomy contains duplicate class IDs.")
+        taxonomy[class_id] = _exact_string(item.get("name"), f"inspection report source_taxonomy[{index}].name")
+    if list(taxonomy) != list(range(len(taxonomy))):
+        raise DatasetReleaseError("inspection report source_taxonomy must use contiguous IDs in exact ID order; regenerate it.")
+    return taxonomy
+
+
+def _inspection_eligibility(
+    report: Mapping[str, object], manifest: Mapping[str, object], source_taxonomy: Mapping[int, str]
+) -> None:
+    if report.get("quality_verdict") == "fail" or report.get("validation_errors"):
+        raise DatasetReleaseError("dataset inspection report records a failing quality result.")
+    dataset = _mapping(manifest.get("dataset"), "source manifest dataset")
+    manifest_id = _exact_string(dataset.get("id"), "source manifest dataset.id")
+    manifest_version = _exact_string(dataset.get("source_version"), "source manifest dataset.source_version")
+    report_id = report.get("dataset_identity")
+    report_version = report.get("dataset_source_version")
+    if not isinstance(report_id, str) or not report_id or report_id != report_id.strip():
+        raise DatasetReleaseError(
+            "inspection report lacks dataset_identity; regenerate it with the current inspector and reviewed metadata."
+        )
+    if not isinstance(report_version, str) or not report_version or report_version != report_version.strip():
+        raise DatasetReleaseError(
+            "inspection report lacks dataset_source_version; regenerate it with the current inspector and reviewed metadata."
+        )
+    if report_id != manifest_id:
+        raise DatasetReleaseError("inspection report dataset identity does not match the source manifest.")
+    if report_version != manifest_version:
+        raise DatasetReleaseError("inspection report source version does not match the source manifest.")
+    if _report_source_taxonomy(report) != dict(source_taxonomy):
+        raise DatasetReleaseError(
+            "inspection report source taxonomy does not exactly match the current source dataset YAML; regenerate it."
+        )
+    duplicates = _mapping(report.get("duplicates"), "inspection report duplicates")
+    for key in ("cross_split_duplicate_images", "cross_split_group_leakage"):
+        if duplicates.get(key):
+            raise DatasetReleaseError(f"inspection report records {key}; split leakage blocks release generation.")
+
+
+def _manifest_eligibility(manifest: Mapping[str, object], source_root: Path) -> None:
+    issues = manifest_validator.validate_manifest(manifest, dataset_root=source_root, check_files=True)
+    if issues:
+        raise DatasetReleaseError("source manifest is invalid:\n" + manifest_validator.format_issues(issues))
+    licence = _mapping(manifest.get("licence"), "source manifest licence")
+    if licence.get("review_decision") != "approved" or licence.get("machine_learning_use_permitted") is not True:
+        raise DatasetReleaseError("source manifest requires an approved licence review permitting machine-learning use.")
+
+
+def _release_metadata(mapping_config: Mapping[str, object], release_name: str, release_version: str) -> dict[str, object]:
+    raw = _mapping(mapping_config.get("release_metadata"), "mapping release_metadata")
+    _only_fields(
+        raw,
+        "mapping release_metadata",
+        {"dataset", "source_provenance", "licence", "storage_release", "quality_review_status", "known_limitations"},
+    )
+    result = copy.deepcopy(raw)
+    dataset = _mapping(result.get("dataset"), "release metadata dataset")
+    dataset = dict(dataset)
+    dataset.setdefault("release_decision", "under_review")
+    if dataset.get("id") != release_name:
+        raise DatasetReleaseError("release metadata dataset.id must exactly match --release-name.")
+    result["dataset"] = dataset
+    storage = _mapping(result.get("storage_release"), "release metadata storage_release")
+    storage = dict(storage)
+    storage["release_version"] = release_version
+    # A manifest cannot truthfully checksum itself.  The completed checksum is
+    # recorded in release_checksums.json and the build report instead.
+    storage.pop("manifest_checksum", None)
+    result["storage_release"] = storage
+    if dataset.get("release_decision") == "approved_for_training":
+        licence = _mapping(result.get("licence"), "release metadata licence")
+        if licence.get("review_decision") != "approved" or licence.get("machine_learning_use_permitted") is not True:
+            raise DatasetReleaseError(
+                "approved_for_training requires an explicitly approved release licence review permitting machine-learning use."
+            )
+        if result.get("quality_review_status") != "completed":
+            raise DatasetReleaseError(
+                "approved_for_training requires explicitly completed release quality review metadata."
+            )
+    return result
+
+
+def _check_output_boundary(source_root: Path, output_root: Path) -> None:
+    resolved_source, resolved_output = source_root.resolve(), output_root.resolve()
+    if _is_beneath(resolved_source, resolved_output):
+        raise DatasetReleaseError("output root must not be inside the source dataset root.")
+    if _is_beneath(resolved_output, resolved_source):
+        raise DatasetReleaseError("source dataset root must not be inside the output root.")
+    if _is_beneath(REPOSITORY_ROOT, resolved_output):
+        raise DatasetReleaseError("output root must be outside the repository so generated releases cannot enter Git.")
+
+
+def _output_split_directory(split: str) -> str:
+    """Use YOLO's common ``val`` directory while retaining manifest ``validation``."""
+    return "val" if split == "validation" else split
+
+
+def _source_samples(manifest: Mapping[str, object]) -> list[tuple[str, Mapping[str, object]]]:
+    samples: list[tuple[str, Mapping[str, object]]] = []
+    for split, _, sample in manifest_validator._iter_samples(manifest):
+        if split not in SPLITS:
+            raise DatasetReleaseError(f"source manifest contains unsupported split {split!r}.")
+        samples.append((split, sample))
+    return sorted(samples, key=lambda value: (SPLITS.index(value[0]), str(value[1].get("sample_id")), str(value[1].get("image_path"))))
+
+
+def _validate_source_layout(
+    source_root: Path,
+    source_yaml: Mapping[str, object],
+    source_samples: Sequence[tuple[str, Mapping[str, object]]],
+) -> None:
+    """Ensure the manifest represents the inspected YAML split directories exactly."""
+    layout_errors: list[dict[str, str]] = []
+    layout = inspector._resolve_layout(source_root, source_yaml, layout_errors)
+    if layout_errors:
+        raise DatasetReleaseError(
+            "source dataset YAML has unsafe or missing split paths: " + json.dumps(layout_errors, sort_keys=True)
+        )
+    manifest_paths: dict[str, tuple[set[Path], set[Path]]] = {
+        split: (set(), set()) for split in SPLITS
+    }
+    for split, sample in source_samples:
+        image = _relative_reference(source_root, sample.get("image_path"), f"source manifest image_path for {sample.get('sample_id')}")
+        label = _relative_reference(source_root, sample.get("label_path"), f"source manifest label_path for {sample.get('sample_id')}")
+        if split not in layout:
+            raise DatasetReleaseError(f"source dataset YAML does not define the manifest {split} split.")
+        image_directory = layout[split]["image_directory"]
+        label_directory = layout[split]["label_directory"]
+        assert isinstance(image_directory, Path) and isinstance(label_directory, Path)
+        if not _is_beneath(image_directory, image) or not _is_beneath(label_directory, label):
+            raise DatasetReleaseError(f"source manifest sample {sample.get('sample_id')!r} is outside its declared {split} YAML split.")
+        manifest_paths[split][0].add(image)
+        manifest_paths[split][1].add(label)
+    for split, details in layout.items():
+        image_directory, label_directory = details["image_directory"], details["label_directory"]
+        assert isinstance(image_directory, Path) and isinstance(label_directory, Path)
+        if not label_directory.is_dir():
+            raise DatasetReleaseError(f"source dataset YAML {split} labels directory is missing.")
+        actual_images = {
+            path.resolve()
+            for path in image_directory.rglob("*")
+            if path.is_file() and path.suffix.casefold() in manifest_validator.IMAGE_EXTENSIONS and _is_beneath(source_root, path)
+        }
+        actual_labels = {
+            path.resolve()
+            for path in label_directory.rglob("*")
+            if path.is_file() and path.suffix.casefold() == ".txt" and _is_beneath(source_root, path)
+        }
+        expected_images, expected_labels = manifest_paths[split]
+        if actual_images != expected_images:
+            raise DatasetReleaseError(f"source manifest does not exactly represent the supported images in the {split} split.")
+        if actual_labels != expected_labels:
+            raise DatasetReleaseError(f"source manifest does not exactly represent the label files in the {split} split (including orphan labels).")
+
+
+def create_release_plan(
+    *, source_root: Path, source_yaml_path: Path, source_manifest_path: Path, inspection_report_path: Path,
+    mapping_path: Path, output_root: Path, release_name: str, release_version: str,
+    empty_image_policy: str | None = None,
+) -> ReleasePlan:
+    """Validate local inputs and calculate a complete deterministic release plan."""
+    for path, label in ((source_root, "source dataset root"), (source_yaml_path, "source dataset YAML"), (source_manifest_path, "source manifest"), (inspection_report_path, "inspection report"), (mapping_path, "mapping configuration"), (output_root, "output root")):
+        _reject_nonlocal_path(path, label)
+    source_root = source_root.resolve()
+    if not source_root.is_dir():
+        raise DatasetReleaseError("source dataset root is not an existing directory.")
+    source_yaml_path = _require_beneath(source_root, source_yaml_path, "source dataset YAML")
+    source_manifest_path = source_manifest_path.resolve()
+    inspection_report_path = inspection_report_path.resolve()
+    mapping_path = mapping_path.resolve()
+    for path, label in ((source_manifest_path, "source manifest"), (inspection_report_path, "inspection report"), (mapping_path, "mapping configuration")):
+        if not path.is_file():
+            raise DatasetReleaseError(f"{label} is not an existing file: {path}")
+    output_root = output_root.resolve()
+    _check_output_boundary(source_root, output_root)
+    release_name, release_version = _safe_name(release_name, "release name"), _safe_name(release_version, "release version")
+    release_root = output_root / release_name / release_version
+    if release_root.exists():
+        raise DatasetReleaseError("completed or partial release path already exists and is protected from overwrite.")
+
+    source_yaml = _load_structured(source_yaml_path, "source dataset YAML")
+    manifest_path, source_manifest = manifest_validator.load_manifest(source_manifest_path)
+    report = _load_structured(inspection_report_path, "inspection report")
+    mapping_config = _load_structured(mapping_path, "mapping configuration")
+    if mapping_config.get("schema_version") != "1.0.0":
+        raise DatasetReleaseError("mapping configuration schema_version must be '1.0.0'.")
+    _only_fields(
+        mapping_config,
+        "mapping configuration",
+        {
+            "schema_version",
+            "source_taxonomy",
+            "class_mapping",
+            "excluded_source_classes",
+            "unmapped_source_classes",
+            "empty_image_policy",
+            "release_metadata",
+        },
+    )
+    source_taxonomy = _source_taxonomy(source_yaml)
+    _manifest_eligibility(source_manifest, source_root)
+    _inspection_eligibility(report, source_manifest, source_taxonomy)
+    if source_taxonomy != _config_source_taxonomy(mapping_config):
+        raise DatasetReleaseError("source dataset YAML taxonomy does not exactly match mapping source_taxonomy.")
+    mapped, excluded, _ = _class_decisions(mapping_config, source_taxonomy)
+    chosen_policy = empty_image_policy or _exact_string(mapping_config.get("empty_image_policy", "retain_negative"), "mapping empty_image_policy")
+    if chosen_policy not in EMPTY_POLICIES:
+        raise DatasetReleaseError("empty image policy must be retain_negative or exclude_image.")
+    _release_metadata(mapping_config, release_name, release_version)
+    source_samples = _source_samples(source_manifest)
+    _validate_source_layout(source_root, source_yaml, source_samples)
+
+    samples: list[PlannedSample] = []
+    source_counts: Counter[int] = Counter()
+    target_counts: Counter[int] = Counter()
+    excluded_counts: Counter[int] = Counter()
+    stems_by_split: dict[str, set[str]] = {split: set() for split in SPLITS}
+    image_checksum_splits: dict[str, set[str]] = {}
+    for split, sample in source_samples:
+        sample_id = _string(sample.get("sample_id"), "source manifest sample_id")
+        group_id = _string(sample.get("group_id"), "source manifest group_id")
+        if sample.get("labelled") is not True:
+            raise DatasetReleaseError(f"source manifest sample {sample_id!r} is not a labelled YOLO sample.")
+        image = _relative_reference(source_root, sample.get("image_path"), f"source manifest image_path for {sample_id}")
+        label = _relative_reference(source_root, sample.get("label_path"), f"source manifest label_path for {sample_id}")
+        if not image.is_file() or not label.is_file():
+            raise DatasetReleaseError(f"source manifest sample {sample_id!r} is missing its required image or label file.")
+        if image.suffix.casefold() not in manifest_validator.IMAGE_EXTENSIONS:
+            raise DatasetReleaseError(f"source manifest sample {sample_id!r} has an unsupported image extension.")
+        stem_key = image.stem.casefold()
+        if stem_key in stems_by_split[split]:
+            raise DatasetReleaseError(f"source manifest has a same-stem image collision in {split}: {image.stem!r}.")
+        stems_by_split[split].add(stem_key)
+        image_checksum = _sha256(image)
+        image_checksum_splits.setdefault(image_checksum, set()).add(split)
+        rows, current_source_counts, current_excluded_counts = _parse_label(label, source_taxonomy, mapped, excluded)
+        source_counts.update(current_source_counts)
+        excluded_counts.update(current_excluded_counts)
+        source_empty_negative = not current_source_counts
+        exclusion_created_negative = bool(current_source_counts) and not rows
+        if exclusion_created_negative and chosen_policy == "exclude_image":
+            continue
+        label_text = _label_text(rows)
+        target_counts.update(class_id for class_id, _ in rows)
+        output_split = _output_split_directory(split)
+        destination_image = f"images/{output_split}/{image.name}"
+        destination_label = f"labels/{output_split}/{image.stem}.txt"
+        samples.append(PlannedSample(split, sample_id, group_id, image, destination_image, destination_label, label_text, image_checksum, tuple(class_id for class_id, _ in rows), source_empty_negative, exclusion_created_negative))
+    if not samples:
+        raise DatasetReleaseError("mapping and empty-image policy leave no samples for the release.")
+    leaking_checksums = [checksum for checksum, split_names in image_checksum_splits.items() if len(split_names) > 1]
+    if leaking_checksums:
+        raise DatasetReleaseError("source file checksums reveal duplicate images across splits; split leakage blocks release generation.")
+
+    inputs = {
+        "source_manifest_sha256": _sha256(manifest_path),
+        "source_inspection_report_sha256": _sha256(inspection_report_path),
+        "source_dataset_yaml_sha256": _sha256(source_yaml_path),
+        "mapping_configuration_sha256": _sha256(mapping_path),
+    }
+    identity_material = {
+        "tool": {"name": TOOL_NAME, "version": TOOL_VERSION}, "release_name": release_name, "release_version": release_version,
+        "input_checksums": inputs,
+        "samples": [{"split": sample.split, "sample_id": sample.sample_id, "image": sample.destination_image, "image_sha256": sample.image_checksum, "label": sample.destination_label, "label_sha256": hashlib.sha256(sample.label_text.encode("utf-8")).hexdigest()} for sample in samples],
+    }
+    commit, dirty = _git_metadata()
+    plan = ReleasePlan(source_root, manifest_path, source_yaml_path, inspection_report_path, mapping_path, output_root, release_root, release_name, release_version, chosen_policy, source_manifest, mapping_config, tuple(samples), dict(source_counts), dict(target_counts), dict(excluded_counts), inputs, hashlib.sha256(_json_text(identity_material).encode("utf-8")).hexdigest(), commit, dirty)
+    manifest_issues = manifest_validator.validate_manifest(_release_manifest(plan))
+    if manifest_issues:
+        raise DatasetReleaseError("release metadata cannot produce a valid manifest:\n" + manifest_validator.format_issues(manifest_issues))
+    return plan
+
+
+def _release_manifest(plan: ReleasePlan) -> dict[str, object]:
+    metadata = _release_metadata(plan.mapping, plan.release_name, plan.release_version)
+    source_taxonomy = _config_source_taxonomy(plan.mapping)
+    mapped, excluded, _ = _class_decisions(plan.mapping, source_taxonomy)
+    split_samples: dict[str, list[dict[str, object]]] = {split: [] for split in SPLITS}
+    for sample in plan.samples:
+        split_samples[sample.split].append({
+            "sample_id": sample.sample_id, "image_path": sample.destination_image, "label_path": sample.destination_label,
+            "group_id": sample.group_id, "labelled": True, "checksum": f"sha256:{sample.image_checksum}",
+            "annotation_summary": {"bounding_box_count": len(sample.annotation_class_ids), "class_ids": list(sample.annotation_class_ids)},
+        })
+    return {
+        "schema_version": "1.0.0", "dataset": metadata["dataset"], "source_provenance": metadata["source_provenance"], "licence": metadata["licence"],
+        "taxonomy": {
+            "target_classes": [{"id": class_id, "name": name} for class_id, name in CANONICAL_TAXONOMY],
+            "class_mappings": [{"source_class": source_taxonomy[source_id], "target_class_id": target_id, "target_class_name": target_name, "mapping_rationale": rationale, "review_decision": "mapped"} for source_id, (target_id, target_name, rationale) in sorted(mapped.items())],
+            "excluded_source_classes": [{"source_class": source_taxonomy[source_id], "reason": reason} for source_id, reason in sorted(excluded.items())],
+            "unmapped_source_classes": [], "bounding_box_coordinate_format": "normalized_xywh",
+        },
+        "splits": {split: {"samples": split_samples[split]} for split in SPLITS},
+        "quality": {"image_count": len(plan.samples), "annotation_count": sum(plan.target_counts.values()), "duplicate_count": 0, "corrupt_file_count": 0, "invalid_annotation_count": 0, "excluded_sample_count": len(_source_samples(plan.source_manifest)) - len(plan.samples), "quality_review_status": metadata["quality_review_status"], "known_limitations": metadata["known_limitations"], "checksums": {"release_identity": f"sha256:{plan.release_identity}"}},
+        "storage_release": metadata["storage_release"],
+    }
+
+
+def _report_payload(plan: ReleasePlan, status: str, *, output_checksums: Mapping[str, str] | None = None, verification: Mapping[str, object] | None = None) -> dict[str, object]:
+    split_counts = {split: sum(1 for sample in plan.samples if sample.split == split) for split in SPLITS}
+    source_split_counts = {split: 0 for split in SPLITS}
+    for split, _ in _source_samples(plan.source_manifest):
+        source_split_counts[split] += 1
+    return {
+        "tool": {"name": TOOL_NAME, "version": TOOL_VERSION, "network_access": False}, "status": status,
+        "release": {"name": plan.release_name, "version": plan.release_version, "identity_sha256": plan.release_identity, "release_decision": _release_metadata(plan.mapping, plan.release_name, plan.release_version)["dataset"]["release_decision"]},
+        "source": {"dataset_id": _mapping(plan.source_manifest["dataset"], "source manifest dataset")["id"], "source_version": _mapping(plan.source_manifest["dataset"], "source manifest dataset")["source_version"], "input_checksums": plan.input_checksums},
+        "counts": {"source_images_by_split": source_split_counts, "output_images_by_split": split_counts, "output_label_files": len(plan.samples), "excluded_images": sum(source_split_counts.values()) - len(plan.samples), "source_annotations_by_class": [{"id": key, "name": _config_source_taxonomy(plan.mapping)[key], "count": plan.source_counts.get(key, 0)} for key in sorted(_config_source_taxonomy(plan.mapping))], "mapped_annotations_by_target_class": [{"id": key, "name": CANONICAL_TARGETS[key], "count": plan.target_counts.get(key, 0)} for key in sorted(CANONICAL_TARGETS)], "excluded_annotations_by_source_class": [{"id": key, "name": _config_source_taxonomy(plan.mapping)[key], "count": plan.excluded_counts.get(key, 0)} for key in sorted(plan.excluded_counts)], "retained_negative_images": sum(1 for sample in plan.samples if sample.source_empty_negative or sample.exclusion_created_negative), "source_empty_negative_images": sum(1 for sample in plan.samples if sample.source_empty_negative), "exclusion_created_negative_images": sum(1 for sample in plan.samples if sample.exclusion_created_negative), "file_copy_total": len(plan.samples) * 2},
+        "empty_image_policy": plan.empty_image_policy, "output_checksums": dict(sorted((output_checksums or {}).items())), "verification": dict(verification or {}),
+        "intended_output_files": sorted({"dataset.yaml", "release_manifest.json", "release_build_report.json", "release_build_report.md", "release_checksums.json", *(sample.destination_image for sample in plan.samples), *(sample.destination_label for sample in plan.samples)}),
+        "git": {"commit": plan.git_commit, "dirty": plan.git_dirty},
+        "warnings": ["A completed release is not legal, privacy, ethical, model-quality, safety, or production approval."], "failures": [],
+    }
+
+
+def _markdown_report(report: Mapping[str, object]) -> str:
+    def table(headers: Sequence[str], rows: Sequence[Sequence[object]]) -> list[str]:
+        return [
+            "| " + " | ".join(headers) + " |",
+            "| " + " | ".join("---" for _ in headers) + " |",
+            *("| " + " | ".join(str(value) for value in row) + " |" for row in rows),
+        ]
+
+    counts = _mapping(report["counts"], "report counts")
+    release = _mapping(report["release"], "release")
+    source = _mapping(report["source"], "source")
+    lines = [
+        "# WalkBuddy navigation dataset release build",
+        "",
+        f"Status: `{report['status']}`.",
+        "",
+        "## Release",
+        "",
+        f"- Name: `{release['name']}`",
+        f"- Version: `{release['version']}`",
+        f"- Decision: `{release['release_decision']}`",
+        f"- Deterministic identity: `{release['identity_sha256']}`",
+        f"- Source dataset: `{source['dataset_id']}` version `{source['source_version']}`",
+        "",
+        "## Sample counts",
+        "",
+    ]
+    source_split_counts = _mapping(counts["source_images_by_split"], "source split counts")
+    output_split_counts = _mapping(counts["output_images_by_split"], "output split counts")
+    lines.extend(
+        table(
+            ["Split", "Source images", "Released images"],
+            [(split, source_split_counts[split], output_split_counts[split]) for split in SPLITS],
+        )
+    )
+    lines.extend(
+        [
+            "",
+            f"- Excluded images: {_integer(counts['excluded_images'], 'excluded images')}",
+            f"- Retained negative images: {_integer(counts['retained_negative_images'], 'retained negative images')}",
+            f"- Source-empty negatives retained: {_integer(counts['source_empty_negative_images'], 'source-empty negatives')}",
+            f"- Exclusion-created negatives retained: {_integer(counts['exclusion_created_negative_images'], 'exclusion-created negatives')}",
+            f"- Output label files: {_integer(counts['output_label_files'], 'output label files')}",
+            f"- File copies: {_integer(counts['file_copy_total'], 'file copy total')}",
+            "",
+            "## Annotation counts",
+            "",
+        ]
+    )
+    lines.extend(
+        table(
+            ["Source ID", "Class", "Source annotations", "Excluded annotations"],
+            [
+                (item["id"], item["name"], item["count"], next((excluded["count"] for excluded in counts["excluded_annotations_by_source_class"] if excluded["id"] == item["id"]), 0))
+                for item in counts["source_annotations_by_class"]
+            ],
+        )
+    )
+    lines.extend(["", "## Canonical mapped annotations", ""])
+    lines.extend(
+        table(
+            ["Target ID", "Class", "Mapped annotations"],
+            [(item["id"], item["name"], item["count"]) for item in counts["mapped_annotations_by_target_class"]],
+        )
+    )
+    lines.extend(["", "## Verification and checksums", ""])
+    verification = _mapping(report["verification"], "verification")
+    lines.extend(f"- `{key}`: `{value}`" for key, value in sorted(verification.items()))
+    lines.extend(f"- Input `{key}`: `{value}`" for key, value in sorted(_mapping(source["input_checksums"], "input checksums").items()))
+    lines.extend(f"- Output `{key}`: `{value}`" for key, value in sorted(_mapping(report["output_checksums"], "output checksums").items()))
+    lines.extend(["", "## Warnings and failures", ""])
+    warnings = _list(report["warnings"], "warnings")
+    failures = _list(report["failures"], "failures")
+    lines.extend(f"- Warning: {warning}" for warning in warnings) if warnings else lines.append("- No warnings.")
+    lines.extend(f"- Failure: {failure}" for failure in failures) if failures else lines.append("- No failures.")
+    lines.extend(["", "## Limitations", "", "- A completed release does not establish legal, privacy, ethical, model-quality, safety, or production approval.", "- Only an explicitly reviewed manifest decision may make this release eligible for training.", ""])
+    return "\n".join(lines)
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="\n")
+
+
+def _inspection_metadata() -> dict[str, object]:
+    return {"class_mapping": [{"source_class_id": class_id, "target_class_id": class_id, "target_class_name": name, "mapping_rationale": "Canonical release verification identity mapping."} for class_id, name in CANONICAL_TAXONOMY], "excluded_source_classes": [], "unmapped_source_classes": []}
+
+
+def _verify_staging(plan: ReleasePlan, staging: Path, manifest: Mapping[str, object]) -> dict[str, object]:
+    issues = manifest_validator.validate_manifest(manifest, dataset_root=staging, check_files=True)
+    if issues:
+        raise DatasetReleaseError("generated release manifest is invalid:\n" + manifest_validator.format_issues(issues))
+    for sample in plan.samples:
+        image = staging / sample.destination_image
+        label = staging / sample.destination_label
+        if not image.is_file() or not label.is_file() or not _is_beneath(staging, image) or not _is_beneath(staging, label):
+            raise DatasetReleaseError("generated release contains a missing or escaped destination file.")
+        rows, _, _ = _parse_label(label, dict(CANONICAL_TAXONOMY), {key: (key, name, "identity") for key, name in CANONICAL_TAXONOMY}, {})
+        if tuple(class_id for class_id, _ in rows) != sample.annotation_class_ids:
+            raise DatasetReleaseError("generated release label verification found a changed class mapping.")
+    metadata_path = staging / ".release_inspection_metadata.json"
+    group_map_path = staging / ".release_groups.json"
+    try:
+        _write_text(metadata_path, _json_text(_inspection_metadata()))
+        _write_text(group_map_path, _json_text({"groups": {sample.destination_image: sample.group_id for sample in plan.samples}}))
+        report, _ = inspector.inspect_dataset(staging, staging / "dataset.yaml", metadata_path=metadata_path, group_map_path=group_map_path, generate_manifest=False)
+    finally:
+        metadata_path.unlink(missing_ok=True)
+        group_map_path.unlink(missing_ok=True)
+    if report.get("quality_verdict") not in {"pass", "pass_with_warnings"}:
+        findings = report.get("validation_errors")
+        raise DatasetReleaseError(
+            "generated release fails the existing candidate dataset inspector: "
+            + json.dumps(findings, sort_keys=True)
+        )
+    return {"manifest_validator": "pass", "candidate_inspector_verdict": report.get("quality_verdict"), "destination_sample_count": len(plan.samples)}
+
+
+def _output_checksums(staging: Path) -> dict[str, str]:
+    return {path.relative_to(staging).as_posix(): _sha256(path) for path in sorted(staging.rglob("*")) if path.is_file()}
+
+
+def build_release(plan: ReleasePlan, *, confirm_build: bool) -> dict[str, object]:
+    """Construct a verified release only after explicit caller confirmation."""
+    if not confirm_build:
+        raise DatasetReleaseError("real release creation requires --confirm-build; use --dry-run first.")
+    if plan.release_root.exists():
+        raise DatasetReleaseError("completed or partial release path already exists and is protected from overwrite.")
+    plan.release_root.parent.mkdir(parents=True, exist_ok=True)
+    staging = plan.release_root.parent / f".{plan.release_root.name}.staging-{uuid.uuid4().hex}"
+    try:
+        staging.mkdir()
+        for sample in plan.samples:
+            destination_image = staging / sample.destination_image
+            destination_label = staging / sample.destination_label
+            destination_image.parent.mkdir(parents=True, exist_ok=True)
+            destination_label.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(sample.source_image, destination_image)
+            _write_text(destination_label, sample.label_text)
+        _write_text(staging / "dataset.yaml", _canonical_yaml(include_test=any(sample.split == "test" for sample in plan.samples)))
+        manifest = _release_manifest(plan)
+        _write_text(staging / "release_manifest.json", _json_text(manifest))
+        verification = _verify_staging(plan, staging, manifest)
+        checksums = _output_checksums(staging)
+        for relative_path, checksum in checksums.items():
+            if _sha256(staging / relative_path) != checksum:
+                raise DatasetReleaseError("generated release checksum verification failed.")
+        _write_text(staging / "release_checksums.json", _json_text({"algorithm": "sha256", "release_identity": plan.release_identity, "files": checksums}))
+        report = _report_payload(plan, "completed", output_checksums=checksums, verification=verification)
+        _write_text(staging / "release_build_report.json", _json_text(report))
+        _write_text(staging / "release_build_report.md", _markdown_report(report))
+        staging.replace(plan.release_root)
+        return report
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def dry_run(plan: ReleasePlan) -> dict[str, object]:
+    """Return the complete plan without creating directories or copying files."""
+    return _report_payload(plan, "planned", verification={"validation": "completed without filesystem writes"})
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a reviewed local YOLO dataset release in the canonical WalkBuddy taxonomy.")
+    parser.add_argument("--source-root", required=True, type=Path, help="Controlled local source dataset root.")
+    parser.add_argument("--source-yaml", required=True, type=Path, help="Source YOLO dataset YAML beneath --source-root.")
+    parser.add_argument("--source-manifest", required=True, type=Path, help="Validated local source manifest JSON.")
+    parser.add_argument("--inspection-report", required=True, type=Path, help="Passing local candidate-inspection JSON report.")
+    parser.add_argument("--mapping-config", required=True, type=Path, help="Reviewed local source-to-WalkBuddy mapping JSON or YAML.")
+    parser.add_argument("--output-root", required=True, type=Path, help="Controlled external root for generated releases.")
+    parser.add_argument("--release-name", required=True, help="Release dataset identifier, matching mapping release_metadata.dataset.id.")
+    parser.add_argument("--release-version", required=True, help="Version component for the controlled release directory.")
+    parser.add_argument("--empty-image-policy", choices=sorted(EMPTY_POLICIES), help="Override the reviewed mapping policy for labels emptied by exclusion.")
+    parser.add_argument("--dry-run", action="store_true", help="Validate and print the release plan without writing files.")
+    parser.add_argument("--confirm-build", action="store_true", help="Explicitly permit creation of the copied release after validation.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.dry_run and args.confirm_build:
+        print("Dataset release build failed: --dry-run and --confirm-build cannot be used together.", file=sys.stderr)
+        return 1
+    try:
+        plan = create_release_plan(source_root=args.source_root, source_yaml_path=args.source_yaml, source_manifest_path=args.source_manifest, inspection_report_path=args.inspection_report, mapping_path=args.mapping_config, output_root=args.output_root, release_name=args.release_name, release_version=args.release_version, empty_image_policy=args.empty_image_policy)
+        report = dry_run(plan) if args.dry_run else build_release(plan, confirm_build=args.confirm_build)
+    except DatasetReleaseError as exc:
+        print(f"Dataset release build failed: {exc}", file=sys.stderr)
+        return 1
+    print(_json_text(report), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ML_side/tools/inspect_candidate_dataset.py
+++ b/ML_side/tools/inspect_candidate_dataset.py
@@ -895,6 +895,9 @@ def inspect_dataset(
         "dataset_identity": metadata.get("dataset", {}).get("id")
         if isinstance(metadata, Mapping) and isinstance(metadata.get("dataset"), Mapping)
         else None,
+        "dataset_source_version": metadata.get("dataset", {}).get("source_version")
+        if isinstance(metadata, Mapping) and isinstance(metadata.get("dataset"), Mapping)
+        else None,
         "settings": {"image_decoding": decode_images, "checksums": checksums},
         "splits": split_reports,
         "source_taxonomy": [{"id": class_id, "name": name} for class_id, name in source_taxonomy.items()],
@@ -997,6 +1000,11 @@ def render_markdown_report(report: Mapping[str, object]) -> str:
         "",
         f"Tool: `{report['tool']['name']}` {report['tool']['version']}.",  # type: ignore[index]
         f"Execution time (runtime metadata): {report['execution']['time_utc']}."  # type: ignore[index]
+        "",
+        "## Source identity",
+        "",
+        f"- Dataset identity: `{report.get('dataset_identity') or 'not recorded'}`.",
+        f"- Source version: `{report.get('dataset_source_version') or 'not recorded'}`.",
         "",
         "## Quality verdict",
         "",


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2><p>Adds a controlled, deterministic dataset-release builder for the WalkBuddy navigation-model pipeline.</p><p>The builder converts an already inspected local YOLO dataset into a standalone canonical release using the approved eight-class WalkBuddy taxonomy. It applies explicit reviewed class mappings, removes explicitly excluded annotations, verifies release integrity, and produces deterministic manifests, reports and checksum evidence.</p><p>No real dataset, generated release, model or weight file is included in this pull request.</p><h2>Changes</h2><ul><li><p>adds <code inline="">ML_side/tools/build_navigation_dataset_release.py</code>;</p></li><li><p>adds <code inline="">ML_side/config/dataset_release.example.json</code>;</p></li><li><p>adds comprehensive release-builder tests;</p></li><li><p>updates dataset documentation;</p></li><li><p>extends candidate inspection reports with <code inline="">dataset_source_version</code>;</p></li><li><p>adds explicit compatibility handling for older inspection reports;</p></li><li><p>verifies generated releases with the existing manifest validator and dataset inspector;</p></li><li><p>verifies generated releases against the training-pipeline dry run.</p></li></ul><h2>Approved WalkBuddy taxonomy</h2>
ID | Class
-- | --
0 | person
1 | stairs
2 | door
3 | chair
4 | table
5 | pole
6 | bicycle
7 | vehicle

<h2>Mapping behaviour</h2><p>Every source class must have exactly one explicit decision:</p><ul><li><p>mapped to one approved WalkBuddy class;</p></li><li><p>excluded with a documented reason;</p></li><li><p>unresolved.</p></li></ul><p>Unresolved, duplicate, conflicting or unknown mappings block release generation.</p><p>The builder never infers mappings through class-name similarity.</p><p>It records:</p><ul><li><p>source-class annotation totals;</p></li><li><p>mapped target-class totals;</p></li><li><p>excluded annotation totals;</p></li><li><p>retained negative samples;</p></li><li><p>excluded images;</p></li><li><p>per-split image, label and annotation counts.</p></li></ul><h2>Release eligibility</h2><p>Release construction requires:</p><ul><li><p>a valid source dataset manifest;</p></li><li><p>complete source files;</p></li><li><p>an approved machine-learning licence review;</p></li><li><p>a non-failing dataset inspection report;</p></li><li><p>exact source identity and version agreement;</p></li><li><p>exact source taxonomy agreement between the inspection report, dataset YAML and mapping configuration;</p></li><li><p>no unresolved mappings;</p></li><li><p>no cross-split duplicate leakage;</p></li><li><p>no configured group leakage;</p></li><li><p>safe controlled local paths.</p></li></ul><p>Structural validation alone does not establish legal, privacy, ethical or production approval.</p><h2>Negative-image policies</h2><p>The builder supports:</p><h3><code inline="">retain_negative</code></h3><p>When exclusions remove every annotation from an image:</p><ul><li><p>the image remains in its original split;</p></li><li><p>an empty label file is produced;</p></li><li><p>the image is recorded as a retained negative sample.</p></li></ul><h3><code inline="">exclude_image</code></h3><p>When exclusions remove every annotation from an image:</p><ul><li><p>the image and label are omitted from the release;</p></li><li><p>counts and manifest samples are updated consistently.</p></li></ul><p>Images that were originally valid empty negative samples remain in their original split under either policy.</p><h2>Dry-run and confirmed build</h2><p>Dry-run:</p><ul><li><p>validates every input;</p></li><li><p>calculates mappings and exclusions;</p></li><li><p>calculates expected release counts;</p></li><li><p>displays the release plan;</p></li><li><p>performs no copying;</p></li><li><p>creates no release directory;</p></li><li><p>modifies no source files;</p></li><li><p>performs no network access.</p></li></ul><p>Real construction requires:</p><pre><code class="language-text">--confirm-build
</code></pre><p><code inline="">--dry-run</code> and <code inline="">--confirm-build</code> cannot be used together.</p><h2>Build and promotion safety</h2><p>The source dataset remains read-only.</p><p>The builder:</p><ul><li><p>copies files rather than creating dataset symlinks;</p></li><li><p>stages the release in a unique temporary directory beneath the controlled output root;</p></li><li><p>prevents output beneath the source dataset root;</p></li><li><p>protects existing completed releases;</p></li><li><p>validates the staged release before promotion;</p></li><li><p>promotes the release atomically where supported;</p></li><li><p>cleans staging after failures and interruptions;</p></li><li><p>never reports a failed or partial build as completed.</p></li></ul><h2>Determinism and checksums</h2><p>Substantive release identity excludes:</p><ul><li><p>timestamps;</p></li><li><p>staging paths;</p></li><li><p>machine-specific absolute paths;</p></li><li><p>Git dirty state;</p></li><li><p>nondeterministic directory ordering.</p></li></ul><p>SHA-256 evidence is recorded for:</p><ul><li><p>source manifest;</p></li><li><p>source inspection report;</p></li><li><p>source dataset YAML;</p></li><li><p>mapping configuration;</p></li><li><p>generated dataset YAML;</p></li><li><p>generated release manifest;</p></li><li><p>copied images;</p></li><li><p>rewritten labels;</p></li><li><p>substantive release outputs.</p></li></ul><p>Large files are hashed in chunks.</p><p>Checksum generation avoids recursive checksum-file churn.</p><h2>Generated release</h2><p>A completed canonical release contains, where applicable:</p><pre><code class="language-text">images/train
images/val
images/test

labels/train
labels/val
labels/test

dataset.yaml
release_manifest.json
release_build_report.json
release_build_report.md
release_checksums.json
</code></pre><p>The generated <code inline="">dataset.yaml</code>:</p><ul><li><p>uses release-relative paths;</p></li><li><p>contains <code inline="">nc: 8</code>;</p></li><li><p>uses the exact approved class order;</p></li><li><p>cannot trigger remote downloads;</p></li><li><p>is compatible with the existing training pipeline.</p></li></ul><h2>Generated manifest status</h2><p>Generated manifests default to:</p><pre><code class="language-text">under_review
</code></pre><p>The builder does not automatically claim training approval.</p><p><code inline="">approved_for_training</code> requires complete explicit reviewed metadata, including approved machine-learning licence evidence and completed quality review.</p><p>Reviewer names, approval values and licence evidence are never fabricated.</p><h2>Verification</h2><ul><li><p>release-builder tests: <strong>54 passed</strong>;</p></li><li><p>updated inspector tests: <strong>38 passed</strong>;</p></li><li><p>complete ML-side test suite: <strong>198 passed</strong>;</p></li><li><p>Python syntax compilation passed;</p></li><li><p>CLI help passed;</p></li><li><p>fictional dry-run passed;</p></li><li><p>fictional confirmed build passed;</p></li><li><p>mapping and exclusion tests passed;</p></li><li><p>negative-image policy tests passed;</p></li><li><p>licence and inspection eligibility tests passed;</p></li><li><p>source identity and taxonomy checks passed;</p></li><li><p>traversal and symlink checks passed;</p></li><li><p>staging and failure-cleanup tests passed;</p></li><li><p>deterministic-output and checksum tests passed;</p></li><li><p>generated manifest validation passed;</p></li><li><p>generated release inspection passed;</p></li><li><p>standalone training-pipeline dry run passed;</p></li><li><p><code inline="">git diff --check</code> passed.</p></li></ul><p>The standalone compatibility test removes the fictional source dataset after construction, proving that the generated release does not rely on files remaining in the source dataset.</p><h2>Scope boundaries</h2><p>This pull request does not:</p><ul><li><p>include or download a real dataset;</p></li><li><p>create a real dataset release in Git;</p></li><li><p>train a model;</p></li><li><p>modify model weights;</p></li><li><p>modify the existing <code inline="">best.pt</code>;</p></li><li><p>change production-backend behaviour;</p></li><li><p>change frontend behaviour;</p></li><li><p>install dependencies;</p></li><li><p>perform network requests;</p></li><li><p>establish legal, privacy or ethical approval;</p></li><li><p>prove model quality, safety or production readiness.</p></li></ul><h2>Compatibility note</h2><p>Existing inspection reports must be regenerated because release identity validation now requires:</p><pre><code class="language-text">dataset_source_version
</code></pre><p>Older reports fail with a clear regeneration message rather than being silently accepted.</p><h2>Follow-up</h2><ul><li><p>obtain an appropriate real candidate dataset;</p></li><li><p>run the candidate dataset inspector;</p></li><li><p>define and review all source-class mappings;</p></li><li><p>generate a canonical WalkBuddy release;</p></li><li><p>review its reports and checksum evidence;</p></li><li><p>explicitly approve the release for internal training;</p></li><li><p>run the training-pipeline dry run;</p></li><li><p>perform a small controlled training smoke test;</p></li><li><p>train and evaluate the first navigation-model candidate.</p></li></ul></body></html><!--EndFragment-->
</body>
</html>