### PR TITLE
Fix dataset release path validation on POSIX

### DIFF
--- a/ML_side/tests/test_build_navigation_dataset_release.py
+++ b/ML_side/tests/test_build_navigation_dataset_release.py
@@ -6,7 +6,7 @@ import base64
 import json
 import shutil
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 
@@ -378,6 +378,15 @@ def test_nonlocal_cli_input_forms_are_rejected(tmp_path: Path, unsafe: str) -> N
     paths = fixture(tmp_path)
     with pytest.raises(builder.DatasetReleaseError, match="controlled local filesystem path"):
         builder.create_release_plan(source_root=paths["source"], source_yaml_path=paths["yaml"], source_manifest_path=paths["manifest"], inspection_report_path=paths["report"], mapping_path=paths["mapping"], output_root=Path(unsafe), release_name="fictional-release", release_version="v1")
+
+
+@pytest.mark.parametrize("unsafe", ["http://example.invalid/source", "https://example.invalid/source", "file://controlled/source"])
+def test_posix_normalised_uri_inputs_are_rejected_before_filesystem_resolution(unsafe: str) -> None:
+    posix_value = PurePosixPath(unsafe)
+    assert str(posix_value).startswith(unsafe.split(":", 1)[0] + ":/")
+
+    with pytest.raises(builder.DatasetReleaseError, match="controlled local filesystem path"):
+        builder._reject_nonlocal_path(posix_value, "output root")
 
 
 def test_repository_output_root_and_wrong_mapping_schema_version_are_rejected(tmp_path: Path) -> None:

--- a/ML_side/tools/build_navigation_dataset_release.py
+++ b/ML_side/tools/build_navigation_dataset_release.py
@@ -13,6 +13,7 @@ import copy
 import hashlib
 import json
 import math
+import re
 import shutil
 import subprocess
 import sys
@@ -40,6 +41,7 @@ CANONICAL_TAXONOMY = manifest_validator.APPROVED_TAXONOMY
 CANONICAL_TARGETS = manifest_validator.APPROVED_TARGETS
 SPLITS = ("train", "validation", "test")
 EMPTY_POLICIES = frozenset({"retain_negative", "exclude_image"})
+URI_SCHEME = re.compile(r"^[a-z][a-z0-9+.-]*:", re.IGNORECASE)
 
 
 class DatasetReleaseError(Exception):
@@ -132,8 +134,10 @@ def _reject_nonlocal_path(path: Path, label: str) -> None:
     raw = str(path)
     folded = raw.casefold()
     windows_path = PureWindowsPath(raw)
+    uri_scheme = URI_SCHEME.match(raw)
     if (
-        folded.startswith(("http://", "https://", "http:\\", "https:\\", "file:"))
+        (uri_scheme is not None and len(uri_scheme.group()) > 2)
+        or folded.startswith(("http://", "https://", "http:\\", "https:\\", "file:"))
         or raw.startswith(("\\\\", "//"))
         or (windows_path.drive.endswith(":") and len(windows_path.drive) > 2)
         or (windows_path.drive and not windows_path.is_absolute())


### PR DESCRIPTION
## Summary

Fixes a cross-platform path-validation issue in the controlled navigation dataset release builder.

On POSIX systems such as Google Colab/Linux, `pathlib` normalises URL-like inputs such as:

`https://example.invalid/source`

into a path resembling:

`https:/example.invalid/source`

This caused the existing non-local path validation to miss the URI and later fail with the unrelated repository output-boundary error.

## Changes

- detect URI schemes before filesystem resolution;
- preserve existing rejection of HTTP/HTTPS/file URIs;
- preserve UNC and Windows drive-relative path protections;
- add explicit POSIX-normalisation regression tests for:
  - `http`
  - `https`
  - `file`

No dataset, model, training, backend, frontend, or unrelated code was changed.

## Verification

Windows:

- release-builder tests: **57 passed**
- full ML suite: **201 passed**
- CLI `--help`: passed
- `git diff --check`: passed

Google Colab / Linux:

- Tesla T4 runtime
- exact commit tested: `3c0c90894e8a099c51cf8bd056146c9d19b28d16`
- full ML suite: **201 passed**

The Linux verification was performed in the same environment where the original regression was discovered.

## Scope

Changed only:

- `ML_side/tools/build_navigation_dataset_release.py`
- `ML_side/tests/test_build_navigation_dataset_release.py`