### PR TITLE
Harden ML runtime readiness and observability

### DIFF
--- a/software_side/walkbuddy_reactNative/backend/Dockerfile
+++ b/software_side/walkbuddy_reactNative/backend/Dockerfile
@@ -33,6 +33,6 @@ ENV TTS_RATE=170
 
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
-  CMD curl -f http://localhost:8000/docs || exit 1
+  CMD curl -f http://localhost:8000/ml/ready || exit 1
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/software_side/walkbuddy_reactNative/backend/main.py
+++ b/software_side/walkbuddy_reactNative/backend/main.py
@@ -10,6 +10,7 @@ import uuid
 import hashlib
 import secrets
 import re
+import time
 
 _EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]{2,}$")
 import json
@@ -72,6 +73,12 @@ from routers import ai_service as ai_router
 from routers import helpers as helpers_router
 from routers import auth as auth_router
 from predictive_path import router as pred_router
+from ml_runtime import (
+    MLRuntimeState,
+    ModelMetadataError,
+    capture_model_lineage,
+    router as ml_runtime_router,
+)
 
 # Telemetry
 from telemetry import init_telemetry
@@ -185,17 +192,48 @@ def _whisper_transcribe(model, path: str) -> str:
 async def lifespan(app: FastAPI):
     logger.info("🚀 Backend startup")
 
+    # Runtime state is reset for each application startup and is shared by
+    # REST and WebSocket inference worker threads.
+    app.state.ml_runtime = MLRuntimeState()
+
     # --- init DB ---
     init_database()
 
     # --- load YOLO ---
+    yolo_load_started = time.perf_counter()
     try:
-        logger.info(f"Loading YOLO from {YOLO_MODEL_PATH}")
+        if not YOLO_MODEL_PATH.is_file():
+            raise FileNotFoundError(YOLO_MODEL_PATH)
+        logger.info("Loading YOLO model artifact: %s", YOLO_MODEL_PATH.name)
         app.state.yolo = YOLO(str(YOLO_MODEL_PATH))
-        logger.info("✅ YOLO ready")
-    except Exception as e:
-        logger.error(f"❌ YOLO load failed: {e}")
+    except FileNotFoundError:
+        load_duration_ms = (time.perf_counter() - yolo_load_started) * 1000
+        logger.error("YOLO load failed: model artifact is missing")
         app.state.yolo = None
+        app.state.ml_runtime.set_model_load_failure(
+            YOLO_MODEL_PATH, load_duration_ms, "model_file_missing"
+        )
+    except Exception:
+        load_duration_ms = (time.perf_counter() - yolo_load_started) * 1000
+        logger.exception("YOLO load failed")
+        app.state.yolo = None
+        app.state.ml_runtime.set_model_load_failure(
+            YOLO_MODEL_PATH, load_duration_ms, "model_load_failed"
+        )
+    else:
+        load_duration_ms = (time.perf_counter() - yolo_load_started) * 1000
+        try:
+            app.state.ml_runtime.set_model_lineage(
+                capture_model_lineage(YOLO_MODEL_PATH, app.state.yolo, load_duration_ms)
+            )
+        except (ModelMetadataError, OSError):
+            # The model is usable even if optional lineage capture fails; retain
+            # a safe status instead of exposing the operational exception.
+            logger.exception("YOLO model metadata capture failed")
+            app.state.ml_runtime.set_model_metadata_failure(
+                YOLO_MODEL_PATH, load_duration_ms
+            )
+        logger.info("✅ YOLO ready")
 
     # --- load EasyOCR ---
     try:
@@ -275,6 +313,9 @@ app = FastAPI(
     title="WalkBuddy Unified Backend",
     lifespan=lifespan,
 )
+app.state.yolo = None
+app.state.ocr_reader = None
+app.state.ml_runtime = MLRuntimeState()
 
 # =========================
 # 7. MIDDLEWARE
@@ -283,6 +324,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         excluded_paths = {
             "/ping",
+            "/ml/ready",
             "/docs",
             "/openapi.json",
             "/redoc",
@@ -340,6 +382,7 @@ app.include_router(helpers_router.router)
 app.include_router(stt.router)
 app.include_router(auth_router.router)
 app.include_router(pred_router.router)
+app.include_router(ml_runtime_router)
 
 # =========================
 # 9. TELEMETRY

--- a/software_side/walkbuddy_reactNative/backend/ml_runtime/__init__.py
+++ b/software_side/walkbuddy_reactNative/backend/ml_runtime/__init__.py
@@ -1,0 +1,23 @@
+"""Operational state and endpoints for the WalkBuddy ML runtime."""
+
+from .errors import (
+    inference_failed_error,
+    model_unavailable_error,
+    websocket_error_payload,
+)
+from .metrics import InferenceMetrics
+from .model_info import ModelLineage, ModelMetadataError, capture_model_lineage
+from .router import router
+from .state import MLRuntimeState
+
+__all__ = [
+    "InferenceMetrics",
+    "MLRuntimeState",
+    "ModelLineage",
+    "ModelMetadataError",
+    "capture_model_lineage",
+    "inference_failed_error",
+    "model_unavailable_error",
+    "router",
+    "websocket_error_payload",
+]

--- a/software_side/walkbuddy_reactNative/backend/ml_runtime/errors.py
+++ b/software_side/walkbuddy_reactNative/backend/ml_runtime/errors.py
@@ -1,0 +1,37 @@
+"""Stable public error payloads for vision-runtime operational failures."""
+
+from __future__ import annotations
+
+
+def model_unavailable_error() -> dict[str, dict[str, str]]:
+    """Return the public response when the vision model is not ready."""
+    return {
+        "error": {
+            "code": "model_unavailable",
+            "message": "Vision model is unavailable.",
+        }
+    }
+
+
+def inference_failed_error() -> dict[str, dict[str, str]]:
+    """Return the public response when vision inference fails."""
+    return {
+        "error": {
+            "code": "inference_failed",
+            "message": "Vision inference failed.",
+        }
+    }
+
+
+def websocket_error_payload(code: str, frame_id: str | None) -> dict[str, str | None]:
+    """Return a WebSocket-safe version of a known vision-runtime error."""
+    errors = {
+        "model_unavailable": "Vision model is unavailable.",
+        "inference_failed": "Vision inference failed.",
+    }
+    return {
+        "type": "error",
+        "code": code,
+        "frame_id": frame_id,
+        "message": errors[code],
+    }

--- a/software_side/walkbuddy_reactNative/backend/ml_runtime/metrics.py
+++ b/software_side/walkbuddy_reactNative/backend/ml_runtime/metrics.py
@@ -1,0 +1,87 @@
+"""Bounded, thread-safe inference metrics for the ML runtime."""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timezone
+from math import ceil, isfinite
+from threading import Lock
+from typing import Any
+
+
+class InferenceMetrics:
+    """Keep a bounded, process-local record of completed inference timings."""
+
+    def __init__(self, latency_window_capacity: int = 256) -> None:
+        if latency_window_capacity < 1:
+            raise ValueError("latency_window_capacity must be at least one")
+        self._lock = Lock()
+        self._latencies_ms: deque[float] = deque(maxlen=latency_window_capacity)
+        self._attempts = 0
+        self._successful_inferences = 0
+        self._failed_inferences = 0
+        self._active_inferences = 0
+        self._processed_frames = 0
+        self._dropped_frames = 0
+        self._last_inference_at: str | None = None
+
+    def begin_inference(self) -> None:
+        """Record an inference attempt immediately before invoking the model."""
+        with self._lock:
+            self._attempts += 1
+            self._active_inferences += 1
+
+    def finish_inference(self, latency_ms: float, *, successful: bool) -> None:
+        """Record a completed attempt and its elapsed inference duration."""
+        try:
+            duration = float(latency_ms)
+        except (TypeError, ValueError):
+            duration = 0.0
+        if not isfinite(duration):
+            duration = 0.0
+        duration = max(0.0, duration)
+        with self._lock:
+            if self._active_inferences:
+                self._active_inferences -= 1
+            self._latencies_ms.append(duration)
+            self._last_inference_at = datetime.now(timezone.utc).isoformat()
+            if successful:
+                self._successful_inferences += 1
+                self._processed_frames += 1
+            else:
+                self._failed_inferences += 1
+
+    def record_dropped_frame(self) -> None:
+        """Record a frame only when the server deliberately drops one."""
+        with self._lock:
+            self._dropped_frames += 1
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a JSON-safe snapshot without exposing request-level data."""
+        with self._lock:
+            samples = sorted(self._latencies_ms)
+            count = len(samples)
+            return {
+                "total_attempts": self._attempts,
+                "successful_inferences": self._successful_inferences,
+                "failed_inferences": self._failed_inferences,
+                "active_inferences": self._active_inferences,
+                "processed_frames": self._processed_frames,
+                "dropped_frames": self._dropped_frames,
+                "latest_latency_ms": self._latencies_ms[-1] if count else None,
+                "mean_latency_ms": (sum(samples) / count) if count else None,
+                "p50_latency_ms": self._percentile(samples, 0.50),
+                "p95_latency_ms": self._percentile(samples, 0.95),
+                "max_latency_ms": samples[-1] if count else None,
+                "latency_window_size": count,
+                "latency_window_capacity": self._latencies_ms.maxlen,
+                "last_inference_at": self._last_inference_at,
+            }
+
+    @staticmethod
+    def _percentile(samples: list[float], percentile: float) -> float | None:
+        """Use the deterministic nearest-rank percentile for bounded samples."""
+        if not samples:
+            return None
+        index = max(0, ceil(percentile * len(samples)) - 1)
+        return samples[index]

--- a/software_side/walkbuddy_reactNative/backend/ml_runtime/model_info.py
+++ b/software_side/walkbuddy_reactNative/backend/ml_runtime/model_info.py
@@ -1,0 +1,187 @@
+"""Capture safe, startup-only lineage metadata for the active YOLO artifact."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib.metadata import version
+from pathlib import Path
+from typing import Any
+
+
+CHECKSUM_CHUNK_SIZE = 1024 * 1024
+
+
+class ModelMetadataError(ValueError):
+    """Raised when an otherwise loaded model has unusable public metadata."""
+
+
+@dataclass(frozen=True)
+class ModelLineage:
+    """The intentionally limited model details safe to expose operationally."""
+
+    loaded: bool
+    filename: str
+    sha256: str | None
+    size_bytes: int | None
+    num_classes: int | None
+    classes: list[str]
+    load_duration_ms: float
+    loaded_at: str
+    runtime: dict[str, Any]
+    failure_category: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a copy suitable for the operational model-info endpoint."""
+        return {
+            "loaded": self.loaded,
+            "filename": self.filename,
+            "sha256": self.sha256,
+            "size_bytes": self.size_bytes,
+            "num_classes": self.num_classes,
+            "classes": list(self.classes),
+            "load_duration_ms": self.load_duration_ms,
+            "loaded_at": self.loaded_at,
+            "runtime": dict(self.runtime),
+            "failure_category": self.failure_category,
+        }
+
+
+def calculate_sha256(path: Path) -> str:
+    """Return the SHA-256 of a local artifact without modifying it."""
+    digest = hashlib.sha256()
+    with path.open("rb") as model_file:
+        for chunk in iter(lambda: model_file.read(CHECKSUM_CHUNK_SIZE), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def normalise_class_names(names: object) -> list[str]:
+    """Validate Ultralytics ``model.names`` and return its ID-ordered labels."""
+    if isinstance(names, Mapping):
+        raw_items = names.items()
+    elif isinstance(names, Sequence) and not isinstance(names, (str, bytes)):
+        raw_items = enumerate(names)
+    else:
+        raise ModelMetadataError("model.names is missing or malformed")
+
+    class_names: dict[int, str] = {}
+    for raw_id, raw_name in raw_items:
+        if isinstance(raw_id, bool):
+            raise ModelMetadataError("model.names is missing or malformed")
+        try:
+            class_id = int(raw_id)
+        except (TypeError, ValueError) as exc:
+            raise ModelMetadataError("model.names is missing or malformed") from exc
+
+        if class_id < 0 or class_id in class_names:
+            raise ModelMetadataError("model.names is missing or malformed")
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise ModelMetadataError("model.names is missing or malformed")
+        class_names[class_id] = raw_name.strip()
+
+    if not class_names:
+        raise ModelMetadataError("model.names is missing or malformed")
+    return [class_names[class_id] for class_id in sorted(class_names)]
+
+
+def runtime_details() -> dict[str, Any]:
+    """Return runtime-version and compute-device information without failing startup."""
+    try:
+        ultralytics_version = version("ultralytics")
+    except Exception:
+        # Package metadata is optional; a malformed installation must not make
+        # model readiness depend on reporting its version.
+        ultralytics_version = None
+
+    runtime: dict[str, Any] = {
+        "ultralytics": ultralytics_version,
+        "torch": None,
+        "cuda_available": False,
+        "device": "unknown",
+    }
+    try:
+        import torch
+        runtime["torch"] = getattr(torch, "__version__", None)
+        cuda_available = bool(torch.cuda.is_available())
+    except Exception:
+        # This is optional operational introspection. A damaged or partial
+        # PyTorch installation must not prevent an otherwise loaded model from
+        # making the backend ready.
+        return runtime
+
+    runtime["cuda_available"] = cuda_available
+    if not cuda_available:
+        runtime["device"] = "cpu"
+        return runtime
+
+    try:
+        runtime["device"] = f"cuda:0 ({torch.cuda.get_device_name(0)})"
+    except Exception:
+        runtime["device"] = "cuda"
+    return runtime
+
+
+def capture_model_lineage(
+    model_path: Path, model: object, load_duration_ms: float
+) -> ModelLineage:
+    """Capture safe lineage once after an already-loaded local model succeeds."""
+    path = model_path.resolve()
+    if not path.is_file():
+        raise ModelMetadataError("model artifact is not a file")
+    try:
+        class_names = normalise_class_names(model.names)
+    except ModelMetadataError:
+        raise
+    except Exception as exc:
+        raise ModelMetadataError("model.names is missing or malformed") from exc
+
+    return ModelLineage(
+        loaded=True,
+        filename=path.name,
+        sha256=calculate_sha256(path),
+        size_bytes=path.stat().st_size,
+        num_classes=len(class_names),
+        classes=class_names,
+        load_duration_ms=round(float(load_duration_ms), 3),
+        loaded_at=datetime.now(timezone.utc).isoformat(),
+        runtime=runtime_details(),
+    )
+
+
+def unavailable_model_lineage(
+    model_path: Path, load_duration_ms: float, failure_category: str
+) -> ModelLineage:
+    """Create a public-safe record for a failed model load without error text."""
+    return ModelLineage(
+        loaded=False,
+        filename=model_path.name,
+        sha256=None,
+        size_bytes=None,
+        num_classes=None,
+        classes=[],
+        load_duration_ms=round(float(load_duration_ms), 3),
+        loaded_at=datetime.now(timezone.utc).isoformat(),
+        runtime=runtime_details(),
+        failure_category=failure_category,
+    )
+
+
+def metadata_unavailable_model_lineage(
+    model_path: Path, load_duration_ms: float
+) -> ModelLineage:
+    """Preserve readiness when a loaded model's optional lineage capture fails."""
+    return ModelLineage(
+        loaded=True,
+        filename=model_path.name,
+        sha256=None,
+        size_bytes=None,
+        num_classes=None,
+        classes=[],
+        load_duration_ms=round(float(load_duration_ms), 3),
+        loaded_at=datetime.now(timezone.utc).isoformat(),
+        runtime=runtime_details(),
+        failure_category="model_metadata_unavailable",
+    )

--- a/software_side/walkbuddy_reactNative/backend/ml_runtime/router.py
+++ b/software_side/walkbuddy_reactNative/backend/ml_runtime/router.py
@@ -1,0 +1,50 @@
+"""Operational HTTP endpoints for the backend ML runtime."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from .state import MLRuntimeState
+
+
+router = APIRouter(prefix="/ml", tags=["ml-runtime"])
+
+
+def _runtime_state(request: Request) -> MLRuntimeState:
+    """Get initialized state or a zero-safe view for unusual pre-startup calls."""
+    runtime_state = getattr(request.app.state, "ml_runtime", None)
+    if isinstance(runtime_state, MLRuntimeState):
+        return runtime_state
+    return MLRuntimeState()
+
+
+@router.get("/health")
+async def ml_health(request: Request) -> dict[str, object]:
+    """Report high-level component health without exposing model lineage."""
+    vision_loaded = bool(getattr(request.app.state, "yolo", None))
+    ocr_loaded = bool(getattr(request.app.state, "ocr_reader", None))
+    return {
+        "status": "ok" if vision_loaded and ocr_loaded else "degraded",
+        "vision": {"loaded": vision_loaded},
+        "ocr": {"loaded": ocr_loaded},
+    }
+
+
+@router.get("/ready")
+async def ml_ready(request: Request) -> JSONResponse:
+    """Return container readiness for the vision MVP independently of liveness."""
+    vision_loaded = bool(getattr(request.app.state, "yolo", None))
+    return JSONResponse(status_code=200 if vision_loaded else 503, content={"ready": vision_loaded})
+
+
+@router.get("/model-info")
+async def model_info(request: Request) -> dict[str, object]:
+    """Return the safe active-model lineage captured once during startup."""
+    return _runtime_state(request).model_info()
+
+
+@router.get("/metrics")
+async def metrics(request: Request) -> dict[str, object]:
+    """Return the bounded, aggregate inference metrics for this process."""
+    return _runtime_state(request).metrics.snapshot()

--- a/software_side/walkbuddy_reactNative/backend/ml_runtime/state.py
+++ b/software_side/walkbuddy_reactNative/backend/ml_runtime/state.py
@@ -1,0 +1,62 @@
+"""Single owner for process-local ML operational state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from .metrics import InferenceMetrics
+from .model_info import (
+    ModelLineage,
+    metadata_unavailable_model_lineage,
+    unavailable_model_lineage,
+)
+
+
+class MLRuntimeState:
+    """Hold model lineage and bounded metrics safely across worker threads."""
+
+    def __init__(self, latency_window_capacity: int = 256) -> None:
+        self.metrics = InferenceMetrics(latency_window_capacity)
+        self._model_lock = Lock()
+        self._model_lineage: ModelLineage | None = None
+
+    def set_model_lineage(self, lineage: ModelLineage) -> None:
+        """Replace the startup lineage atomically after a successful model load."""
+        with self._model_lock:
+            self._model_lineage = lineage
+
+    def set_model_load_failure(
+        self, model_path: Path, load_duration_ms: float, failure_category: str
+    ) -> None:
+        """Record a failed startup without retaining exception text or paths."""
+        self.set_model_lineage(
+            unavailable_model_lineage(model_path, load_duration_ms, failure_category)
+        )
+
+    def set_model_metadata_failure(
+        self, model_path: Path, load_duration_ms: float
+    ) -> None:
+        """Record unavailable lineage without marking a successfully loaded model down."""
+        self.set_model_lineage(
+            metadata_unavailable_model_lineage(model_path, load_duration_ms)
+        )
+
+    def model_info(self) -> dict[str, Any]:
+        """Return safe lineage data, including pre-startup unavailable state."""
+        with self._model_lock:
+            if self._model_lineage is None:
+                return {
+                    "loaded": False,
+                    "filename": None,
+                    "sha256": None,
+                    "size_bytes": None,
+                    "num_classes": None,
+                    "classes": [],
+                    "load_duration_ms": None,
+                    "loaded_at": None,
+                    "runtime": {},
+                    "failure_category": "not_initialized",
+                }
+            return self._model_lineage.as_dict()

--- a/software_side/walkbuddy_reactNative/backend/routers/ai_service.py
+++ b/software_side/walkbuddy_reactNative/backend/routers/ai_service.py
@@ -6,6 +6,7 @@ import logging
 import anyio
 from fastapi import APIRouter, UploadFile, File, Request, WebSocket, WebSocketDisconnect, HTTPException
 from opentelemetry import trace
+from fastapi.responses import JSONResponse
 
 from adapters.vision_adapter import vision_adapter
 from adapters.ocr_adapter import ocr_adapter
@@ -13,10 +14,59 @@ from internal import state
 from internal.motion_tracker import MotionTracker
 from tts_service.message_reasoning import process_adapter_output
 from slow_lane import safe_or_stop_recommendation
+from ml_runtime import (
+    inference_failed_error,
+    model_unavailable_error,
+    websocket_error_payload,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 tracer = trace.get_tracer("ai_service")
+
+
+def _begin_vision_metrics(app) -> float | None:
+    """Start aggregate timing without allowing instrumentation to affect vision."""
+    runtime = getattr(app.state, "ml_runtime", None)
+    if runtime is None:
+        return None
+    try:
+        runtime.metrics.begin_inference()
+        return time.perf_counter()
+    except Exception:
+        # Metrics are best-effort observability; never reject a vision request
+        # merely because recording operational state failed.
+        logger.exception("Unable to start vision runtime metrics")
+        return None
+
+
+def _finish_vision_metrics(app, started_at: float | None, *, successful: bool) -> None:
+    """Finish aggregate timing without allowing instrumentation to affect vision."""
+    if started_at is None:
+        return
+    runtime = getattr(app.state, "ml_runtime", None)
+    if runtime is None:
+        return
+    try:
+        runtime.metrics.finish_inference(
+            (time.perf_counter() - started_at) * 1000, successful=successful
+        )
+    except Exception:
+        # Metrics are best-effort observability; never reject a vision request
+        # merely because recording operational state failed.
+        logger.exception("Unable to finish vision runtime metrics")
+
+
+def _record_dropped_vision_frame(app) -> None:
+    """Record a deliberately skipped frame without affecting WebSocket handling."""
+    runtime = getattr(app.state, "ml_runtime", None)
+    if runtime is None:
+        return
+    try:
+        runtime.metrics.record_dropped_frame()
+    except Exception:
+        # A malformed runtime metrics object must not alter WebSocket handling.
+        logger.exception("Unable to record dropped vision frame")
 
 
 def normalize_vision_events(raw_events):
@@ -127,7 +177,7 @@ def _guidance_payload(result: dict, max_messages: int = 1) -> tuple[str, str]:
 @router.post("/vision")
 async def vision_endpoint(request: Request, file: UploadFile = File(...)):
     if not request.app.state.yolo:
-        raise HTTPException(503, "Vision model unavailable")
+        return JSONResponse(status_code=503, content=model_unavailable_error())
 
     content = await file.read()
     if not content:
@@ -142,14 +192,22 @@ async def vision_endpoint(request: Request, file: UploadFile = File(...)):
 
         try:
             async with request.app.state.vision_limiter:
-                result = await anyio.to_thread.run_sync(
-                    vision_adapter,
-                    request.app.state.yolo,
-                    temp_path,
-                )
-        except Exception as e:
-            logger.error(f"Vision adapter error: {e}")
-            raise HTTPException(500, "Vision processing failed")
+                metrics_started_at = _begin_vision_metrics(request.app)
+                try:
+                    result = await anyio.to_thread.run_sync(
+                        vision_adapter,
+                        request.app.state.yolo,
+                        temp_path,
+                    )
+                except Exception:
+                    _finish_vision_metrics(
+                        request.app, metrics_started_at, successful=False
+                    )
+                    raise
+                _finish_vision_metrics(request.app, metrics_started_at, successful=True)
+        except Exception:
+            logger.exception("Vision adapter error")
+            return JSONResponse(status_code=500, content=inference_failed_error())
 
         for d in result["detections"]:
             state.memory.add_event(**_event_from_detection(d))
@@ -319,7 +377,8 @@ async def vision_ws_endpoint(websocket: WebSocket):
                          "risk_level": str, "inference_time_ms": int,
                          "server_timestamp_ms": int}
                     OR {"type": "frame_dropped", "frame_id": str, "reason": str}
-                    OR {"type": "error", "frame_id": str|null, "message": str}
+                    OR {"type": "error", "code": str, "frame_id": str|null,
+                        "message": str}
       Server → text:   {"type": "ping"}  (every ~15 s)
       Client → text:   {"type": "pong"}
     """
@@ -327,11 +386,9 @@ async def vision_ws_endpoint(websocket: WebSocket):
 
     yolo = websocket.app.state.yolo
     if yolo is None:
-        await websocket.send_text(json.dumps({
-            "type": "error",
-            "frame_id": None,
-            "message": "YOLO model not loaded",
-        }))
+        await websocket.send_text(
+            json.dumps(websocket_error_payload("model_unavailable", None))
+        )
         await websocket.close(1011)
         return
 
@@ -376,6 +433,7 @@ async def vision_ws_endpoint(websocket: WebSocket):
 
                 if frame_meta is None:
                     logger.debug("[WS Vision] Binary received without frame_meta — skipped")
+                    _record_dropped_vision_frame(websocket.app)
                     continue
 
                 fid = frame_meta.get("frame_id", "unknown")
@@ -389,6 +447,8 @@ async def vision_ws_endpoint(websocket: WebSocket):
                 # in FIFO order, so multiple WS clients share the slot fairly.
                 async with limiter:
                     t0 = time.monotonic()
+                    metrics_started_at = _begin_vision_metrics(websocket.app)
+                    metrics_finished = False
 
                     with tracer.start_as_current_span("ws.vision.frame") as frame_span:
                         frame_span.set_attribute("frame.id", fid)
@@ -404,6 +464,10 @@ async def vision_ws_endpoint(websocket: WebSocket):
                             result = await anyio.to_thread.run_sync(
                                 vision_adapter, yolo, temp_path
                             )
+                            _finish_vision_metrics(
+                                websocket.app, metrics_started_at, successful=True
+                            )
+                            metrics_finished = True
                             image_width, image_height = _image_dimensions(result)
                             result["detections"] = tracker.update(
                                 result["detections"],
@@ -439,13 +503,15 @@ async def vision_ws_endpoint(websocket: WebSocket):
                                 "server_timestamp_ms": int(time.time() * 1000),
                             }))
 
-                        except Exception as exc:
-                            logger.error(f"[WS Vision] Inference error (frame {fid}): {exc}")
-                            await websocket.send_text(json.dumps({
-                                "type": "error",
-                                "frame_id": fid,
-                                "message": str(exc),
-                            }))
+                        except Exception:
+                            if not metrics_finished:
+                                _finish_vision_metrics(
+                                    websocket.app, metrics_started_at, successful=False
+                                )
+                            logger.exception("[WS Vision] Inference error (frame %s)", fid)
+                            await websocket.send_text(
+                                json.dumps(websocket_error_payload("inference_failed", fid))
+                            )
 
                         finally:
                             if temp_path and os.path.exists(temp_path):

--- a/software_side/walkbuddy_reactNative/backend/tests/test_ml_runtime.py
+++ b/software_side/walkbuddy_reactNative/backend/tests/test_ml_runtime.py
@@ -1,0 +1,774 @@
+"""Tests for the production ML runtime operational state and public failures."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Iterator
+
+import pytest
+import httpx
+from fastapi import FastAPI, WebSocketDisconnect
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from ml_runtime.metrics import InferenceMetrics
+from ml_runtime.model_info import (
+    ModelMetadataError,
+    calculate_sha256,
+    capture_model_lineage,
+    normalise_class_names,
+    runtime_details,
+)
+from ml_runtime.router import router as ml_runtime_router
+from ml_runtime.state import MLRuntimeState
+
+
+class FakeModel:
+    names = {
+        0: "book",
+        1: "books",
+        2: "monitor",
+        3: "office-chair",
+        4: "whiteboard",
+        5: "table",
+        6: "tv",
+    }
+
+
+def _app_with_runtime(*, yolo: object | None, ocr_reader: object | None) -> FastAPI:
+    app = FastAPI()
+    app.state.yolo = yolo
+    app.state.ocr_reader = ocr_reader
+    app.state.ml_runtime = MLRuntimeState(latency_window_capacity=4)
+    app.include_router(ml_runtime_router)
+    return app
+
+
+def test_model_sha256_is_calculated_without_mutating_artifact(tmp_path: Path) -> None:
+    artifact = tmp_path / "best.pt"
+    artifact.write_bytes(b"walkbuddy")
+
+    assert calculate_sha256(artifact) == (
+        "8c819d4eb6291df5e33d12e42ee44bb4413634751186d49641984d5f6ad26836"
+    )
+    assert artifact.read_bytes() == b"walkbuddy"
+
+
+def test_model_lineage_captures_ordered_classes_and_class_count(tmp_path: Path) -> None:
+    artifact = tmp_path / "private" / "best.pt"
+    artifact.parent.mkdir()
+    artifact.write_bytes(b"model")
+
+    lineage = capture_model_lineage(artifact, FakeModel(), 12.3456)
+
+    assert lineage.loaded is True
+    assert lineage.filename == "best.pt"
+    assert lineage.num_classes == 7
+    assert lineage.classes == [
+        "book", "books", "monitor", "office-chair", "whiteboard", "table", "tv"
+    ]
+    assert lineage.load_duration_ms == 12.346
+
+
+def test_model_info_does_not_expose_absolute_model_path(tmp_path: Path) -> None:
+    artifact = tmp_path / "private-model-dir" / "best.pt"
+    artifact.parent.mkdir()
+    artifact.write_bytes(b"model")
+    runtime = MLRuntimeState()
+    runtime.set_model_lineage(capture_model_lineage(artifact, FakeModel(), 1.0))
+
+    model_info = runtime.model_info()
+
+    assert model_info["filename"] == "best.pt"
+    assert str(artifact.parent) not in json.dumps(model_info)
+
+
+def test_model_names_property_failure_is_normalised_to_safe_metadata_error(
+    tmp_path: Path,
+) -> None:
+    class FailingMetadataModel:
+        @property
+        def names(self) -> dict[int, str]:
+            raise RuntimeError("private loader detail")
+
+    artifact = tmp_path / "best.pt"
+    artifact.write_bytes(b"model")
+
+    with pytest.raises(ModelMetadataError, match="model.names"):
+        capture_model_lineage(artifact, FailingMetadataModel(), 1.0)
+
+
+@pytest.mark.parametrize("names", (None, {}, {"invalid": "book"}, ["", "book"]))
+def test_malformed_model_names_are_rejected(names: object) -> None:
+    with pytest.raises(ModelMetadataError, match="model.names"):
+        normalise_class_names(names)
+
+
+def test_model_load_failure_is_reported_without_exception_text(tmp_path: Path) -> None:
+    runtime = MLRuntimeState()
+    runtime.set_model_load_failure(tmp_path / "best.pt", 4.5, "model_file_missing")
+
+    model_info = runtime.model_info()
+
+    assert model_info["loaded"] is False
+    assert model_info["failure_category"] == "model_file_missing"
+    assert model_info["filename"] == "best.pt"
+
+
+def test_ml_health_reports_healthy_components() -> None:
+    app = _app_with_runtime(yolo=object(), ocr_reader=object())
+
+    with TestClient(app) as client:
+        response = client.get("/ml/health")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "vision": {"loaded": True},
+        "ocr": {"loaded": True},
+    }
+
+
+def test_ml_health_reports_degraded_components() -> None:
+    app = _app_with_runtime(yolo=None, ocr_reader=object())
+
+    with TestClient(app) as client:
+        response = client.get("/ml/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "degraded"
+    assert response.json()["vision"] == {"loaded": False}
+
+
+def test_ml_ready_returns_200_only_when_yolo_is_available() -> None:
+    app = _app_with_runtime(yolo=object(), ocr_reader=None)
+
+    with TestClient(app) as client:
+        response = client.get("/ml/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {"ready": True}
+
+
+def test_ml_ready_returns_503_when_yolo_is_unavailable() -> None:
+    app = _app_with_runtime(yolo=None, ocr_reader=None)
+
+    with TestClient(app) as client:
+        response = client.get("/ml/ready")
+
+    assert response.status_code == 503
+    assert response.json() == {"ready": False}
+
+
+def test_model_info_endpoint_reports_captured_lineage(tmp_path: Path) -> None:
+    artifact = tmp_path / "best.pt"
+    artifact.write_bytes(b"model")
+    app = _app_with_runtime(yolo=object(), ocr_reader=None)
+    app.state.ml_runtime.set_model_lineage(
+        capture_model_lineage(artifact, FakeModel(), 3.5)
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/ml/model-info")
+
+    assert response.status_code == 200
+    assert response.json()["loaded"] is True
+    assert response.json()["filename"] == "best.pt"
+    assert response.json()["num_classes"] == 7
+
+
+def test_metrics_endpoint_is_zero_safe_before_inference() -> None:
+    app = _app_with_runtime(yolo=object(), ocr_reader=None)
+
+    with TestClient(app) as client:
+        metrics = client.get("/ml/metrics").json()
+
+    assert metrics["total_attempts"] == 0
+    assert metrics["successful_inferences"] == 0
+    assert metrics["failed_inferences"] == 0
+    assert metrics["active_inferences"] == 0
+    assert metrics["latency_window_size"] == 0
+    assert metrics["p50_latency_ms"] is None
+
+
+def test_successful_inference_increments_shared_metrics() -> None:
+    metrics = InferenceMetrics()
+    metrics.begin_inference()
+    metrics.finish_inference(12.0, successful=True)
+
+    snapshot = metrics.snapshot()
+
+    assert snapshot["total_attempts"] == 1
+    assert snapshot["successful_inferences"] == 1
+    assert snapshot["failed_inferences"] == 0
+    assert snapshot["processed_frames"] == 1
+    assert snapshot["active_inferences"] == 0
+
+
+def test_failed_inference_increments_shared_metrics() -> None:
+    metrics = InferenceMetrics()
+    metrics.begin_inference()
+    metrics.finish_inference(8.0, successful=False)
+
+    snapshot = metrics.snapshot()
+
+    assert snapshot["total_attempts"] == 1
+    assert snapshot["successful_inferences"] == 0
+    assert snapshot["failed_inferences"] == 1
+    assert snapshot["processed_frames"] == 0
+
+
+def test_latency_statistics_use_deterministic_nearest_rank_percentiles() -> None:
+    metrics = InferenceMetrics()
+    for latency in (30.0, 10.0, 40.0, 20.0, 50.0):
+        metrics.begin_inference()
+        metrics.finish_inference(latency, successful=True)
+
+    snapshot = metrics.snapshot()
+
+    assert snapshot["latest_latency_ms"] == 50.0
+    assert snapshot["mean_latency_ms"] == 30.0
+    assert snapshot["p50_latency_ms"] == 30.0
+    assert snapshot["p95_latency_ms"] == 50.0
+    assert snapshot["max_latency_ms"] == 50.0
+
+
+@pytest.mark.parametrize(
+    ("samples", "expected_p50", "expected_p95"),
+    (
+        ([], None, None),
+        ([5.0], 5.0, 5.0),
+        ([1.0, 2.0, 3.0, 4.0], 2.0, 4.0),
+        (list(range(1, 101)), 50, 95),
+    ),
+)
+def test_latency_percentiles_cover_empty_small_and_large_windows(
+    samples: list[float], expected_p50: float | None, expected_p95: float | None
+) -> None:
+    assert InferenceMetrics._percentile(samples, 0.50) == expected_p50
+    assert InferenceMetrics._percentile(samples, 0.95) == expected_p95
+
+
+def test_latency_window_is_bounded() -> None:
+    metrics = InferenceMetrics(latency_window_capacity=2)
+    for latency in (1.0, 2.0, 3.0):
+        metrics.begin_inference()
+        metrics.finish_inference(latency, successful=True)
+
+    snapshot = metrics.snapshot()
+
+    assert snapshot["total_attempts"] == 3
+    assert snapshot["latency_window_size"] == 2
+    assert snapshot["latency_window_capacity"] == 2
+    assert snapshot["mean_latency_ms"] == 2.5
+
+
+def test_metrics_normalise_nonfinite_latencies_for_safe_json_output() -> None:
+    metrics = InferenceMetrics()
+    for latency in (float("nan"), float("inf"), float("-inf")):
+        metrics.begin_inference()
+        metrics.finish_inference(latency, successful=True)
+
+    snapshot = metrics.snapshot()
+    numeric_values = (
+        snapshot["latest_latency_ms"],
+        snapshot["mean_latency_ms"],
+        snapshot["p50_latency_ms"],
+        snapshot["p95_latency_ms"],
+        snapshot["max_latency_ms"],
+    )
+    assert all(value is not None and math.isfinite(value) for value in numeric_values)
+
+
+def test_runtime_introspection_failure_does_not_escape(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FailingCuda:
+        @staticmethod
+        def is_available() -> bool:
+            raise OSError("runtime probing failed")
+
+    torch_stub = ModuleType("torch")
+    torch_stub.__version__ = "test"
+    torch_stub.cuda = FailingCuda()
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+
+    details = runtime_details()
+
+    assert details["cuda_available"] is False
+    assert details["device"] == "unknown"
+
+
+def test_metrics_are_thread_safe_for_worker_thread_inference() -> None:
+    metrics = InferenceMetrics(latency_window_capacity=16)
+
+    def record_attempt() -> None:
+        for _ in range(25):
+            metrics.begin_inference()
+            metrics.finish_inference(1.0, successful=True)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        list(executor.map(lambda _index: record_attempt(), range(4)))
+
+    snapshot = metrics.snapshot()
+    assert snapshot["total_attempts"] == 100
+    assert snapshot["successful_inferences"] == 100
+    assert snapshot["active_inferences"] == 0
+    assert snapshot["latency_window_size"] == 16
+
+
+class _Memory:
+    def add_event(self, **_kwargs: object) -> None:
+        pass
+
+
+class _AsyncLimiter:
+    async def __aenter__(self) -> "_AsyncLimiter":
+        return self
+
+    async def __aexit__(self, *_args: object) -> bool:
+        return False
+
+
+class _BrokenMetrics:
+    def __init__(self, failure_point: str) -> None:
+        self._failure_point = failure_point
+
+    def begin_inference(self) -> None:
+        if self._failure_point == "begin":
+            raise RuntimeError("metrics begin failed")
+
+    def finish_inference(self, _latency_ms: float, *, successful: bool) -> None:
+        if self._failure_point == "finish":
+            raise RuntimeError("metrics finish failed")
+
+
+class _Upload:
+    filename = "frame.jpg"
+
+    async def read(self) -> bytes:
+        return b"image-bytes"
+
+
+class _WebSocket:
+    def __init__(self, app: object, messages: list[dict[str, object]]) -> None:
+        self.app = app
+        self.client = None
+        self._messages = iter(messages)
+        self.sent: list[dict[str, object]] = []
+        self.close_code: int | None = None
+
+    async def accept(self) -> None:
+        pass
+
+    async def send_text(self, message: str) -> None:
+        self.sent.append(json.loads(message))
+
+    async def close(self, code: int) -> None:
+        self.close_code = code
+
+    async def receive(self) -> dict[str, object]:
+        try:
+            return next(self._messages)
+        except StopIteration as exc:
+            raise WebSocketDisconnect() from exc
+
+
+_AI_STUB_MODULES = (
+    "adapters",
+    "adapters.vision_adapter",
+    "adapters.ocr_adapter",
+    "internal",
+    "internal.state",
+    "internal.motion_tracker",
+    "tts_service",
+    "tts_service.message_reasoning",
+    "slow_lane",
+)
+
+_MAIN_STUB_MODULES = (
+    "ultralytics",
+    "easyocr",
+    "routers",
+    "routers.stt",
+    "routers.audiobooks",
+    "routers.ai_service",
+    "routers.helpers",
+    "routers.auth",
+    "internal",
+    "internal.state",
+    "slow_lane",
+    "predictive_path",
+    "predictive_path.router",
+    "telemetry",
+)
+
+
+@pytest.fixture
+def ai_service_module() -> Iterator[ModuleType]:
+    """Import the router with fakes, avoiding CV, OCR, model, and GPU imports."""
+    original_modules = {
+        name: sys.modules[name] for name in _AI_STUB_MODULES if name in sys.modules
+    }
+    for name in _AI_STUB_MODULES:
+        sys.modules.pop(name, None)
+
+    adapters = ModuleType("adapters")
+    adapters.__path__ = []
+    vision = ModuleType("adapters.vision_adapter")
+    vision.vision_adapter = lambda *_args: {"detections": [], "image_id": "frame", "metadata": {}}
+    ocr = ModuleType("adapters.ocr_adapter")
+    ocr.ocr_adapter = lambda *_args: {"detections": [], "image_id": "frame"}
+
+    internal = ModuleType("internal")
+    internal.__path__ = []
+    state = ModuleType("internal.state")
+    state.memory = _Memory()
+    motion = ModuleType("internal.motion_tracker")
+    motion.MotionTracker = type("MotionTracker", (), {"update": lambda self, detections, **_kwargs: detections})
+
+    tts_service = ModuleType("tts_service")
+    tts_service.__path__ = []
+    reasoning = ModuleType("tts_service.message_reasoning")
+    reasoning.process_adapter_output = lambda *_args, **_kwargs: []
+
+    slow_lane = ModuleType("slow_lane")
+    slow_lane.safe_or_stop_recommendation = lambda *_args: None
+
+    sys.modules.update({
+        "adapters": adapters,
+        "adapters.vision_adapter": vision,
+        "adapters.ocr_adapter": ocr,
+        "internal": internal,
+        "internal.state": state,
+        "internal.motion_tracker": motion,
+        "tts_service": tts_service,
+        "tts_service.message_reasoning": reasoning,
+        "slow_lane": slow_lane,
+    })
+
+    spec = importlib.util.spec_from_file_location(
+        "ai_service_runtime_test", BACKEND_DIR / "routers" / "ai_service.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        for name in _AI_STUB_MODULES:
+            sys.modules.pop(name, None)
+        sys.modules.update(original_modules)
+
+
+@pytest.fixture
+def main_module() -> Iterator[ModuleType]:
+    """Import the FastAPI app without starting or importing heavy ML packages."""
+    original_modules = {
+        name: sys.modules[name] for name in _MAIN_STUB_MODULES if name in sys.modules
+    }
+    original_sys_path = sys.path.copy()
+    for name in _MAIN_STUB_MODULES:
+        sys.modules.pop(name, None)
+
+    def router_module(name: str) -> ModuleType:
+        module = ModuleType(name)
+        module.router = APIRouter()
+        return module
+
+    ultralytics = ModuleType("ultralytics")
+    ultralytics.YOLO = object
+    easyocr = ModuleType("easyocr")
+    easyocr.Reader = object
+
+    routers = ModuleType("routers")
+    routers.__path__ = []
+    routers.stt = router_module("routers.stt")
+    routers.audiobooks = router_module("routers.audiobooks")
+    routers.ai_service = router_module("routers.ai_service")
+    routers.helpers = router_module("routers.helpers")
+    routers.auth = router_module("routers.auth")
+
+    internal = ModuleType("internal")
+    internal.__path__ = []
+    internal_state = ModuleType("internal.state")
+    internal_state.collaboration_sessions = {}
+    internal_state.llm_brain = None
+    internal.state = internal_state
+
+    slow_lane = ModuleType("slow_lane")
+    slow_lane.SlowLaneBrain = object
+
+    predictive_path = ModuleType("predictive_path")
+    predictive_path.__path__ = []
+    predictive_path.router = router_module("predictive_path.router")
+
+    telemetry = ModuleType("telemetry")
+    telemetry.init_telemetry = lambda _app: None
+
+    sys.modules.update({
+        "ultralytics": ultralytics,
+        "easyocr": easyocr,
+        "routers": routers,
+        "routers.stt": routers.stt,
+        "routers.audiobooks": routers.audiobooks,
+        "routers.ai_service": routers.ai_service,
+        "routers.helpers": routers.helpers,
+        "routers.auth": routers.auth,
+        "internal": internal,
+        "internal.state": internal_state,
+        "slow_lane": slow_lane,
+        "predictive_path": predictive_path,
+        "predictive_path.router": predictive_path.router,
+        "telemetry": telemetry,
+    })
+
+    spec = importlib.util.spec_from_file_location(
+        "ml_runtime_main_test", BACKEND_DIR / "main.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        for name in _MAIN_STUB_MODULES:
+            sys.modules.pop(name, None)
+        sys.modules.update(original_modules)
+        sys.path[:] = original_sys_path
+
+
+def _vision_request(*, yolo: object | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                yolo=yolo,
+                vision_limiter=_AsyncLimiter(),
+                ml_runtime=MLRuntimeState(),
+            )
+        )
+    )
+
+
+def test_only_readiness_is_public_when_an_api_key_is_configured(
+    main_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WALKBUDDY_API_KEY", "test-key")
+
+    async def request_statuses() -> dict[str, int]:
+        transport = httpx.ASGITransport(app=main_module.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            ready = await client.get("/ml/ready")
+            health = await client.get("/ml/health")
+            model_info = await client.get("/ml/model-info")
+            metrics = await client.get("/ml/metrics")
+            model_info_with_key = await client.get(
+                "/ml/model-info", headers={"X-API-Key": "test-key"}
+            )
+            ping = await client.get("/ping")
+        return {
+            "ready": ready.status_code,
+            "health": health.status_code,
+            "model_info": model_info.status_code,
+            "metrics": metrics.status_code,
+            "model_info_with_key": model_info_with_key.status_code,
+            "ping": ping.status_code,
+        }
+
+    statuses = asyncio.run(request_statuses())
+
+    assert statuses == {
+        "ready": 503,
+        "health": 401,
+        "model_info": 401,
+        "metrics": 401,
+        "model_info_with_key": 200,
+        "ping": 200,
+    }
+
+
+def test_lifespan_records_missing_model_without_preventing_startup(
+    main_module: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    main_module.YOLO_MODEL_PATH = tmp_path / "missing-best.pt"
+    main_module.init_database = lambda: None
+    monkeypatch.setattr(main_module, "_cleanup_sessions_loop", lambda: None)
+    monkeypatch.setattr(main_module.asyncio, "create_task", lambda _coroutine: None)
+
+    async def start_with_missing_model() -> dict[str, object]:
+        async with main_module.lifespan(main_module.app):
+            return main_module.app.state.ml_runtime.model_info()
+
+    model_info = asyncio.run(start_with_missing_model())
+
+    assert main_module.app.state.yolo is None
+    assert model_info["loaded"] is False
+    assert model_info["failure_category"] == "model_file_missing"
+
+
+def test_rest_model_unavailable_response_uses_stable_error_code(
+    ai_service_module: ModuleType,
+) -> None:
+    response = asyncio.run(ai_service_module.vision_endpoint(_vision_request(yolo=None), _Upload()))
+
+    assert response.status_code == 503
+    assert json.loads(response.body) == {
+        "error": {
+            "code": "model_unavailable",
+            "message": "Vision model is unavailable.",
+        }
+    }
+
+
+def test_rest_inference_failure_hides_raw_exception_text(
+    ai_service_module: ModuleType,
+) -> None:
+    ai_service_module.vision_adapter = lambda *_args: (_ for _ in ()).throw(
+        RuntimeError("private model failure detail")
+    )
+
+    request = _vision_request(yolo=object())
+    response = asyncio.run(ai_service_module.vision_endpoint(request, _Upload()))
+
+    payload = json.loads(response.body)
+    assert response.status_code == 500
+    assert payload["error"]["code"] == "inference_failed"
+    assert "private model failure detail" not in json.dumps(payload)
+    assert request.app.state.ml_runtime.metrics.snapshot()["failed_inferences"] == 1
+
+
+def test_successful_rest_vision_response_shape_is_preserved(
+    ai_service_module: ModuleType,
+) -> None:
+    ai_service_module.vision_adapter = lambda *_args: {
+        "detections": [],
+        "guidance_message": "ignored",
+        "image_id": "frame",
+        "metadata": {"image_shape": [480, 640]},
+    }
+    ai_service_module._guidance_payload = lambda *_args, **_kwargs: ("Path clear", "CLEAR")
+
+    request = _vision_request(yolo=object())
+    response = asyncio.run(ai_service_module.vision_endpoint(request, _Upload()))
+
+    assert response == {
+        "detections": [],
+        "guidance_message": "Path clear",
+        "image_id": "frame",
+    }
+    assert request.app.state.ml_runtime.metrics.snapshot()["successful_inferences"] == 1
+
+
+@pytest.mark.parametrize("failure_point", ("begin", "finish"))
+def test_metrics_collection_failure_does_not_break_rest_vision(
+    ai_service_module: ModuleType, failure_point: str
+) -> None:
+    ai_service_module.vision_adapter = lambda *_args: {
+        "detections": [],
+        "image_id": "frame",
+        "metadata": {"image_shape": [480, 640]},
+    }
+    ai_service_module._guidance_payload = lambda *_args, **_kwargs: ("Path clear", "CLEAR")
+    request = _vision_request(yolo=object())
+    request.app.state.ml_runtime = SimpleNamespace(metrics=_BrokenMetrics(failure_point))
+
+    response = asyncio.run(ai_service_module.vision_endpoint(request, _Upload()))
+
+    assert response["guidance_message"] == "Path clear"
+
+
+def test_websocket_model_unavailable_response_uses_stable_error_code(
+    ai_service_module: ModuleType,
+) -> None:
+    websocket = _WebSocket(
+        SimpleNamespace(state=SimpleNamespace(yolo=None)), messages=[]
+    )
+
+    asyncio.run(ai_service_module.vision_ws_endpoint(websocket))
+
+    assert websocket.close_code == 1011
+    assert websocket.sent == [{
+        "type": "error",
+        "code": "model_unavailable",
+        "frame_id": None,
+        "message": "Vision model is unavailable.",
+    }]
+
+
+def test_websocket_inference_failure_hides_raw_exception_text(
+    ai_service_module: ModuleType,
+) -> None:
+    ai_service_module.vision_adapter = lambda *_args: (_ for _ in ()).throw(
+        RuntimeError("private model failure detail")
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            yolo=object(), vision_limiter=_AsyncLimiter(), ml_runtime=MLRuntimeState()
+        )
+    )
+    websocket = _WebSocket(app, [
+        {"text": json.dumps({"type": "frame_meta", "frame_id": "frame-1"}), "bytes": None},
+        {"text": None, "bytes": b"image-bytes"},
+    ])
+
+    asyncio.run(ai_service_module.vision_ws_endpoint(websocket))
+
+    assert websocket.sent[-1]["code"] == "inference_failed"
+    assert "private model failure detail" not in json.dumps(websocket.sent[-1])
+    assert app.state.ml_runtime.metrics.snapshot()["failed_inferences"] == 1
+
+
+def test_websocket_tracks_only_frames_the_server_actually_skips(
+    ai_service_module: ModuleType,
+) -> None:
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            yolo=object(), vision_limiter=_AsyncLimiter(), ml_runtime=MLRuntimeState()
+        )
+    )
+    websocket = _WebSocket(app, [{"text": None, "bytes": b"missing-metadata"}])
+
+    asyncio.run(ai_service_module.vision_ws_endpoint(websocket))
+
+    assert app.state.ml_runtime.metrics.snapshot()["dropped_frames"] == 1
+    assert app.state.ml_runtime.metrics.snapshot()["total_attempts"] == 0
+
+
+def test_successful_websocket_detection_result_shape_is_preserved(
+    ai_service_module: ModuleType,
+) -> None:
+    ai_service_module.vision_adapter = lambda *_args: {
+        "detections": [],
+        "image_id": "frame",
+        "metadata": {"image_shape": [480, 640]},
+    }
+    ai_service_module._guidance_payload = lambda *_args, **_kwargs: ("Path clear", "CLEAR")
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            yolo=object(), vision_limiter=_AsyncLimiter(), ml_runtime=MLRuntimeState()
+        )
+    )
+    websocket = _WebSocket(app, [
+        {"text": json.dumps({"type": "frame_meta", "frame_id": "frame-1"}), "bytes": None},
+        {"text": None, "bytes": b"image-bytes"},
+    ])
+
+    asyncio.run(ai_service_module.vision_ws_endpoint(websocket))
+
+    payload = websocket.sent[-1]
+    assert payload["type"] == "detection_result"
+    assert set(payload) == {
+        "type", "frame_id", "detections", "guidance_message", "risk_level",
+        "inference_time_ms", "server_timestamp_ms",
+    }
+    assert app.state.ml_runtime.metrics.snapshot()["successful_inferences"] == 1


### PR DESCRIPTION
## Summary

Hardens the production ML runtime so WalkBuddy can distinguish process liveness from actual vision-model readiness, report which YOLO artifact is live, expose bounded inference telemetry, and return structured ML failures.

This is a production ML/integration hardening change only. It does not modify training, datasets, taxonomy, model weights, confidence thresholds, or frontend behaviour.

## Changes

- Add ML runtime state for readiness, model lineage, and inference metrics.
- Add `GET /ml/ready` for YOLO readiness.
- Add protected ML operational endpoints for health, model information, and runtime metrics.
- Capture active YOLO metadata at startup:
  - filename
  - SHA-256
  - file size
  - class names
  - class count
  - load duration/timestamp
  - Ultralytics/PyTorch/CUDA/device details
- Keep model metadata collection best-effort so optional runtime introspection cannot break application startup.
- Add bounded, thread-safe inference metrics for REST and WebSocket vision paths.
- Add latency statistics and inference success/failure counters.
- Normalise non-finite metric values so API responses remain valid JSON.
- Replace raw ML exception exposure with stable:
  - `model_unavailable`
  - `inference_failed`
  error codes.
- Preserve successful REST and WebSocket response shapes.
- Keep `/ping` as process liveness.
- Update Docker health checking to use `/ml/ready` so a container is not reported healthy when YOLO is unavailable.
- Avoid exposing model directories, absolute model paths, environment values, or raw exception details.

## Verification

After rebasing onto the latest `t2-2026-development`:

- ML suite: **201 passed**
- Focused ML runtime suite: **37 passed**
- Backend suite: **60 passed**
- Python compilation: passed
- `git diff --check`: passed
- Working tree: clean

## Scope

No changes to:

- model training
- datasets
- dataset release tooling
- model weights
- approved taxonomy
- hazard/risk mapping
- confidence or IoU thresholds
- frontend code
- unrelated backend features

## Commit

`405b240f0f4a536d24811602346b651c01f8b110` — `Harden ML runtime readiness and observability`