### PR TITLE
Add candidate model validation and promotion gating

### DIFF
--- a/ML_side/README.md
+++ b/ML_side/README.md
@@ -24,6 +24,10 @@ The experimental entry point and historical demo material should not be used to 
 For a reproducible, read-only baseline of a locally supplied `best.pt`, see
 [`docs/current_model_baseline.md`](docs/current_model_baseline.md).
 
+For offline candidate validation, versioned evaluation artifacts, and explicit
+promotion-gate review, see
+[`docs/candidate_model_promotion.md`](docs/candidate_model_promotion.md).
+
 ### Unresolved Work
 
 The repository-configured v1 training taxonomy lacks important navigation-hazard classes such as stairs, doors, and people. The active best.pt metadata still requires confirmation in a valid backend environment. In addition, multiple class-to-risk policies exist across the system and can classify ordinary objects more severely than intended. Any runtime safety-policy change requires cross-stream review before implementation.

--- a/ML_side/config/promotion_gates.example.json
+++ b/ML_side/config/promotion_gates.example.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "policy_status": "EXAMPLE_NOT_APPROVED_POLICY",
+  "purpose": "Illustrates the optional comparison-gate format. These values are not approved WalkBuddy promotion policy.",
+  "gates": {
+    "aggregate_minimum_deltas": {
+      "mAP50": -0.02,
+      "mAP50_95": -0.02
+    },
+    "per_class_minimum_deltas": {
+      "recall": {
+        "stairs": -0.03,
+        "door": -0.03,
+        "person": -0.03
+      }
+    },
+    "required_classes": [
+      "person",
+      "stairs",
+      "door",
+      "chair",
+      "table",
+      "pole",
+      "bicycle",
+      "vehicle"
+    ],
+    "maximum_latency_increase_ms": 5.0
+  }
+}

--- a/ML_side/docs/candidate_model_promotion.md
+++ b/ML_side/docs/candidate_model_promotion.md
@@ -1,0 +1,108 @@
+# Candidate model validation and promotion gating
+
+This offline workflow validates candidate detection-model artifacts and compares
+controlled, versioned evaluations. It never replaces `ML_side/models/best.pt`,
+copies weights into production, deploys a model, downloads artifacts, or starts
+training.
+
+## Lifecycle and taxonomy
+
+The approved navigation taxonomy is fixed for this workflow:
+
+| ID | Class |
+| ---: | --- |
+| 0 | `person` |
+| 1 | `stairs` |
+| 2 | `door` |
+| 3 | `chair` |
+| 4 | `table` |
+| 5 | `pole` |
+| 6 | `bicycle` |
+| 7 | `vehicle` |
+
+The current seven-class `best.pt` is stored as a `historical_reference` in
+`ML_side/evaluation/baselines/historical_7class_baseline.json`. Its taxonomy and
+unlabelled qualitative review are not comparable to a first eight-class model,
+so a comparison against it always returns `REVIEW`, never an automatic pass or
+failure.
+
+The first structurally valid eight-class candidate needs human review after its
+controlled evaluation. A human-approved evaluation artifact may later be
+labelled `canonical_8class_baseline`; only future candidates can be evaluated
+automatically against that compatible baseline.
+
+## Validate a trusted candidate artifact
+
+Use a model and smoke image obtained from a trusted project source. Model
+loading deserializes weights. Run this from the supported backend environment
+after following `docs/LOCAL_SETUP.md`; choose an output directory outside the
+repository to avoid generated reports entering Git.
+
+```powershell
+& ".\software_side\walkbuddy_reactNative\backend\.venv\Scripts\python.exe" ".\ML_side\tools\validate_candidate_model.py" --model ".\path\to\candidate.pt" --smoke-image ".\path\to\trusted-smoke-image.jpg" --output ".\outside-repository\candidate-validation"
+```
+
+The validator records existence, regular-file status, size, SHA-256, load
+result, detection task metadata when available, class metadata, exact class
+count and ordered taxonomy, JSON-safe report metadata, and a no-save smoke
+inference. The smoke inference confirms only execution, not detection quality.
+An unavailable optional task field can produce `pass_with_warnings`; a missing,
+malformed, non-eight-class, wrong-taxonomy, unloadable, or non-executing model
+produces `fail`.
+
+## Versioned evaluation artifacts
+
+`ML_side/tools/evaluate_current_model.py` now writes version `1.0.0` machine
+artifacts. The summary and mode-specific JSON include tool identity, UTC
+timestamp, model filename/size/SHA-256/class mapping, evaluation mode, and
+effective settings. Labelled-validation artifacts also identify the metric unit,
+metric fields, latency unit, and Ultralytics validation source. They
+intentionally omit absolute machine-specific paths.
+
+Unlabelled audits use explicit `--operating-confidence` and `--operating-iou`
+(defaults are recorded in the artifact) and pass those settings only to
+`model.predict`. Labelled validation continues to use `model.val` without
+forcing the operating-point values into AP calculation; its artifact records
+that the Ultralytics default validation sweep is used instead.
+
+## Compare controlled evaluations
+
+Both inputs must be versioned `summary.json` artifacts (or directories
+containing one), use the approved eight-class ID/name mapping in the same
+order, use the same evaluation mode and settings, and include required labelled
+validation metrics for the requested gates.
+
+```powershell
+& ".\software_side\walkbuddy_reactNative\backend\.venv\Scripts\python.exe" ".\ML_side\tools\compare_model_evaluations.py" --baseline ".\outside-repository\canonical-baseline" --candidate ".\outside-repository\candidate-evaluation" --candidate-validation ".\outside-repository\candidate-validation" --output ".\outside-repository\comparison" --gates ".\approved-promotion-gates.json"
+```
+
+The comparison reports aggregate, per-class (keyed by class name), and latency
+deltas. It records the supplied gate configuration filename, SHA-256, schema,
+policy status, and exact gate values, plus the candidate-validation report
+filename, SHA-256, and verdict. An automatic result requires that validation
+report to match the candidate evaluation's size, SHA-256, and class lineage.
+Its verdict is deliberately constrained:
+
+- `FAIL`: a candidate (or non-historical baseline) has a non-approved taxonomy,
+  or a compatible candidate breaches an explicitly supplied gate.
+- `REVIEW`: a historical/non-canonical baseline, incompatible mode/settings,
+  unsupported metric semantics, missing or non-finite metrics, no matching
+  candidate-validation report, or no explicitly supplied gate configuration.
+- `PASS`: a compatible candidate satisfies every explicitly supplied gate.
+
+`ML_side/config/promotion_gates.example.json` demonstrates the supported format
+only. It is explicitly **not approved WalkBuddy policy** and is never loaded by
+default; supplying it still returns `REVIEW`. Only a separately approved
+configuration with `policy_status` set to `APPROVED_POLICY` is eligible for
+automatic decisions. ML-team/project approval is required before any
+thresholds, a canonical baseline designation, or a real promotion decision is
+used.
+
+## Exit codes
+
+`validate_candidate_model.py` returns `0` for `pass` or `pass_with_warnings`
+and `1` for `fail` or a controlled command error. `compare_model_evaluations.py`
+returns `0` for `PASS`, `1` for `FAIL` or a controlled command error, and `2`
+for `REVIEW`, so unattended callers can distinguish incomplete evidence from a
+configured regression. `evaluate_current_model.py` returns `0` after a
+completed evaluation and `1` for a controlled evaluation error.

--- a/ML_side/docs/current_model_baseline.md
+++ b/ML_side/docs/current_model_baseline.md
@@ -50,14 +50,27 @@ as `null` with an explanation; no values are estimated or fabricated.
 
 Each run writes these files to the requested output directory:
 
-- `model_metadata.json` — local path, size, SHA-256, and class mapping.
-- `summary.json` — run mode and aggregate results.
-- `predictions.json` — unlabelled mode only; per-image detections and failures.
-- `validation_metrics.json` — labelled mode only; available validation metrics.
+All machine-readable artifacts use schema version `1.0.0`, include tool
+identity and model lineage, and omit absolute local paths. The descriptions
+below retain the existing filenames for compatibility.
+
+Labelled-validation artifacts also record the metric semantics: aggregate and
+per-class precision, recall, mAP50, and mAP50-95 are fractions from 0 to 1;
+available inference timing is in milliseconds per image.
+
+- `model_metadata.json` — versioned model filename, size, SHA-256, and class mapping.
+- `summary.json` — versioned run mode, effective settings, lineage, and aggregate results.
+- `predictions.json` — versioned unlabelled-mode per-image detections and failures.
+- `validation_metrics.json` — versioned labelled-mode available validation metrics.
 - `baseline_report.md` — readable summary.
 
 The tool refuses to write into a non-empty output directory unless `--overwrite`
 is supplied. It never copies source images into the output directory.
+
+Unlabelled audits record the explicit operating confidence and IoU used for
+`model.predict`. Labelled validation records its separate Ultralytics AP
+configuration and does not force those operating-point values into
+`model.val`.
 
 ## Verified local smoke test
 

--- a/ML_side/evaluation/baselines/historical_7class_baseline.json
+++ b/ML_side/evaluation/baselines/historical_7class_baseline.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1.0.0",
+  "tool": {
+    "name": "historical_7class_baseline",
+    "version": "1.0.0"
+  },
+  "baseline_type": "historical_reference",
+  "model": {
+    "filename": "best.pt",
+    "file_size_bytes": 6244458,
+    "sha256": "198df54da4f6aa071b342bee77b100e78f243df785b325ec364036e106572238",
+    "class_count": 7,
+    "class_id_to_name": {
+      "0": "book",
+      "1": "books",
+      "2": "monitor",
+      "3": "office-chair",
+      "4": "whiteboard",
+      "5": "table",
+      "6": "tv"
+    },
+    "ordered_class_names": [
+      "book",
+      "books",
+      "monitor",
+      "office-chair",
+      "whiteboard",
+      "table",
+      "tv"
+    ]
+  },
+  "mode": "unlabelled_qualitative_review",
+  "evaluation_settings": {
+    "operating_point_inference": {
+      "confidence": null,
+      "iou": null,
+      "note": "The historical review did not record a controlled operating-point configuration."
+    },
+    "validation_ap": null
+  },
+  "results": {
+    "images_processed": 33,
+    "processing_failures": 0,
+    "average_inference_time_ms": 85.43,
+    "detection_counts_by_class": {
+      "books": 37,
+      "monitor": 3,
+      "office-chair": 3,
+      "table": 1
+    }
+  },
+  "source": {
+    "document": "ML_side/docs/current_model_baseline.md",
+    "section": "Completed qualitative baseline review"
+  },
+  "limitations": [
+    "This artifact uses a historical seven-class taxonomy that differs from the approved eight-class navigation taxonomy.",
+    "It cannot be used as an automatic accuracy-promotion gate for the first eight-class candidate.",
+    "The prior review was an unlabelled qualitative review, not a like-for-like eight-class labelled evaluation.",
+    "Historical evaluation settings may differ from a future controlled evaluation.",
+    "No precision, recall, mAP, or per-class validation metrics are recorded here."
+  ]
+}

--- a/ML_side/tests/test_compare_model_evaluations.py
+++ b/ML_side/tests/test_compare_model_evaluations.py
@@ -1,0 +1,646 @@
+"""Tests for versioned candidate-evaluation comparison and gating."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import compare_model_evaluations as comparison
+
+
+CLASS_NAMES = comparison.APPROVED_CLASS_NAMES
+HISTORICAL_REFERENCE = (
+    Path(__file__).resolve().parents[1]
+    / "evaluation"
+    / "baselines"
+    / "historical_7class_baseline.json"
+)
+
+
+def metrics(
+    *,
+    value: float = 0.5,
+    latency: float = 10.0,
+    missing: str | None = None,
+) -> dict[str, object]:
+    values: dict[str, object] = {
+        "precision": value,
+        "recall": value,
+        "mAP50": value,
+        "mAP50_95": value,
+        "inference_timing_ms": {"inference": latency},
+        "per_class_results": {
+            str(index): {
+                "class_name": name,
+                "precision": value,
+                "recall": value,
+                "mAP50": value,
+                "mAP50_95": value,
+            }
+            for index, name in enumerate(CLASS_NAMES)
+        },
+    }
+    if missing is not None:
+        values[missing] = None
+    return values
+
+
+def artifact(
+    *,
+    sha256: str,
+    baseline_type: str = "canonical_8class_baseline",
+    mode: str = "labelled_validation",
+    settings: dict[str, object] | None = None,
+    metric_values: dict[str, object] | None = None,
+) -> dict[str, object]:
+    classes = list(CLASS_NAMES)
+    return {
+        "schema_version": comparison.SCHEMA_VERSION,
+        "tool": {"name": "evaluate_current_model", "version": "2.0.0"},
+        "created_at_utc": "2026-08-09T00:00:00Z",
+        "baseline_type": baseline_type,
+        "model": {
+            "filename": "candidate.pt",
+            "file_size_bytes": 42,
+            "sha256": sha256,
+            "class_count": len(classes),
+            "class_id_to_name": {str(index): name for index, name in enumerate(classes)},
+            "ordered_class_names": classes,
+        },
+        "mode": mode,
+        "metric_semantics": comparison.model_evaluator.LABELLED_VALIDATION_METRIC_SEMANTICS
+        if mode == "labelled_validation"
+        else None,
+        "evaluation_settings": settings
+        or {
+            "operating_point_inference": None,
+            "validation_ap": {
+                "engine": "ultralytics_model_val",
+                "confidence": "ultralytics_default_sweep",
+                "iou": "ultralytics_default",
+            },
+        },
+        "results": {"validation_metrics": metric_values or metrics()},
+    }
+
+
+def write_artifact(tmp_path: Path, name: str, payload: dict[str, object]) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def approved_gates(**gates: object) -> dict[str, object]:
+    return {
+        "schema_version": comparison.SCHEMA_VERSION,
+        "policy_status": "APPROVED_POLICY",
+        "gates": gates
+        or {
+            "aggregate_minimum_deltas": {"mAP50": -0.01},
+            "required_classes": ["person", "stairs"],
+            "maximum_latency_increase_ms": 2.0,
+        },
+    }
+
+
+def validation_report(candidate: dict[str, object], *, verdict: str = "pass") -> dict[str, object]:
+    passed_checks = [
+        "artifact_exists",
+        "artifact_size",
+        "sha256",
+        "model_load",
+        "class_count",
+        "approved_taxonomy",
+        "report_metadata",
+        "smoke_inference",
+    ]
+    return {
+        "schema_version": comparison.SCHEMA_VERSION,
+        "tool": {"name": comparison.CANDIDATE_VALIDATION_TOOL_NAME, "version": "1.0.0"},
+        "candidate": dict(candidate["model"]),  # type: ignore[arg-type]
+        "verdict": verdict,
+        "checks": [
+            *({"name": name, "status": "pass"} for name in passed_checks),
+            {"name": "detection_task", "status": "pass"},
+        ],
+    }
+
+
+def compare(
+    tmp_path: Path,
+    baseline: dict[str, object],
+    candidate: dict[str, object],
+    gates: dict[str, object] | None = None,
+    *,
+    include_validation: bool = True,
+    validation_verdict: str = "pass",
+) -> dict[str, object]:
+    gate_path = write_artifact(tmp_path, "gates.json", gates) if gates else None
+    validation_path = (
+        write_artifact(
+            tmp_path,
+            "candidate-validation.json",
+            validation_report(candidate, verdict=validation_verdict),
+        )
+        if include_validation
+        else None
+    )
+    return comparison.compare_evaluations(
+        write_artifact(tmp_path, "baseline.json", baseline),
+        write_artifact(tmp_path, "candidate.json", candidate),
+        gate_config_path=gate_path,
+        candidate_validation_path=validation_path,
+    )
+
+
+def test_compatible_candidate_without_gates_requires_review(tmp_path: Path) -> None:
+    report = compare(tmp_path, artifact(sha256="a" * 64), artifact(sha256="b" * 64))
+
+    assert report["verdict"] == "REVIEW"
+    assert report["technical_compatibility"]["status"] == "compatible"  # type: ignore[index]
+    assert report["policy_gate"]["configuration_supplied"] is False  # type: ignore[index]
+
+
+def test_approved_gates_without_matching_candidate_validation_require_review(
+    tmp_path: Path,
+) -> None:
+    report = compare(
+        tmp_path,
+        artifact(sha256="a" * 64),
+        artifact(sha256="b" * 64),
+        approved_gates(),
+        include_validation=False,
+    )
+
+    assert report["verdict"] == "REVIEW"
+    assert report["technical_compatibility"]["status"] == "candidate_validation_missing"  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    ("validation_verdict", "expected_status"),
+    [("fail", "candidate_validation_failed"), ("pass", "candidate_validation_mismatch")],
+)
+def test_failed_or_mismatched_candidate_validation_cannot_pass(
+    tmp_path: Path, validation_verdict: str, expected_status: str
+) -> None:
+    baseline = artifact(sha256="a" * 64)
+    candidate = artifact(sha256="b" * 64)
+    if expected_status == "candidate_validation_mismatch":
+        report_path = write_artifact(
+            tmp_path,
+            "candidate-validation.json",
+            validation_report(artifact(sha256="c" * 64)),
+        )
+        report = comparison.compare_evaluations(
+            write_artifact(tmp_path, "baseline.json", baseline),
+            write_artifact(tmp_path, "candidate.json", candidate),
+            gate_config_path=write_artifact(tmp_path, "gates.json", approved_gates()),
+            candidate_validation_path=report_path,
+        )
+    else:
+        report = compare(
+            tmp_path,
+            baseline,
+            candidate,
+            approved_gates(),
+            validation_verdict=validation_verdict,
+        )
+
+    assert report["verdict"] == "FAIL"
+    assert report["technical_compatibility"]["status"] == expected_status  # type: ignore[index]
+
+
+def test_incomplete_successful_candidate_validation_report_is_rejected(tmp_path: Path) -> None:
+    candidate = artifact(sha256="b" * 64)
+    incomplete = validation_report(candidate)
+    incomplete["checks"] = []
+    report_path = write_artifact(tmp_path, "candidate-validation.json", incomplete)
+
+    with pytest.raises(comparison.ComparisonError, match="required successful check"):
+        comparison.load_candidate_validation_report(report_path)
+
+
+def test_approved_gates_can_pass_a_compatible_improvement(tmp_path: Path) -> None:
+    baseline = artifact(sha256="a" * 64, metric_values=metrics(value=0.5, latency=10.0))
+    candidate = artifact(sha256="b" * 64, metric_values=metrics(value=0.55, latency=11.0))
+    report = compare(tmp_path, baseline, candidate, approved_gates())
+
+    assert report["verdict"] == "PASS"
+    assert report["deltas"]["aggregate"]["mAP50"] == pytest.approx(0.05)  # type: ignore[index]
+    assert report["deltas"]["per_class"]["stairs"]["recall"] == pytest.approx(0.05)  # type: ignore[index]
+    assert report["deltas"]["latency_ms"] == pytest.approx(1.0)  # type: ignore[index]
+    assert report["candidate_validation"]["verdict"] == "pass"  # type: ignore[index]
+    assert report["policy_gate"]["source_filename"] == "gates.json"  # type: ignore[index]
+    assert report["policy_gate"]["gates"] == approved_gates()["gates"]  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    ("candidate_metrics", "gates"),
+    [
+        (
+            metrics(value=0.45),
+            approved_gates(aggregate_minimum_deltas={"mAP50": -0.01}),
+        ),
+        (
+            metrics(value=0.5, latency=14.0),
+            approved_gates(maximum_latency_increase_ms=2.0),
+        ),
+    ],
+)
+def test_aggregate_and_latency_gate_breaches_fail(
+    tmp_path: Path, candidate_metrics: dict[str, object], gates: dict[str, object]
+) -> None:
+    report = compare(
+        tmp_path,
+        artifact(sha256="a" * 64, metric_values=metrics()),
+        artifact(sha256="b" * 64, metric_values=candidate_metrics),
+        gates,
+    )
+
+    assert report["verdict"] == "FAIL"
+
+
+def test_per_class_gate_breach_fails_by_canonical_name(tmp_path: Path) -> None:
+    candidate_metrics = metrics()
+    candidate_metrics["per_class_results"]["1"]["recall"] = 0.1  # type: ignore[index]
+    gates = approved_gates(per_class_minimum_deltas={"recall": {"stairs": -0.01}})
+
+    report = compare(
+        tmp_path,
+        artifact(sha256="a" * 64, metric_values=metrics()),
+        artifact(sha256="b" * 64, metric_values=candidate_metrics),
+        gates,
+    )
+
+    assert report["verdict"] == "FAIL"
+    assert report["deltas"]["per_class"]["stairs"]["recall"] == pytest.approx(-0.4)  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    ("candidate_value", "expected_verdict"),
+    [(0.48, "PASS"), (0.480001, "PASS"), (0.479999, "FAIL")],
+)
+def test_metric_gate_boundaries_are_deterministic(
+    tmp_path: Path, candidate_value: float, expected_verdict: str
+) -> None:
+    report = compare(
+        tmp_path,
+        artifact(sha256="a" * 64, metric_values=metrics(value=0.5)),
+        artifact(sha256="b" * 64, metric_values=metrics(value=candidate_value)),
+        approved_gates(aggregate_minimum_deltas={"mAP50": -0.02}),
+    )
+
+    assert report["verdict"] == expected_verdict
+
+
+@pytest.mark.parametrize("missing", ["precision", "mAP50"])
+def test_missing_or_nonfinite_metrics_require_review(tmp_path: Path, missing: str) -> None:
+    report = compare(
+        tmp_path,
+        artifact(sha256="a" * 64),
+        artifact(sha256="b" * 64, metric_values=metrics(missing=missing)),
+        approved_gates(),
+    )
+
+    assert report["verdict"] == "REVIEW"
+    assert report["technical_compatibility"]["status"] == "missing_metrics"  # type: ignore[index]
+
+
+def test_nonfinite_metric_requires_review(tmp_path: Path) -> None:
+    baseline_path = write_artifact(tmp_path, "baseline.json", artifact(sha256="a" * 64))
+    candidate = artifact(sha256="b" * 64)
+    candidate["results"]["validation_metrics"]["mAP50"] = float("nan")  # type: ignore[index]
+    candidate_path = tmp_path / "candidate.json"
+    candidate_path.write_text(json.dumps(candidate).replace("NaN", "NaN"), encoding="utf-8")
+    gates_path = write_artifact(tmp_path, "gates.json", approved_gates())
+
+    report = comparison.compare_evaluations(
+        baseline_path,
+        candidate_path,
+        gate_config_path=gates_path,
+        candidate_validation_path=write_artifact(
+            tmp_path, "candidate-validation.json", validation_report(candidate)
+        ),
+    )
+
+    assert report["verdict"] == "REVIEW"
+    assert report["deltas"]["aggregate"]["mAP50"] is None  # type: ignore[index]
+
+
+def test_nonfinite_evaluation_settings_are_rejected_before_comparison(tmp_path: Path) -> None:
+    invalid = artifact(sha256="a" * 64)
+    invalid["evaluation_settings"] = {"operating_point_inference": {"confidence": float("inf")}}
+
+    with pytest.raises(comparison.ComparisonError, match="settings contain"):
+        comparison.load_evaluation_artifact(write_artifact(tmp_path, "invalid.json", invalid))
+
+
+@pytest.mark.parametrize("invalid_value", [float("inf"), 80.0])
+def test_nonfinite_or_wrong_unit_metrics_require_review(
+    tmp_path: Path, invalid_value: float
+) -> None:
+    candidate_metrics = metrics()
+    candidate_metrics["precision"] = invalid_value
+
+    report = compare(
+        tmp_path,
+        artifact(sha256="a" * 64),
+        artifact(sha256="b" * 64, metric_values=candidate_metrics),
+        approved_gates(),
+    )
+
+    assert report["verdict"] == "REVIEW"
+    assert report["technical_compatibility"]["status"] == "missing_metrics"  # type: ignore[index]
+
+
+@pytest.mark.parametrize("mutation", ["missing", "unknown", "duplicate", "null"])
+def test_incomplete_or_unknown_per_class_metrics_require_review(
+    tmp_path: Path, mutation: str
+) -> None:
+    candidate_metrics = metrics()
+    per_class = candidate_metrics["per_class_results"]  # type: ignore[index]
+    if mutation == "missing":
+        del per_class["1"]
+    elif mutation == "unknown":
+        per_class["8"] = {
+            "class_name": "book",
+            "precision": 0.5,
+            "recall": 0.5,
+            "mAP50": 0.5,
+            "mAP50_95": 0.5,
+        }
+    elif mutation == "duplicate":
+        per_class["1"]["class_name"] = "person"
+    else:
+        per_class["1"]["mAP50"] = None
+
+    report = compare(
+        tmp_path,
+        artifact(sha256="a" * 64),
+        artifact(sha256="b" * 64, metric_values=candidate_metrics),
+        approved_gates(),
+    )
+
+    assert report["verdict"] == "REVIEW"
+    assert report["technical_compatibility"]["status"] == "missing_metrics"  # type: ignore[index]
+
+
+def test_wrong_taxonomy_and_class_order_fail_not_review(tmp_path: Path) -> None:
+    candidate = artifact(sha256="b" * 64)
+    candidate["model"]["ordered_class_names"] = list(reversed(CLASS_NAMES))  # type: ignore[index]
+
+    report = compare(tmp_path, artifact(sha256="a" * 64), candidate, approved_gates())
+
+    assert report["verdict"] == "FAIL"
+    assert report["technical_compatibility"]["status"] == "incompatible_taxonomy"  # type: ignore[index]
+
+
+def test_historical_and_noncanonical_baselines_require_review(tmp_path: Path) -> None:
+    historical = artifact(sha256="a" * 64, baseline_type="historical_reference")
+    historical["model"].update(  # type: ignore[index]
+        {"filename": "best.pt", "class_count": 7, "class_id_to_name": {"0": "book"}, "ordered_class_names": ["book"]}
+    )
+    historical_report = compare(tmp_path, historical, artifact(sha256="b" * 64), approved_gates())
+    noncanonical_report = compare(
+        tmp_path,
+        artifact(sha256="c" * 64, baseline_type="evaluation"),
+        artifact(sha256="d" * 64),
+        approved_gates(),
+    )
+
+    assert historical_report["verdict"] == "REVIEW"
+    assert historical_report["technical_compatibility"]["status"] == "historical_reference_only"  # type: ignore[index]
+    assert noncanonical_report["verdict"] == "REVIEW"
+    assert noncanonical_report["technical_compatibility"]["status"] == "baseline_not_canonical"  # type: ignore[index]
+
+
+def test_committed_historical_reference_is_grounded_and_never_auto_promotes(
+    tmp_path: Path,
+) -> None:
+    source, historical = comparison.load_evaluation_artifact(HISTORICAL_REFERENCE)
+    candidate = artifact(sha256="b" * 64)
+
+    report = comparison.compare_evaluations(
+        source,
+        write_artifact(tmp_path, "candidate.json", candidate),
+        gate_config_path=write_artifact(tmp_path, "gates.json", approved_gates()),
+        candidate_validation_path=write_artifact(
+            tmp_path, "candidate-validation.json", validation_report(candidate)
+        ),
+    )
+
+    assert historical["baseline_type"] == "historical_reference"
+    assert historical["model"]["class_count"] == 7  # type: ignore[index]
+    assert historical["results"]["images_processed"] == 33  # type: ignore[index]
+    assert historical["results"]["average_inference_time_ms"] == 85.43  # type: ignore[index]
+    assert historical["results"].get("validation_metrics") is None  # type: ignore[index]
+    assert report["verdict"] == "REVIEW"
+    assert report["technical_compatibility"]["status"] == "historical_reference_only"  # type: ignore[index]
+
+
+def test_wrong_taxonomy_candidate_fails_even_against_historical_reference(tmp_path: Path) -> None:
+    historical = artifact(sha256="a" * 64, baseline_type="historical_reference")
+    historical["model"].update(  # type: ignore[index]
+        {"filename": "best.pt", "class_count": 7, "class_id_to_name": {"0": "book"}, "ordered_class_names": ["book"]}
+    )
+    candidate = artifact(sha256="b" * 64)
+    candidate["model"]["class_count"] = 7  # type: ignore[index]
+
+    report = compare(tmp_path, historical, candidate, approved_gates())
+
+    assert report["verdict"] == "FAIL"
+    assert report["technical_compatibility"]["status"] == "incompatible_taxonomy"  # type: ignore[index]
+
+
+@pytest.mark.parametrize("field", ["mode", "evaluation_settings"])
+def test_incompatible_mode_or_settings_requires_review(tmp_path: Path, field: str) -> None:
+    candidate = artifact(sha256="b" * 64)
+    if field == "mode":
+        candidate["mode"] = "unlabelled_inference_audit"
+    else:
+        candidate["evaluation_settings"] = {"operating_point_inference": {"confidence": 0.3}}
+
+    report = compare(tmp_path, artifact(sha256="a" * 64), candidate, approved_gates())
+
+    assert report["verdict"] == "REVIEW"
+    expected_status = {
+        "mode": "incompatible_evaluation_mode",
+        "evaluation_settings": "incompatible_evaluation_settings",
+    }[field]
+    assert report["technical_compatibility"]["status"] == expected_status  # type: ignore[index]
+
+
+def test_missing_metric_semantics_or_matching_unlabelled_audits_require_review(
+    tmp_path: Path,
+) -> None:
+    missing_semantics = artifact(sha256="b" * 64)
+    missing_semantics["metric_semantics"] = None
+    semantics_report = compare(
+        tmp_path, artifact(sha256="a" * 64), missing_semantics, approved_gates()
+    )
+
+    unlabelled_baseline = artifact(
+        sha256="c" * 64, mode="unlabelled_inference_audit"
+    )
+    unlabelled_candidate = artifact(
+        sha256="d" * 64, mode="unlabelled_inference_audit"
+    )
+    unlabelled_report = compare(
+        tmp_path, unlabelled_baseline, unlabelled_candidate, approved_gates()
+    )
+
+    assert semantics_report["verdict"] == "REVIEW"
+    assert semantics_report["technical_compatibility"]["status"] == "incompatible_metric_semantics"  # type: ignore[index]
+    assert unlabelled_report["verdict"] == "REVIEW"
+    assert unlabelled_report["technical_compatibility"]["status"] == "ineligible_evaluation_mode"  # type: ignore[index]
+
+
+def test_example_policy_and_invalid_gate_targets_do_not_auto_pass(tmp_path: Path) -> None:
+    example_policy = approved_gates()
+    example_policy["policy_status"] = "EXAMPLE_NOT_APPROVED_POLICY"
+    report = compare(
+        tmp_path, artifact(sha256="a" * 64), artifact(sha256="b" * 64), example_policy
+    )
+    invalid = approved_gates(per_class_minimum_deltas={"recall": {"book": -0.1}})
+    invalid_path = write_artifact(tmp_path, "invalid-gates.json", invalid)
+
+    assert report["verdict"] == "REVIEW"
+    with pytest.raises(comparison.ComparisonError, match="approved classes"):
+        comparison._load_gate_config(invalid_path)
+
+
+@pytest.mark.parametrize(
+    "invalid_policy",
+    [
+        {"schema_version": comparison.SCHEMA_VERSION, "policy_status": "UNKNOWN", "gates": {"required_classes": ["person"]}},
+        approved_gates(aggregate_minimum_deltas={"mAP50": -2.0}),
+    ],
+)
+def test_malformed_or_unknown_gate_policy_fails_safely(
+    tmp_path: Path, invalid_policy: dict[str, object]
+) -> None:
+    with pytest.raises(comparison.ComparisonError):
+        comparison._load_gate_config(write_artifact(tmp_path, "invalid-gates.json", invalid_policy))
+
+
+def test_unknown_schema_output_files_and_cli_exit_codes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    baseline = artifact(sha256="a" * 64)
+    baseline["schema_version"] = "9.9.9"
+    baseline_path = write_artifact(tmp_path, "unknown.json", baseline)
+    candidate_path = write_artifact(tmp_path, "candidate.json", artifact(sha256="b" * 64))
+    with pytest.raises(comparison.ComparisonError, match="unsupported schema_version"):
+        comparison.compare_evaluations(baseline_path, candidate_path)
+
+    output = tmp_path / "comparison-output"
+    report = comparison.run_comparison(
+        baseline_path=candidate_path,
+        candidate_path=candidate_path,
+        output_path=output,
+        gate_config_path=write_artifact(tmp_path, "gates.json", approved_gates()),
+        candidate_validation_path=write_artifact(
+            tmp_path,
+            "candidate-validation.json",
+            validation_report(artifact(sha256="b" * 64)),
+        ),
+    )
+    assert report["verdict"] == "PASS"
+    assert json.loads((output / "model_comparison.json").read_text(encoding="utf-8"))["verdict"] == "PASS"
+    assert "## Deltas" in (output / "model_comparison.md").read_text(encoding="utf-8")
+
+    review_exit = comparison.main(
+        [
+            "--baseline",
+            str(candidate_path),
+            "--candidate",
+            str(candidate_path),
+            "--output",
+            str(tmp_path / "cli-output"),
+        ]
+    )
+    assert review_exit == 2
+    assert "Model comparison verdict: REVIEW" in capsys.readouterr().out
+
+
+def test_empty_directory_and_models_output_are_rejected(tmp_path: Path) -> None:
+    empty_directory = tmp_path / "empty"
+    empty_directory.mkdir()
+    candidate = artifact(sha256="b" * 64)
+
+    with pytest.raises(comparison.ComparisonError, match="missing"):
+        comparison.compare_evaluations(empty_directory, write_artifact(tmp_path, "candidate.json", candidate))
+    with pytest.raises(comparison.ComparisonError, match="ML_side/models"):
+        comparison._prepare_output_directory(comparison.MODELS_DIR, overwrite=False)
+
+
+def test_corrupt_evaluation_json_is_rejected_without_fallback(tmp_path: Path) -> None:
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(comparison.ComparisonError, match="read as JSON"):
+        comparison.load_evaluation_artifact(corrupt)
+
+
+def test_comparison_atomic_write_cleans_up_after_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "model_comparison.json"
+    monkeypatch.setattr(
+        Path,
+        "write_text",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("write failed")),
+    )
+
+    with pytest.raises(OSError, match="write failed"):
+        comparison._atomic_write_text(target, "{}\n")
+
+    assert not target.exists()
+    assert not list(tmp_path.glob(".model_comparison.json.*.tmp"))
+
+
+def test_cli_returns_one_for_a_configured_gate_failure(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    baseline_path = write_artifact(tmp_path, "baseline.json", artifact(sha256="a" * 64))
+    candidate_path = write_artifact(
+        tmp_path,
+        "candidate.json",
+        artifact(sha256="b" * 64, metric_values=metrics(value=0.1)),
+    )
+    gates_path = write_artifact(
+        tmp_path,
+        "gates.json",
+        approved_gates(aggregate_minimum_deltas={"mAP50": -0.01}),
+    )
+
+    result = comparison.main(
+        [
+            "--baseline",
+            str(baseline_path),
+            "--candidate",
+            str(candidate_path),
+            "--gates",
+            str(gates_path),
+            "--candidate-validation",
+            str(
+                write_artifact(
+                    tmp_path,
+                    "candidate-validation.json",
+                    validation_report(artifact(sha256="b" * 64, metric_values=metrics(value=0.1))),
+                )
+            ),
+            "--output",
+            str(tmp_path / "cli-output"),
+        ]
+    )
+
+    assert result == 1
+    assert "Model comparison verdict: FAIL" in capsys.readouterr().out

--- a/ML_side/tests/test_evaluate_current_model.py
+++ b/ML_side/tests/test_evaluate_current_model.py
@@ -53,12 +53,18 @@ class FakeModel:
 
     def __init__(self) -> None:
         self.predict_sources: list[str] = []
+        self.predict_arguments: list[dict[str, float | bool | str]] = []
         self.validation_arguments: dict[str, object] | None = None
 
-    def predict(self, *, source: str, save: bool, verbose: bool) -> list[FakeResult]:
+    def predict(
+        self, *, source: str, save: bool, verbose: bool, conf: float, iou: float
+    ) -> list[FakeResult]:
         assert save is False
         assert verbose is False
         self.predict_sources.append(source)
+        self.predict_arguments.append(
+            {"source": source, "save": save, "verbose": verbose, "conf": conf, "iou": iou}
+        )
         if Path(source).name == "broken.jpeg":
             raise RuntimeError("cannot decode image")
         return [FakeResult([FakeBox(1, 0.91, [1.0, 2.0, 3.0, 4.0])])]
@@ -146,11 +152,14 @@ def test_unlabelled_audit_serialises_predictions_and_preserves_source_images(
     output = tmp_path / "results"
     before = {path.name: path.read_bytes() for path in images.iterdir()}
 
+    fake_model = FakeModel()
     summary = evaluator.evaluate(
         model_path=model_path,
         images_path=images,
         output_path=output,
-        yolo_loader=lambda _: FakeModel(),
+        operating_confidence=0.4,
+        operating_iou=0.6,
+        yolo_loader=lambda _: fake_model,
     )
 
     predictions = json.loads((output / "predictions.json").read_text(encoding="utf-8"))
@@ -167,6 +176,18 @@ def test_unlabelled_audit_serialises_predictions_and_preserves_source_images(
         }
     ]
     assert "not precision, recall, or mAP" in predictions["result_label"]
+    assert predictions["schema_version"] == evaluator.EVALUATION_SCHEMA_VERSION
+    assert predictions["tool"] == {"name": evaluator.TOOL_NAME, "version": evaluator.TOOL_VERSION}
+    assert predictions["model"]["ordered_class_names"] == ["book", "monitor"]
+    assert predictions["evaluation_settings"]["operating_point_inference"] == {
+        "confidence": 0.4,
+        "iou": 0.6,
+        "save": False,
+        "verbose": False,
+    }
+    assert predictions["metric_semantics"] is None
+    assert fake_model.predict_arguments[1]["conf"] == 0.4
+    assert fake_model.predict_arguments[1]["iou"] == 0.6
     assert {path.name: path.read_bytes() for path in images.iterdir()} == before
     assert not list(output.glob("*.jpg"))
     assert (output / "model_metadata.json").is_file()
@@ -209,6 +230,7 @@ def test_output_write_failure_is_readable(
 
     with pytest.raises(evaluator.EvaluationError, match="Output write failed"):
         evaluator._write_json(tmp_path / "results.json", {"result": "baseline"})
+    assert not list(tmp_path.glob(".results.json.*.tmp"))
 
 
 def test_dataset_yaml_validation_rejects_missing_and_download_directives(tmp_path: Path) -> None:
@@ -235,7 +257,10 @@ def test_labelled_validation_extracts_available_metrics(tmp_path: Path) -> None:
         yolo_loader=lambda _: model,
     )
 
-    metrics = json.loads((output / "validation_metrics.json").read_text(encoding="utf-8"))
+    metrics_artifact = json.loads(
+        (output / "validation_metrics.json").read_text(encoding="utf-8")
+    )
+    metrics = metrics_artifact["validation_metrics"]
     assert summary["mode"] == "labelled_validation"
     assert metrics["precision"] == 0.625
     assert metrics["recall"] == 0.5
@@ -247,6 +272,12 @@ def test_labelled_validation_extracts_available_metrics(tmp_path: Path) -> None:
     assert model.validation_arguments["data"] == str(dataset_yaml.resolve())
     assert model.validation_arguments["plots"] is False
     assert model.validation_arguments["save_json"] is False
+    assert "conf" not in model.validation_arguments
+    assert "iou" not in model.validation_arguments
+    assert metrics_artifact["schema_version"] == evaluator.EVALUATION_SCHEMA_VERSION
+    assert metrics_artifact["evaluation_settings"]["operating_point_inference"] is None
+    assert metrics_artifact["evaluation_settings"]["validation_ap"]["confidence"] == "ultralytics_default_sweep"
+    assert metrics_artifact["metric_semantics"] == evaluator.LABELLED_VALIDATION_METRIC_SEMANTICS
 
 
 def test_main_reports_a_readable_error(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/ML_side/tests/test_validate_candidate_model.py
+++ b/ML_side/tests/test_validate_candidate_model.py
@@ -1,0 +1,342 @@
+"""Tests for offline candidate detection-model validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import validate_candidate_model as validator
+
+
+APPROVED_NAMES = [name for _, name in validator.APPROVED_TAXONOMY]
+
+
+class FakeCandidateModel:
+    def __init__(
+        self,
+        names: object | None = None,
+        *,
+        task: object = "detect",
+        smoke_error: Exception | None = None,
+    ) -> None:
+        self.names = dict(enumerate(APPROVED_NAMES)) if names is None else names
+        self.task = task
+        self.smoke_error = smoke_error
+        self.predict_calls: list[dict[str, object]] = []
+
+    def predict(self, **kwargs: object) -> list[object]:
+        self.predict_calls.append(kwargs)
+        if self.smoke_error is not None:
+            raise self.smoke_error
+        return [object()]
+
+
+class MissingTaskModel:
+    names = dict(enumerate(APPROVED_NAMES))
+
+    def predict(self, **_: object) -> list[object]:
+        return [object()]
+
+
+class EmptyDetectionModel(FakeCandidateModel):
+    def predict(self, **kwargs: object) -> list[object]:
+        self.predict_calls.append(kwargs)
+        return []
+
+
+class DuplicateIdNames(Mapping[object, object]):
+    """Mapping-shaped model.names payload with duplicate normalized class IDs."""
+
+    def __iter__(self) -> Iterator[object]:
+        return iter(())
+
+    def __len__(self) -> int:
+        return 0
+
+    def __getitem__(self, _: object) -> object:
+        raise KeyError
+
+    def items(self) -> list[tuple[object, object]]:  # type: ignore[override]
+        return [("0", "person"), (0, "stairs")]
+
+
+def make_candidate(tmp_path: Path, contents: bytes = b"candidate-model") -> Path:
+    path = tmp_path / "candidate.pt"
+    path.write_bytes(contents)
+    return path
+
+
+def make_smoke_image(tmp_path: Path) -> Path:
+    path = tmp_path / "smoke.jpg"
+    path.write_bytes(b"not-decoded-by-fake")
+    return path
+
+
+def statuses(report: Mapping[str, object]) -> dict[str, str]:
+    return {
+        str(check["name"]): str(check["status"])
+        for check in report["checks"]  # type: ignore[index]
+    }
+
+
+def test_approved_candidate_passes_and_does_not_modify_artifact(tmp_path: Path) -> None:
+    candidate = make_candidate(tmp_path)
+    smoke = make_smoke_image(tmp_path)
+    before = candidate.read_bytes()
+    model = FakeCandidateModel()
+
+    report = validator.validate_candidate(
+        candidate, smoke_image=smoke, yolo_loader=lambda _: model
+    )
+
+    assert report["schema_version"] == validator.SCHEMA_VERSION
+    assert report["tool"] == {"name": validator.TOOL_NAME, "version": validator.TOOL_VERSION}
+    assert report["verdict"] == "pass"
+    assert report["candidate"]["sha256"] == hashlib.sha256(before).hexdigest()  # type: ignore[index]
+    assert report["candidate"]["ordered_class_names"] == APPROVED_NAMES  # type: ignore[index]
+    assert statuses(report)["approved_taxonomy"] == "pass"
+    assert model.predict_calls == [
+        {"source": str(smoke.resolve()), "save": False, "verbose": False}
+    ]
+    assert candidate.read_bytes() == before
+
+
+def test_list_style_class_names_and_empty_detections_are_valid_execution(tmp_path: Path) -> None:
+    model = EmptyDetectionModel(list(APPROVED_NAMES))
+    report = validator.validate_candidate(
+        make_candidate(tmp_path),
+        smoke_image=make_smoke_image(tmp_path),
+        yolo_loader=lambda _: model,
+    )
+
+    assert report["verdict"] == "pass"
+    assert statuses(report)["approved_taxonomy"] == "pass"
+    assert statuses(report)["smoke_inference"] == "pass"
+
+
+@pytest.mark.parametrize(
+    ("names", "check_name"),
+    [
+        (APPROVED_NAMES[:-1], "class_count"),
+        (APPROVED_NAMES[1:] + APPROVED_NAMES[:1], "approved_taxonomy"),
+        (["person", "person", *APPROVED_NAMES[2:]], "approved_taxonomy"),
+        (DuplicateIdNames(), "class_metadata"),
+        ({0: "person", 1: ""}, "class_metadata"),
+        ({0.5: "person", **dict(enumerate(APPROVED_NAMES[1:], start=1))}, "class_metadata"),
+    ],
+)
+def test_invalid_class_metadata_fails(
+    tmp_path: Path, names: object, check_name: str
+) -> None:
+    candidate = make_candidate(tmp_path)
+    report = validator.validate_candidate(
+        candidate,
+        smoke_image=make_smoke_image(tmp_path),
+        yolo_loader=lambda _: FakeCandidateModel(names),
+    )
+
+    assert report["verdict"] == "fail"
+    assert statuses(report)[check_name] == "fail"
+
+
+def test_model_load_and_metadata_failures_are_safe(tmp_path: Path) -> None:
+    candidate = make_candidate(tmp_path)
+    smoke = make_smoke_image(tmp_path)
+
+    failed_load = validator.validate_candidate(
+        candidate,
+        smoke_image=smoke,
+        yolo_loader=lambda _: (_ for _ in ()).throw(RuntimeError("corrupt")),
+    )
+    metadata_failure = validator.validate_candidate(
+        candidate,
+        smoke_image=smoke,
+        yolo_loader=lambda _: FakeCandidateModel(names=object()),
+    )
+
+    assert failed_load["verdict"] == "fail"
+    assert statuses(failed_load)["model_load"] == "fail"
+    assert statuses(failed_load)["smoke_inference"] == "fail"
+    assert metadata_failure["verdict"] == "fail"
+    assert statuses(metadata_failure)["class_metadata"] == "fail"
+
+
+def test_checksum_failure_and_model_directory_are_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    candidate = make_candidate(tmp_path)
+    monkeypatch.setattr(
+        validator.model_inspector,
+        "calculate_sha256",
+        lambda _: (_ for _ in ()).throw(OSError("unreadable")),
+    )
+
+    report = validator.validate_candidate(
+        candidate,
+        smoke_image=make_smoke_image(tmp_path),
+        yolo_loader=lambda _: FakeCandidateModel(),
+    )
+
+    assert report["verdict"] == "fail"
+    assert statuses(report)["sha256"] == "fail"
+    with pytest.raises(validator.CandidateValidationError, match="ML_side/models"):
+        validator.prepare_output_directory(validator.MODELS_DIR / "nested", overwrite=False)
+
+
+def test_directory_candidate_is_rejected(tmp_path: Path) -> None:
+    candidate_directory = tmp_path / "candidate-directory"
+    candidate_directory.mkdir()
+
+    report = validator.validate_candidate(
+        candidate_directory,
+        smoke_image=make_smoke_image(tmp_path),
+        yolo_loader=lambda _: pytest.fail("loader must not run for a directory"),
+    )
+
+    assert report["verdict"] == "fail"
+    assert statuses(report)["artifact_is_file"] == "fail"
+
+
+def test_missing_task_is_warning_but_smoke_still_runs(tmp_path: Path) -> None:
+    report = validator.validate_candidate(
+        make_candidate(tmp_path),
+        smoke_image=make_smoke_image(tmp_path),
+        yolo_loader=lambda _: MissingTaskModel(),
+    )
+
+    assert report["verdict"] == "pass_with_warnings"
+    assert statuses(report)["detection_task"] == "warning"
+    assert statuses(report)["smoke_inference"] == "pass"
+
+
+@pytest.mark.parametrize("task", [float("nan"), float("inf")])
+def test_nonfinite_optional_task_metadata_cannot_enter_json(tmp_path: Path, task: float) -> None:
+    report = validator.validate_candidate(
+        make_candidate(tmp_path),
+        smoke_image=make_smoke_image(tmp_path),
+        yolo_loader=lambda _: FakeCandidateModel(task=task),
+    )
+
+    assert report["verdict"] == "fail"
+    assert report["candidate"]["task"] is None  # type: ignore[index]
+    assert json.dumps(report, allow_nan=False)
+
+
+@pytest.mark.parametrize(
+    ("candidate_contents", "smoke_path", "expected_check"),
+    [
+        (b"", "present", "artifact_size"),
+        (b"candidate", "missing", "smoke_inference"),
+    ],
+)
+def test_empty_or_nonexecuting_inputs_fail(
+    tmp_path: Path,
+    candidate_contents: bytes,
+    smoke_path: str,
+    expected_check: str,
+) -> None:
+    smoke = make_smoke_image(tmp_path) if smoke_path == "present" else tmp_path / "missing.jpg"
+    report = validator.validate_candidate(
+        make_candidate(tmp_path, candidate_contents),
+        smoke_image=smoke,
+        yolo_loader=lambda _: FakeCandidateModel(),
+    )
+
+    assert report["verdict"] == "fail"
+    assert statuses(report)[expected_check] == "fail"
+
+
+def test_missing_smoke_image_or_failed_smoke_inference_fails(tmp_path: Path) -> None:
+    candidate = make_candidate(tmp_path)
+    no_smoke = validator.validate_candidate(candidate, yolo_loader=lambda _: FakeCandidateModel())
+    failed_smoke = validator.validate_candidate(
+        candidate,
+        smoke_image=make_smoke_image(tmp_path),
+        yolo_loader=lambda _: FakeCandidateModel(smoke_error=RuntimeError("bad image")),
+    )
+
+    assert no_smoke["verdict"] == "fail"
+    assert statuses(no_smoke)["smoke_inference"] == "fail"
+    assert failed_smoke["verdict"] == "fail"
+    assert statuses(failed_smoke)["smoke_inference"] == "fail"
+
+
+def test_reports_are_versioned_and_output_refuses_models_directory(tmp_path: Path) -> None:
+    output = tmp_path / "reports"
+    report = validator.run_validation(
+        candidate_path=make_candidate(tmp_path),
+        smoke_image=make_smoke_image(tmp_path),
+        output_path=output,
+        yolo_loader=lambda _: FakeCandidateModel(),
+    )
+
+    written = json.loads((output / "candidate_model_report.json").read_text(encoding="utf-8"))
+    assert written == report
+    assert "candidate.pt" in (output / "candidate_model_report.md").read_text(encoding="utf-8")
+    assert str(tmp_path) not in (output / "candidate_model_report.md").read_text(encoding="utf-8")
+    with pytest.raises(validator.CandidateValidationError, match="ML_side/models"):
+        validator.prepare_output_directory(validator.MODELS_DIR, overwrite=False)
+
+
+def test_nonempty_output_and_nonfinite_json_are_rejected(tmp_path: Path) -> None:
+    output = tmp_path / "reports"
+    output.mkdir()
+    (output / "old.txt").write_text("keep", encoding="utf-8")
+
+    with pytest.raises(validator.CandidateValidationError, match="not empty"):
+        validator.run_validation(
+            candidate_path=make_candidate(tmp_path),
+            smoke_image=make_smoke_image(tmp_path),
+            output_path=output,
+            yolo_loader=lambda _: FakeCandidateModel(),
+        )
+    with pytest.raises(ValueError, match="Non-finite"):
+        validator._safe_json({"value": float("nan")})
+
+
+def test_cli_returns_nonzero_for_failed_validation(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = validator.main(
+        [
+            "--model",
+            str(tmp_path / "missing.pt"),
+            "--smoke-image",
+            str(make_smoke_image(tmp_path)),
+            "--output",
+            str(tmp_path / "reports"),
+        ]
+    )
+
+    assert result == 1
+    assert "Candidate validation verdict: fail" in capsys.readouterr().out
+
+
+def test_cli_returns_zero_for_a_valid_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(validator, "run_validation", lambda **_: {"verdict": "pass"})
+
+    result = validator.main(
+        [
+            "--model",
+            str(tmp_path / "candidate.pt"),
+            "--smoke-image",
+            str(tmp_path / "smoke.jpg"),
+            "--output",
+            str(tmp_path / "reports"),
+        ]
+    )
+
+    assert result == 0
+    assert "Candidate validation verdict: pass" in capsys.readouterr().out

--- a/ML_side/tools/compare_model_evaluations.py
+++ b/ML_side/tools/compare_model_evaluations.py
@@ -1,0 +1,771 @@
+"""Compare versioned, offline WalkBuddy model-evaluation artifacts.
+
+This tool reports a promotion recommendation only. It cannot promote, copy,
+rename, deploy, or otherwise alter model weights.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import evaluate_current_model as model_evaluator
+import validate_dataset_manifest as manifest_validator
+
+
+SCHEMA_VERSION = "1.0.0"
+TOOL_NAME = "compare_model_evaluations"
+TOOL_VERSION = "1.0.0"
+APPROVED_CLASS_NAMES = [name for _, name in manifest_validator.APPROVED_TAXONOMY]
+AGGREGATE_METRICS = ("precision", "recall", "mAP50", "mAP50_95")
+APPROVED_POLICY_STATUS = "APPROVED_POLICY"
+EXAMPLE_POLICY_STATUS = "EXAMPLE_NOT_APPROVED_POLICY"
+CANDIDATE_VALIDATION_TOOL_NAME = "validate_candidate_model"
+METRIC_COMPARISON_TOLERANCE = 1e-12
+ML_SIDE_DIR = Path(__file__).resolve().parents[1]
+MODELS_DIR = (ML_SIDE_DIR / "models").resolve()
+
+
+class ComparisonError(Exception):
+    """Raised when input artifacts or a supplied gate configuration are invalid."""
+
+
+def _timestamp_utc() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _is_finite_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value))
+
+
+def _safe_float(value: object) -> float | None:
+    return float(value) if _is_finite_number(value) else None
+
+
+def _probability(value: object) -> float | None:
+    numeric = _safe_float(value)
+    return numeric if numeric is not None and 0 <= numeric <= 1 else None
+
+
+def _is_json_safe(value: object) -> bool:
+    """Reject non-finite values in compatibility-critical configuration fields."""
+    if value is None or isinstance(value, (str, int, bool)):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, Mapping):
+        return all(isinstance(key, str) and _is_json_safe(item) for key, item in value.items())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return all(_is_json_safe(item) for item in value)
+    return False
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise ComparisonError("Artifact checksum could not be computed.") from exc
+    return digest.hexdigest()
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ComparisonError("Evaluation artifact is missing.") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ComparisonError("Evaluation artifact could not be read as JSON.") from exc
+    if not isinstance(payload, dict):
+        raise ComparisonError("Evaluation artifact root must be a JSON object.")
+    return payload
+
+
+def load_evaluation_artifact(path_value: str | Path) -> tuple[Path, dict[str, object]]:
+    """Load a versioned summary file or a directory containing ``summary.json``."""
+    path = Path(path_value).expanduser().resolve()
+    source = path / "summary.json" if path.is_dir() else path
+    payload = _read_json(source)
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ComparisonError("Evaluation artifact has an unsupported schema_version.")
+    tool = payload.get("tool")
+    model = payload.get("model")
+    settings = payload.get("evaluation_settings")
+    if not isinstance(tool, Mapping) or not isinstance(model, Mapping) or not isinstance(settings, Mapping):
+        raise ComparisonError("Evaluation artifact is missing the versioned tool, model, or settings fields.")
+    if not _is_json_safe(settings):
+        raise ComparisonError("Evaluation artifact settings contain non-finite or malformed values.")
+    if not isinstance(tool.get("name"), str) or not isinstance(tool.get("version"), str):
+        raise ComparisonError("Evaluation artifact tool metadata is malformed.")
+    if not isinstance(model.get("filename"), str) or not isinstance(model.get("sha256"), str):
+        raise ComparisonError("Evaluation artifact model lineage is malformed.")
+    if len(model["sha256"]) != 64 or any(character not in "0123456789abcdef" for character in model["sha256"]):
+        raise ComparisonError("Evaluation artifact model checksum must be a lowercase SHA-256 value.")
+    if (
+        not isinstance(model.get("file_size_bytes"), int)
+        or isinstance(model["file_size_bytes"], bool)
+        or model["file_size_bytes"] <= 0
+    ):
+        raise ComparisonError("Evaluation artifact model size is malformed.")
+    if not isinstance(payload.get("mode"), str):
+        raise ComparisonError("Evaluation artifact is missing its evaluation mode.")
+    return source, payload
+
+
+def _ordered_classes(artifact: Mapping[str, object]) -> list[str] | None:
+    model = artifact.get("model")
+    if not isinstance(model, Mapping):
+        return None
+    names = model.get("ordered_class_names")
+    if not isinstance(names, Sequence) or isinstance(names, (str, bytes)):
+        return None
+    if not all(isinstance(name, str) and name for name in names):
+        return None
+    return list(names)
+
+
+def _uses_approved_taxonomy(artifact: Mapping[str, object]) -> bool:
+    """Require both the class ID map and ordered names to match the target taxonomy."""
+    model = artifact.get("model")
+    if not isinstance(model, Mapping):
+        return False
+    expected_map = {str(index): name for index, name in enumerate(APPROVED_CLASS_NAMES)}
+    return (
+        isinstance(model.get("class_count"), int)
+        and not isinstance(model.get("class_count"), bool)
+        and model.get("class_count") == len(APPROVED_CLASS_NAMES)
+        and model.get("class_id_to_name") == expected_map
+        and _ordered_classes(artifact) == APPROVED_CLASS_NAMES
+    )
+
+
+def _validation_metrics(artifact: Mapping[str, object]) -> Mapping[str, object] | None:
+    results = artifact.get("results")
+    if isinstance(results, Mapping) and isinstance(results.get("validation_metrics"), Mapping):
+        return results["validation_metrics"]  # type: ignore[return-value]
+    direct = artifact.get("validation_metrics")
+    return direct if isinstance(direct, Mapping) else None
+
+
+def _per_class_metrics(metrics: Mapping[str, object]) -> tuple[dict[str, Mapping[str, object]], list[str]]:
+    raw = metrics.get("per_class_results")
+    if raw is None:
+        return {}, ["Per-class metrics are missing."]
+    if not isinstance(raw, Mapping):
+        return {}, ["Per-class metrics have an invalid structure."]
+    by_name: dict[str, Mapping[str, object]] = {}
+    issues: list[str] = []
+    for value in raw.values():
+        if not isinstance(value, Mapping) or not isinstance(value.get("class_name"), str):
+            issues.append("A per-class metric entry is malformed.")
+            continue
+        class_name = value["class_name"]
+        if class_name in by_name:
+            issues.append(f"Per-class metric name is duplicated: {class_name}.")
+            continue
+        by_name[class_name] = value
+    return by_name, issues
+
+
+def _latency_ms(metrics: Mapping[str, object]) -> float | None:
+    timing = metrics.get("inference_timing_ms")
+    if not isinstance(timing, Mapping):
+        return None
+    for key in ("inference", "inference_ms"):
+        if key in timing:
+            latency = _safe_float(timing[key])
+            return latency if latency is not None and latency >= 0 else None
+    return None
+
+
+def _public_model_reference(artifact: Mapping[str, object], source: Path) -> dict[str, object]:
+    model = artifact.get("model")
+    assert isinstance(model, Mapping)
+    return {
+        "artifact": source.name,
+        "baseline_type": artifact.get("baseline_type", "evaluation"),
+        "filename": model.get("filename"),
+        "sha256": model.get("sha256"),
+        "class_count": model.get("class_count"),
+        "ordered_class_names": _ordered_classes(artifact),
+        "mode": artifact.get("mode"),
+    }
+
+
+def _settings_match(baseline: Mapping[str, object], candidate: Mapping[str, object]) -> bool:
+    return baseline.get("evaluation_settings") == candidate.get("evaluation_settings")
+
+
+def _has_compatible_metric_semantics(artifact: Mapping[str, object]) -> bool:
+    """Accept only the evaluator's documented labelled-validation metric meaning."""
+    tool = artifact.get("tool")
+    return (
+        artifact.get("mode") == "labelled_validation"
+        and isinstance(tool, Mapping)
+        and tool.get("name") == model_evaluator.TOOL_NAME
+        and artifact.get("metric_semantics")
+        == model_evaluator.LABELLED_VALIDATION_METRIC_SEMANTICS
+    )
+
+
+def load_candidate_validation_report(path_value: str | Path) -> tuple[Path, dict[str, object]]:
+    """Load a matching, versioned candidate-validation report without loading weights."""
+    path = Path(path_value).expanduser().resolve()
+    source = path / "candidate_model_report.json" if path.is_dir() else path
+    payload = _read_json(source)
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ComparisonError("Candidate validation report has an unsupported schema_version.")
+    tool = payload.get("tool")
+    candidate = payload.get("candidate")
+    if (
+        not isinstance(tool, Mapping)
+        or tool.get("name") != CANDIDATE_VALIDATION_TOOL_NAME
+        or not isinstance(tool.get("version"), str)
+        or not isinstance(candidate, Mapping)
+    ):
+        raise ComparisonError("Candidate validation report is malformed.")
+    if payload.get("verdict") not in {"pass", "pass_with_warnings", "fail"}:
+        raise ComparisonError("Candidate validation report has an invalid verdict.")
+    checks = payload.get("checks")
+    if not isinstance(checks, Sequence) or isinstance(checks, (str, bytes)):
+        raise ComparisonError("Candidate validation report checks are malformed.")
+    checks_by_name: dict[str, str] = {}
+    for check in checks:
+        if not isinstance(check, Mapping):
+            raise ComparisonError("Candidate validation report checks are malformed.")
+        name = check.get("name")
+        status = check.get("status")
+        if not isinstance(name, str) or not isinstance(status, str) or name in checks_by_name:
+            raise ComparisonError("Candidate validation report checks are malformed.")
+        checks_by_name[name] = status
+    if payload["verdict"] in {"pass", "pass_with_warnings"}:
+        required_passes = {
+            "artifact_exists",
+            "artifact_size",
+            "sha256",
+            "model_load",
+            "class_count",
+            "approved_taxonomy",
+            "report_metadata",
+            "smoke_inference",
+        }
+        if any(checks_by_name.get(name) != "pass" for name in required_passes):
+            raise ComparisonError("Candidate validation report is missing a required successful check.")
+        if checks_by_name.get("detection_task") not in {"pass", "warning"}:
+            raise ComparisonError("Candidate validation report has an invalid detection-task check.")
+        if any(status == "fail" for status in checks_by_name.values()):
+            raise ComparisonError("Candidate validation report verdict conflicts with failed checks.")
+    return source, payload
+
+
+def _candidate_validation_reference(
+    source: Path | None, report: Mapping[str, object] | None
+) -> dict[str, object]:
+    if source is None or report is None:
+        return {
+            "supplied": False,
+            "source_filename": None,
+            "sha256": None,
+            "verdict": None,
+        }
+    return {
+        "supplied": True,
+        "source_filename": source.name,
+        "sha256": _sha256(source),
+        "verdict": report.get("verdict"),
+    }
+
+
+def _candidate_validation_status(
+    candidate_evaluation: Mapping[str, object], validation_report: Mapping[str, object] | None
+) -> tuple[str, str]:
+    """Ensure a PASS is tied to validation of the same candidate artifact lineage."""
+    if validation_report is None:
+        return "missing", "No candidate-validation report was supplied."
+    if validation_report.get("verdict") == "fail":
+        return "failed", "The candidate-validation report recorded a failed artifact."
+    candidate = validation_report.get("candidate")
+    evaluation_model = candidate_evaluation.get("model")
+    if not isinstance(candidate, Mapping) or not isinstance(evaluation_model, Mapping):
+        return "mismatch", "Candidate validation lineage is malformed."
+    required_fields = (
+        "file_size_bytes",
+        "sha256",
+        "class_count",
+        "class_id_to_name",
+        "ordered_class_names",
+    )
+    if any(candidate.get(field) != evaluation_model.get(field) for field in required_fields):
+        return "mismatch", "Candidate-validation lineage does not match the candidate evaluation."
+    return "valid", "Candidate validation matches the candidate evaluation lineage."
+
+
+def _load_gate_config(path_value: str | Path) -> dict[str, object]:
+    payload = _read_json(Path(path_value).expanduser().resolve())
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ComparisonError("Gate configuration has an unsupported schema_version.")
+    policy_status = payload.get("policy_status")
+    if policy_status not in {APPROVED_POLICY_STATUS, EXAMPLE_POLICY_STATUS}:
+        raise ComparisonError("Gate configuration policy_status is unknown or malformed.")
+    gates = payload.get("gates")
+    if not isinstance(gates, Mapping):
+        raise ComparisonError("Gate configuration is missing a gates object.")
+    aggregate = gates.get("aggregate_minimum_deltas", {})
+    per_class = gates.get("per_class_minimum_deltas", {})
+    required_classes = gates.get("required_classes", [])
+    latency = gates.get("maximum_latency_increase_ms")
+    if not isinstance(aggregate, Mapping) or not isinstance(per_class, Mapping):
+        raise ComparisonError("Gate configuration metrics must be objects.")
+    if not isinstance(required_classes, Sequence) or isinstance(required_classes, (str, bytes)):
+        raise ComparisonError("Gate configuration required_classes must be an array.")
+    if latency is not None and not _is_finite_number(latency):
+        raise ComparisonError("Gate configuration latency tolerance must be finite.")
+    for metric, tolerance in aggregate.items():
+        if not isinstance(metric, str) or metric not in AGGREGATE_METRICS:
+            raise ComparisonError("Aggregate gate metrics must be supported metric names.")
+        if not _is_finite_number(tolerance) or not -1 <= float(tolerance) <= 1:
+            raise ComparisonError("Aggregate gate tolerances must be finite numeric values.")
+    for metric, class_thresholds in per_class.items():
+        if not isinstance(metric, str) or metric not in AGGREGATE_METRICS:
+            raise ComparisonError("Per-class gate metrics must be supported metric names.")
+        if not isinstance(class_thresholds, Mapping):
+            raise ComparisonError("Per-class gate tolerances must be objects keyed by class name.")
+        for class_name, tolerance in class_thresholds.items():
+            if (
+                class_name not in APPROVED_CLASS_NAMES
+                or not _is_finite_number(tolerance)
+                or not -1 <= float(tolerance) <= 1
+            ):
+                raise ComparisonError(
+                    "Per-class gate targets must be approved classes with finite numeric tolerances."
+                )
+    if not all(isinstance(name, str) and name in APPROVED_CLASS_NAMES for name in required_classes):
+        raise ComparisonError("Gate configuration required_classes must use approved class names.")
+    if len(set(required_classes)) != len(required_classes):
+        raise ComparisonError("Gate configuration required_classes must not contain duplicates.")
+    if not any((aggregate, per_class, required_classes, latency is not None)):
+        raise ComparisonError("Gate configuration must declare at least one gate.")
+    return payload
+
+
+def _gate_policy_reference(
+    source: Path | None, gate_config: Mapping[str, object] | None
+) -> dict[str, object]:
+    if source is None or gate_config is None:
+        return {
+            "configuration_supplied": False,
+            "source_filename": None,
+            "sha256": None,
+            "schema_version": None,
+            "policy_status": "not_supplied",
+            "gates": None,
+        }
+    return {
+        "configuration_supplied": True,
+        "source_filename": source.name,
+        "sha256": _sha256(source),
+        "schema_version": gate_config["schema_version"],
+        "policy_status": gate_config["policy_status"],
+        "gates": gate_config["gates"],
+    }
+
+
+def _empty_deltas() -> dict[str, object]:
+    return {"aggregate": {}, "per_class": {}, "latency_ms": None}
+
+
+def _per_class_coverage_issues(
+    metrics_by_name: Mapping[str, Mapping[str, object]], *, artifact_role: str
+) -> list[str]:
+    expected = set(APPROVED_CLASS_NAMES)
+    actual = set(metrics_by_name)
+    issues: list[str] = []
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unexpected = sorted(actual - expected)
+        if missing:
+            issues.append(f"{artifact_role} per-class metrics are missing: {', '.join(missing)}.")
+        if unexpected:
+            issues.append(f"{artifact_role} per-class metrics include unknown classes: {', '.join(unexpected)}.")
+    for class_name in sorted(expected & actual):
+        for metric in AGGREGATE_METRICS:
+            if _probability(metrics_by_name[class_name].get(metric)) is None:
+                issues.append(
+                    f"{artifact_role} per-class metric {metric} for {class_name} is missing, non-finite, or outside 0..1."
+                )
+    return issues
+
+
+def _metric_deltas(
+    baseline_metrics: Mapping[str, object], candidate_metrics: Mapping[str, object]
+) -> tuple[dict[str, object], list[str]]:
+    deltas = _empty_deltas()
+    missing: list[str] = []
+    aggregate: dict[str, float | None] = {}
+    for name in AGGREGATE_METRICS:
+        baseline_value = _probability(baseline_metrics.get(name))
+        candidate_value = _probability(candidate_metrics.get(name))
+        if baseline_value is None or candidate_value is None:
+            aggregate[name] = None
+            missing.append(
+                f"Aggregate metric {name} is missing, non-finite, or outside 0..1."
+            )
+        else:
+            aggregate[name] = candidate_value - baseline_value
+    deltas["aggregate"] = aggregate
+
+    baseline_per_class, baseline_issues = _per_class_metrics(baseline_metrics)
+    candidate_per_class, candidate_issues = _per_class_metrics(candidate_metrics)
+    missing.extend(baseline_issues)
+    missing.extend(candidate_issues)
+    missing.extend(_per_class_coverage_issues(baseline_per_class, artifact_role="Baseline"))
+    missing.extend(_per_class_coverage_issues(candidate_per_class, artifact_role="Candidate"))
+    per_class: dict[str, dict[str, float | None]] = {}
+    for class_name in sorted(set(baseline_per_class) | set(candidate_per_class)):
+        per_class[class_name] = {}
+        for metric in AGGREGATE_METRICS:
+            baseline_value = _probability(baseline_per_class.get(class_name, {}).get(metric))
+            candidate_value = _probability(candidate_per_class.get(class_name, {}).get(metric))
+            per_class[class_name][metric] = (
+                candidate_value - baseline_value
+                if baseline_value is not None and candidate_value is not None
+                else None
+            )
+    deltas["per_class"] = per_class
+
+    baseline_latency = _latency_ms(baseline_metrics)
+    candidate_latency = _latency_ms(candidate_metrics)
+    deltas["latency_ms"] = (
+        candidate_latency - baseline_latency
+        if baseline_latency is not None and candidate_latency is not None
+        else None
+    )
+    return deltas, missing
+
+
+def _below_minimum(actual: float, minimum: float) -> bool:
+    """Treat a value within a tiny floating-point representation error as equal."""
+    return actual < minimum and not math.isclose(
+        actual, minimum, rel_tol=0.0, abs_tol=METRIC_COMPARISON_TOLERANCE
+    )
+
+
+def _above_maximum(actual: float, maximum: float) -> bool:
+    """Treat a value within a tiny floating-point representation error as equal."""
+    return actual > maximum and not math.isclose(
+        actual, maximum, rel_tol=0.0, abs_tol=METRIC_COMPARISON_TOLERANCE
+    )
+
+
+def _evaluate_gates(
+    deltas: Mapping[str, object],
+    baseline_metrics: Mapping[str, object],
+    candidate_metrics: Mapping[str, object],
+    gate_config: Mapping[str, object] | None,
+) -> tuple[str, list[str]]:
+    if gate_config is None:
+        return "REVIEW", ["No explicitly supplied promotion-gate configuration is available."]
+
+    if gate_config.get("policy_status") != APPROVED_POLICY_STATUS:
+        return "REVIEW", [
+            "The supplied configuration is not marked APPROVED_POLICY; automatic promotion requires ML-team/project approval."
+        ]
+
+    gates = gate_config["gates"]
+    assert isinstance(gates, Mapping)
+    reasons: list[str] = []
+    aggregate_deltas = deltas["aggregate"]
+    assert isinstance(aggregate_deltas, Mapping)
+    for metric, minimum_delta in gates.get("aggregate_minimum_deltas", {}).items():
+        actual_delta = aggregate_deltas.get(metric)
+        if not _is_finite_number(actual_delta):
+            return "REVIEW", [f"Required aggregate metric {metric} is missing or non-finite."]
+        if _below_minimum(float(actual_delta), float(minimum_delta)):
+            reasons.append(f"Aggregate {metric} delta {actual_delta} is below configured minimum {minimum_delta}.")
+
+    per_class_deltas = deltas["per_class"]
+    assert isinstance(per_class_deltas, Mapping)
+    baseline_per_class, _ = _per_class_metrics(baseline_metrics)
+    candidate_per_class, _ = _per_class_metrics(candidate_metrics)
+    for metric, class_thresholds in gates.get("per_class_minimum_deltas", {}).items():
+        assert isinstance(class_thresholds, Mapping)
+        for class_name, minimum_delta in class_thresholds.items():
+            actual = per_class_deltas.get(class_name)
+            actual_delta = actual.get(metric) if isinstance(actual, Mapping) else None
+            if class_name not in baseline_per_class or class_name not in candidate_per_class or not _is_finite_number(actual_delta):
+                return "REVIEW", [f"Required per-class metric {metric} for {class_name} is missing or non-finite."]
+            if _below_minimum(float(actual_delta), float(minimum_delta)):
+                reasons.append(
+                    f"Per-class {metric} delta for {class_name} is below configured minimum {minimum_delta}."
+                )
+
+    for class_name in gates.get("required_classes", []):
+        if class_name not in baseline_per_class or class_name not in candidate_per_class:
+            return "REVIEW", [f"Required class {class_name} is missing from per-class metrics."]
+
+    maximum_latency = gates.get("maximum_latency_increase_ms")
+    if maximum_latency is not None:
+        latency_delta = deltas["latency_ms"]
+        if not _is_finite_number(latency_delta):
+            return "REVIEW", ["Required inference latency is missing or non-finite."]
+        if _above_maximum(float(latency_delta), float(maximum_latency)):
+            reasons.append(
+                f"Inference latency increase {latency_delta} ms exceeds configured maximum {maximum_latency} ms."
+            )
+    return ("FAIL", reasons) if reasons else ("PASS", ["All explicitly supplied gates passed."])
+
+
+def compare_evaluations(
+    baseline_path: str | Path,
+    candidate_path: str | Path,
+    *,
+    gate_config_path: str | Path | None = None,
+    candidate_validation_path: str | Path | None = None,
+) -> dict[str, object]:
+    """Compare compatible versioned evaluation artifacts without changing models."""
+    baseline_source, baseline = load_evaluation_artifact(baseline_path)
+    candidate_source, candidate = load_evaluation_artifact(candidate_path)
+    gate_source = Path(gate_config_path).expanduser().resolve() if gate_config_path is not None else None
+    gate_config = _load_gate_config(gate_source) if gate_source is not None else None
+    validation_source: Path | None = None
+    validation_report: dict[str, object] | None = None
+    if candidate_validation_path is not None:
+        validation_source, validation_report = load_candidate_validation_report(
+            candidate_validation_path
+        )
+    validation_status, validation_reason = _candidate_validation_status(
+        candidate, validation_report
+    )
+    reasons: list[str] = []
+    compatibility = "compatible"
+
+    if not _uses_approved_taxonomy(candidate):
+        compatibility = "incompatible_taxonomy"
+        reasons.append("The candidate must use the approved ordered eight-class taxonomy.")
+    elif validation_status == "failed":
+        compatibility = "candidate_validation_failed"
+        reasons.append(validation_reason)
+    elif validation_status == "mismatch":
+        compatibility = "candidate_validation_mismatch"
+        reasons.append(validation_reason)
+    elif baseline.get("baseline_type") == "historical_reference":
+        compatibility = "historical_reference_only"
+        reasons.append("Historical references cannot be used for automatic promotion.")
+    elif not _uses_approved_taxonomy(baseline):
+        compatibility = "incompatible_taxonomy"
+        reasons.append("The non-historical baseline must use the approved ordered eight-class taxonomy.")
+    elif baseline.get("baseline_type") != "canonical_8class_baseline":
+        compatibility = "baseline_not_canonical"
+        reasons.append("The baseline is not designated as a human-approved canonical 8-class baseline.")
+    elif baseline.get("mode") != candidate.get("mode"):
+        compatibility = "incompatible_evaluation_mode"
+        reasons.append("Evaluation modes differ.")
+    elif baseline.get("mode") != "labelled_validation":
+        compatibility = "ineligible_evaluation_mode"
+        reasons.append("Automatic promotion requires labelled validation, not an inference audit.")
+    elif not _settings_match(baseline, candidate):
+        compatibility = "incompatible_evaluation_settings"
+        reasons.append("Evaluation settings differ.")
+    elif not _has_compatible_metric_semantics(baseline) or not _has_compatible_metric_semantics(candidate):
+        compatibility = "incompatible_metric_semantics"
+        reasons.append("Artifacts do not declare the supported labelled-validation metric semantics.")
+    elif validation_status == "missing":
+        compatibility = "candidate_validation_missing"
+        reasons.append(validation_reason)
+
+    baseline_metrics = _validation_metrics(baseline)
+    candidate_metrics = _validation_metrics(candidate)
+    if baseline_metrics is None or candidate_metrics is None:
+        deltas = _empty_deltas()
+        reasons.append("Labelled validation metrics are missing.")
+        if compatibility == "compatible":
+            compatibility = "missing_metrics"
+    else:
+        deltas, metric_issues = _metric_deltas(baseline_metrics, candidate_metrics)
+        if metric_issues:
+            reasons.extend(metric_issues)
+            if compatibility == "compatible":
+                compatibility = "missing_metrics"
+
+    if compatibility != "compatible":
+        verdict = (
+            "FAIL"
+            if compatibility
+            in {
+                "incompatible_taxonomy",
+                "candidate_validation_failed",
+                "candidate_validation_mismatch",
+            }
+            else "REVIEW"
+        )
+        policy_reasons = ["Automatic promotion is not eligible for this comparison."]
+    else:
+        assert baseline_metrics is not None and candidate_metrics is not None
+        verdict, policy_reasons = _evaluate_gates(
+            deltas, baseline_metrics, candidate_metrics, gate_config
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tool": {"name": TOOL_NAME, "version": TOOL_VERSION},
+        "created_at_utc": _timestamp_utc(),
+        "baseline": _public_model_reference(baseline, baseline_source),
+        "candidate": _public_model_reference(candidate, candidate_source),
+        "candidate_validation": _candidate_validation_reference(
+            validation_source, validation_report
+        ),
+        "technical_compatibility": {"status": compatibility, "reasons": reasons},
+        "policy_gate": {
+            **_gate_policy_reference(gate_source, gate_config),
+            "result": verdict,
+            "reasons": policy_reasons,
+        },
+        "deltas": deltas,
+        "verdict": verdict,
+    }
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _prepare_output_directory(output_path: str | Path, overwrite: bool) -> Path:
+    path = Path(output_path).expanduser().resolve()
+    if _is_within(path, MODELS_DIR):
+        raise ComparisonError("Comparison output must not be written inside ML_side/models.")
+    if path.exists() and not path.is_dir():
+        raise ComparisonError("Comparison output path is not a directory.")
+    if path.exists() and any(path.iterdir()) and not overwrite:
+        raise ComparisonError("Comparison output directory is not empty. Use --overwrite to replace reports.")
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ComparisonError("Comparison output directory could not be created.") from exc
+    return path
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Replace one report atomically without leaving a partial destination file."""
+    temporary_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        temporary_path.write_text(content, encoding="utf-8")
+        os.replace(temporary_path, path)
+    except (OSError, UnicodeError):
+        try:
+            temporary_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def render_markdown_report(report: Mapping[str, object]) -> str:
+    compatibility = report["technical_compatibility"]
+    policy = report["policy_gate"]
+    validation = report["candidate_validation"]
+    assert (
+        isinstance(compatibility, Mapping)
+        and isinstance(policy, Mapping)
+        and isinstance(validation, Mapping)
+    )
+    lines = [
+        "# Model Evaluation Comparison",
+        "",
+        f"- Verdict: **{report['verdict']}**",
+        f"- Technical compatibility: `{compatibility['status']}`",
+        f"- Policy configuration supplied: `{policy['configuration_supplied']}`",
+        f"- Policy configuration file: `{policy['source_filename']}`",
+        f"- Policy configuration SHA-256: `{policy['sha256']}`",
+        f"- Policy status: `{policy['policy_status']}`",
+        f"- Candidate validation supplied: `{validation['supplied']}`",
+        f"- Candidate validation file: `{validation['source_filename']}`",
+        f"- Candidate validation verdict: `{validation['verdict']}`",
+        "",
+        "## Reasons",
+        "",
+    ]
+    reasons = list(compatibility["reasons"]) + list(policy["reasons"])
+    lines.extend(f"- {reason}" for reason in reasons)
+    lines.extend(["", "## Deltas", "", "```json", json.dumps(report["deltas"], indent=2, sort_keys=True, allow_nan=False), "```", ""])
+    return "\n".join(lines)
+
+
+def run_comparison(
+    *,
+    baseline_path: str | Path,
+    candidate_path: str | Path,
+    output_path: str | Path,
+    gate_config_path: str | Path | None = None,
+    candidate_validation_path: str | Path | None = None,
+    overwrite: bool = False,
+) -> dict[str, object]:
+    output = _prepare_output_directory(output_path, overwrite)
+    report = compare_evaluations(
+        baseline_path,
+        candidate_path,
+        gate_config_path=gate_config_path,
+        candidate_validation_path=candidate_validation_path,
+    )
+    try:
+        _atomic_write_text(
+            output / "model_comparison.json",
+            json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        )
+        _atomic_write_text(
+            output / "model_comparison.md", render_markdown_report(report)
+        )
+    except (OSError, TypeError, UnicodeError, ValueError) as exc:
+        raise ComparisonError("Comparison report could not be written.") from exc
+    return report
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare versioned WalkBuddy model evaluations without promoting models."
+    )
+    parser.add_argument("--baseline", required=True, help="Baseline summary JSON or result directory.")
+    parser.add_argument("--candidate", required=True, help="Candidate summary JSON or result directory.")
+    parser.add_argument("--output", required=True, help="Directory for comparison reports.")
+    parser.add_argument(
+        "--candidate-validation",
+        help="Candidate validation JSON or directory; required for an automatic PASS.",
+    )
+    parser.add_argument("--gates", help="Explicitly supplied promotion-gate JSON; no default is used.")
+    parser.add_argument("--overwrite", action="store_true", help="Allow report replacement in a non-empty output directory.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = run_comparison(
+            baseline_path=args.baseline,
+            candidate_path=args.candidate,
+            output_path=args.output,
+            gate_config_path=args.gates,
+            candidate_validation_path=args.candidate_validation,
+            overwrite=args.overwrite,
+        )
+    except ComparisonError as exc:
+        print(f"Model comparison failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Model comparison verdict: {report['verdict']}")
+    return {"PASS": 0, "FAIL": 1, "REVIEW": 2}[str(report["verdict"])]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ML_side/tools/evaluate_current_model.py
+++ b/ML_side/tools/evaluate_current_model.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
+import os
 import re
 import sys
+from uuid import uuid4
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from time import perf_counter
 from typing import Any
@@ -18,6 +22,18 @@ import inspect_active_model as model_inspector
 
 DEFAULT_MODEL_PATH = Path(__file__).resolve().parents[1] / "models" / "best.pt"
 SUPPORTED_IMAGE_EXTENSIONS = frozenset({".jpg", ".jpeg", ".png"})
+EVALUATION_SCHEMA_VERSION = "1.0.0"
+TOOL_NAME = "evaluate_current_model"
+TOOL_VERSION = "2.0.0"
+DEFAULT_OPERATING_CONFIDENCE = 0.25
+DEFAULT_OPERATING_IOU = 0.45
+LABELLED_VALIDATION_METRIC_SEMANTICS = {
+    "metric_unit": "fraction_0_to_1",
+    "aggregate_metrics": ["precision", "recall", "mAP50", "mAP50_95"],
+    "per_class_metrics": ["precision", "recall", "mAP50", "mAP50_95"],
+    "latency": "milliseconds_per_image",
+    "source": "ultralytics_model_val",
+}
 UNLABELLED_AUDIT_LABEL = (
     "Unlabelled inference audit — these results are not precision, recall, or "
     "mAP accuracy metrics."
@@ -26,6 +42,26 @@ UNLABELLED_AUDIT_LABEL = (
 
 class EvaluationError(Exception):
     """Raised when a baseline evaluation cannot be completed safely."""
+
+
+def _timestamp_utc() -> str:
+    """Return a portable UTC timestamp for generated evaluation artifacts."""
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _finite_float(value: object) -> float:
+    """Return a finite scalar so generated JSON cannot contain NaN or infinity."""
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise ValueError("Expected a finite numeric value.")
+    return numeric
+
+
+def _validate_operating_point(confidence: float, iou: float) -> None:
+    if not 0 <= confidence <= 1:
+        raise EvaluationError("Operating confidence must be between 0 and 1.")
+    if not 0 <= iou <= 1:
+        raise EvaluationError("Operating IoU must be between 0 and 1.")
 
 
 @dataclass(frozen=True)
@@ -149,7 +185,7 @@ def _as_float(value: object) -> float:
     values = _as_list(value)
     if len(values) != 1:
         raise ValueError("Expected a scalar value.")
-    return float(values[0])
+    return _finite_float(values[0])
 
 
 def _as_int(value: object) -> int:
@@ -173,7 +209,7 @@ def serialise_prediction_result(
                     "class_id": class_id,
                     "class_name": class_names.get(class_id, f"unknown_{class_id}"),
                     "confidence": _as_float(getattr(box, "conf")),
-                    "bbox_xyxy": [float(value) for value in coordinates[:4]],
+                    "bbox_xyxy": [_finite_float(value) for value in coordinates[:4]],
                 }
             )
 
@@ -186,7 +222,12 @@ def serialise_prediction_result(
 
 
 def run_unlabelled_inference_audit(
-    model: Any, discovery: ImageDiscovery, class_names: Mapping[int, str]
+    model: Any,
+    discovery: ImageDiscovery,
+    class_names: Mapping[int, str],
+    *,
+    confidence: float,
+    iou: float,
 ) -> tuple[list[dict[str, object]], list[dict[str, str]], dict[str, object]]:
     """Run local inference one image at a time without saving or copying images."""
     predictions: list[dict[str, object]] = []
@@ -197,19 +238,30 @@ def run_unlabelled_inference_audit(
     for image_path in discovery.images:
         try:
             started = perf_counter()
-            results = model.predict(source=str(image_path), save=False, verbose=False)
+            results = model.predict(
+                source=str(image_path),
+                save=False,
+                verbose=False,
+                conf=confidence,
+                iou=iou,
+            )
             inference_ms = (perf_counter() - started) * 1000
             if not results:
                 raise ValueError("Model returned no result.")
             prediction = serialise_prediction_result(
                 results[0], image_path, class_names, inference_ms
             )
-        except Exception as exc:
-            failed_images.append({"image_filename": image_path.name, "error": str(exc)})
+        except Exception:
+            failed_images.append(
+                {
+                    "image_filename": image_path.name,
+                    "error": "Inference or detection serialisation failed.",
+                }
+            )
             continue
 
         predictions.append(prediction)
-        inference_times.append(float(prediction["inference_time_ms"]))
+        inference_times.append(_finite_float(prediction["inference_time_ms"]))
         for detection in prediction["detections"]:  # type: ignore[union-attr]
             detection_counts[str(detection["class_name"])] += 1
 
@@ -258,7 +310,7 @@ def _sequence_value(value: object, index: int) -> float | None:
     if value is None:
         return None
     try:
-        return float(_as_list(value)[index])
+        return _finite_float(_as_list(value)[index])
     except (IndexError, TypeError, ValueError):
         return None
 
@@ -290,7 +342,7 @@ def extract_validation_metrics(
 
     speed = getattr(metrics, "speed", None)
     inference_timing_ms = (
-        {str(key): float(value) for key, value in speed.items()}
+        {str(key): _finite_float(value) for key, value in speed.items()}
         if isinstance(speed, Mapping)
         else None
     )
@@ -322,28 +374,77 @@ def extract_validation_metrics(
     }
 
 
-def _metadata_payload(metadata: model_inspector.ModelMetadata) -> dict[str, object]:
+def _model_lineage(metadata: model_inspector.ModelMetadata) -> dict[str, object]:
     return {
         "filename": metadata.path.name,
-        "resolved_path": str(metadata.path),
         "file_size_bytes": metadata.size_bytes,
         "sha256": metadata.sha256,
         "class_count": len(metadata.class_names),
         "class_id_to_name": {str(key): value for key, value in metadata.class_names.items()},
+        "ordered_class_names": [metadata.class_names[key] for key in sorted(metadata.class_names)],
     }
+
+
+def _metadata_payload(metadata: model_inspector.ModelMetadata) -> dict[str, object]:
+    """Return a versioned, path-safe model metadata artifact."""
+    return {
+        "schema_version": EVALUATION_SCHEMA_VERSION,
+        "tool": {"name": TOOL_NAME, "version": TOOL_VERSION},
+        "created_at_utc": _timestamp_utc(),
+        "model": _model_lineage(metadata),
+    }
+
+
+def _evaluation_envelope(
+    metadata: model_inspector.ModelMetadata,
+    *,
+    mode: str,
+    settings: Mapping[str, object],
+    metric_semantics: Mapping[str, object] | None,
+    results: Mapping[str, object],
+) -> dict[str, object]:
+    """Create the common versioned result structure consumed by comparison tooling."""
+    return {
+        "schema_version": EVALUATION_SCHEMA_VERSION,
+        "tool": {"name": TOOL_NAME, "version": TOOL_VERSION},
+        "created_at_utc": _timestamp_utc(),
+        "baseline_type": "evaluation",
+        "model": _model_lineage(metadata),
+        "mode": mode,
+        "evaluation_settings": dict(settings),
+        "metric_semantics": dict(metric_semantics) if metric_semantics is not None else None,
+        "results": dict(results),
+    }
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Replace one report atomically without leaving a partial destination file."""
+    temporary_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        temporary_path.write_text(content, encoding="utf-8")
+        os.replace(temporary_path, path)
+    except (OSError, UnicodeError):
+        try:
+            temporary_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 def _write_json(path: Path, payload: Mapping[str, object]) -> None:
     try:
-        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    except (OSError, TypeError) as exc:
+        _atomic_write_text(
+            path,
+            json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        )
+    except (OSError, TypeError, ValueError) as exc:
         raise EvaluationError(f"Output write failed: {path}") from exc
 
 
 def _write_report(path: Path, content: str) -> None:
     try:
-        path.write_text(content, encoding="utf-8")
-    except OSError as exc:
+        _atomic_write_text(path, content)
+    except (OSError, UnicodeError) as exc:
         raise EvaluationError(f"Output write failed: {path}") from exc
 
 
@@ -356,7 +457,6 @@ def _format_report(
         "## Model metadata",
         "",
         f"- Filename: `{metadata.path.name}`",
-        f"- Resolved path: `{metadata.path}`",
         f"- File size: {metadata.size_bytes} bytes",
         f"- SHA-256: `{metadata.sha256}`",
         f"- Class count: {len(metadata.class_names)}",
@@ -403,11 +503,14 @@ def evaluate(
     images_path: str | Path | None = None,
     dataset_yaml: str | Path | None = None,
     overwrite: bool = False,
+    operating_confidence: float = DEFAULT_OPERATING_CONFIDENCE,
+    operating_iou: float = DEFAULT_OPERATING_IOU,
     yolo_loader: Callable[[str], Any] | None = None,
 ) -> dict[str, object]:
     """Evaluate a local model in exactly one safe, explicit mode."""
     if (images_path is None) == (dataset_yaml is None):
         raise EvaluationError("Provide exactly one of an image folder or a dataset YAML file.")
+    _validate_operating_point(operating_confidence, operating_iou)
 
     model = validate_model_path(model_path)
     discovery = discover_images(images_path) if images_path is not None else None
@@ -418,13 +521,42 @@ def evaluate(
 
     if discovery is not None:
         predictions, failed_images, summary = run_unlabelled_inference_audit(
-            yolo_model, discovery, metadata.class_names
+            yolo_model,
+            discovery,
+            metadata.class_names,
+            confidence=operating_confidence,
+            iou=operating_iou,
         )
+        settings = {
+            "operating_point_inference": {
+                "confidence": operating_confidence,
+                "iou": operating_iou,
+                "save": False,
+                "verbose": False,
+            },
+            "validation_ap": None,
+        }
+        summary = {
+            **_evaluation_envelope(
+                metadata,
+                mode="unlabelled_inference_audit",
+                settings=settings,
+                metric_semantics=None,
+                results=summary,
+            ),
+            **summary,
+        }
         _write_json(output / "model_metadata.json", metadata_payload)
         _write_json(
             output / "predictions.json",
             {
+                "schema_version": EVALUATION_SCHEMA_VERSION,
+                "tool": {"name": TOOL_NAME, "version": TOOL_VERSION},
+                "created_at_utc": _timestamp_utc(),
+                "model": _model_lineage(metadata),
                 "mode": "unlabelled_inference_audit",
+                "evaluation_settings": settings,
+                "metric_semantics": None,
                 "result_label": UNLABELLED_AUDIT_LABEL,
                 "images": predictions,
                 "failed_images": failed_images,
@@ -446,13 +578,47 @@ def evaluate(
             raise EvaluationError("Labelled validation failed.") from exc
 
         validation_metrics = extract_validation_metrics(validation_result, metadata.class_names)
+        settings = {
+            "operating_point_inference": None,
+            "validation_ap": {
+                "engine": "ultralytics_model_val",
+                "confidence": "ultralytics_default_sweep",
+                "iou": "ultralytics_default",
+                "plots": False,
+                "save_json": False,
+                "verbose": False,
+            },
+        }
+        labelled_results = {"validation_metrics": validation_metrics}
         summary = {
+            **_evaluation_envelope(
+                metadata,
+                mode="labelled_validation",
+                settings=settings,
+                metric_semantics=LABELLED_VALIDATION_METRIC_SEMANTICS,
+                results=labelled_results,
+            ),
             "mode": "labelled_validation",
-            "dataset_yaml": str(dataset),
+            "dataset_yaml_filename": dataset.name,
             "validation_metrics": validation_metrics,
         }
         _write_json(output / "model_metadata.json", metadata_payload)
-        _write_json(output / "validation_metrics.json", validation_metrics)
+        _write_json(
+            output / "validation_metrics.json",
+            {
+                "schema_version": EVALUATION_SCHEMA_VERSION,
+                "tool": {"name": TOOL_NAME, "version": TOOL_VERSION},
+                "created_at_utc": _timestamp_utc(),
+                "model": _model_lineage(metadata),
+                "mode": "labelled_validation",
+                "evaluation_settings": settings,
+                "metric_semantics": LABELLED_VALIDATION_METRIC_SEMANTICS,
+                "validation_metrics": validation_metrics,
+                # Retain the existing top-level metric keys for consumers of the
+                # earlier artifact shape.
+                **validation_metrics,
+            },
+        )
         _write_json(output / "summary.json", summary)
 
     _write_report(output / "baseline_report.md", _format_report(metadata, summary))
@@ -473,6 +639,18 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     mode.add_argument("--dataset-yaml", help="Local labelled YOLO dataset YAML for validation.")
     parser.add_argument("--output", required=True, help="Directory for generated result files.")
     parser.add_argument(
+        "--operating-confidence",
+        type=float,
+        default=DEFAULT_OPERATING_CONFIDENCE,
+        help="Confidence used only for unlabelled operating-point inference audits.",
+    )
+    parser.add_argument(
+        "--operating-iou",
+        type=float,
+        default=DEFAULT_OPERATING_IOU,
+        help="IoU used only for unlabelled operating-point inference audits.",
+    )
+    parser.add_argument(
         "--overwrite",
         action="store_true",
         help="Allow writing result files into a non-empty output directory.",
@@ -490,6 +668,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             images_path=args.images,
             dataset_yaml=args.dataset_yaml,
             overwrite=args.overwrite,
+            operating_confidence=args.operating_confidence,
+            operating_iou=args.operating_iou,
         )
     except EvaluationError as exc:
         print(f"Evaluation failed: {exc}", file=sys.stderr)

--- a/ML_side/tools/validate_candidate_model.py
+++ b/ML_side/tools/validate_candidate_model.py
@@ -1,0 +1,389 @@
+"""Offline validation for a candidate WalkBuddy navigation detection model.
+
+This tool validates a supplied artifact and writes only reports. It never
+renames, copies, promotes, exports, or replaces model weights.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import UTC, datetime
+from numbers import Integral
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import inspect_active_model as model_inspector
+import validate_dataset_manifest as manifest_validator
+
+
+SCHEMA_VERSION = "1.0.0"
+TOOL_NAME = "validate_candidate_model"
+TOOL_VERSION = "1.0.0"
+ML_SIDE_DIR = Path(__file__).resolve().parents[1]
+MODELS_DIR = (ML_SIDE_DIR / "models").resolve()
+APPROVED_TAXONOMY = manifest_validator.APPROVED_TAXONOMY
+
+
+class CandidateValidationError(Exception):
+    """Raised for an unsafe report destination or invalid command invocation."""
+
+
+def _timestamp_utc() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _check(name: str, status: str, message: str) -> dict[str, str]:
+    return {"name": name, "status": status, "message": message}
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def prepare_output_directory(output_path: str | Path, overwrite: bool) -> Path:
+    """Create a report directory while refusing model-weight locations."""
+    path = Path(output_path).expanduser().resolve()
+    if _is_within(path, MODELS_DIR):
+        raise CandidateValidationError("Report output must not be written inside ML_side/models.")
+    if path.exists() and not path.is_dir():
+        raise CandidateValidationError("Report output path is not a directory.")
+    if path.exists() and any(path.iterdir()) and not overwrite:
+        raise CandidateValidationError(
+            "Report output directory is not empty. Use --overwrite to replace report files."
+        )
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise CandidateValidationError("Report output directory could not be created.") from exc
+    return path
+
+
+def _safe_json(value: object) -> object:
+    """Reject values that would make the report non-portable JSON."""
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("Non-finite value")
+        return value
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _safe_json(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [_safe_json(item) for item in value]
+    raise ValueError("Non-serialisable value")
+
+
+def _write_json(path: Path, payload: Mapping[str, object]) -> None:
+    try:
+        safe_payload = _safe_json(payload)
+        _atomic_write_text(
+            path,
+            json.dumps(safe_payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        )
+    except (OSError, TypeError, ValueError) as exc:
+        raise CandidateValidationError("Candidate report JSON could not be written.") from exc
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Replace one report atomically without leaving a partial destination file."""
+    temporary_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        temporary_path.write_text(content, encoding="utf-8")
+        os.replace(temporary_path, path)
+    except (OSError, UnicodeError):
+        try:
+            temporary_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def render_markdown_report(report: Mapping[str, object]) -> str:
+    """Render a path-safe human-readable report from the machine-readable data."""
+    candidate = report["candidate"]
+    assert isinstance(candidate, Mapping)
+    lines = [
+        "# Candidate Model Validation",
+        "",
+        f"- Verdict: **{report['verdict']}**",
+        f"- File: `{candidate.get('filename')}`",
+        f"- File size: {candidate.get('file_size_bytes')} bytes",
+        f"- SHA-256: `{candidate.get('sha256')}`",
+        f"- Class count: {candidate.get('class_count')}",
+        "",
+        "## Checks",
+        "",
+        "| Check | Status | Detail |",
+        "| --- | --- | --- |",
+    ]
+    for check in report["checks"]:
+        assert isinstance(check, Mapping)
+        lines.append(f"| {check['name']} | {check['status']} | {check['message']} |")
+    warnings = report["warnings"]
+    if warnings:
+        lines.extend(["", "## Warnings", ""])
+        lines.extend(f"- {warning}" for warning in warnings)
+    lines.extend(
+        [
+            "",
+            "The smoke test confirms only that the supplied model executed on a local image. "
+            "It does not establish detection quality or approve deployment.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _candidate_stub(candidate_path: Path) -> dict[str, object]:
+    return {
+        "filename": candidate_path.name,
+        "file_size_bytes": None,
+        "sha256": None,
+        "task": None,
+        "class_count": None,
+        "class_id_to_name": None,
+        "ordered_class_names": None,
+    }
+
+
+def _has_strict_class_ids(names: object) -> bool:
+    """Reject lossy IDs such as ``0.5`` before class metadata is normalised."""
+    if isinstance(names, Mapping):
+        raw_ids = names.keys()
+    elif isinstance(names, Sequence) and not isinstance(names, (str, bytes)):
+        raw_ids = range(len(names))
+    else:
+        return False
+    for raw_id in raw_ids:
+        if isinstance(raw_id, bool):
+            return False
+        if isinstance(raw_id, Integral):
+            continue
+        if (
+            isinstance(raw_id, str)
+            and raw_id.isascii()
+            and raw_id.isdecimal()
+            and raw_id == str(int(raw_id))
+        ):
+            continue
+        return False
+    return True
+
+
+def validate_candidate(
+    candidate_path: str | Path,
+    *,
+    smoke_image: str | Path | None = None,
+    yolo_loader: Callable[[str], Any] | None = None,
+) -> dict[str, object]:
+    """Validate an artifact with injected loading and local-only optional smoke input."""
+    path = Path(candidate_path).expanduser().resolve()
+    candidate = _candidate_stub(path)
+    checks: list[dict[str, str]] = []
+    warnings: list[str] = []
+    model: Any | None = None
+
+    if not path.exists():
+        checks.append(_check("artifact_exists", "fail", "Candidate artifact is missing."))
+    elif not path.is_file():
+        checks.append(_check("artifact_is_file", "fail", "Candidate path is not a regular file."))
+    else:
+        checks.append(_check("artifact_exists", "pass", "Candidate artifact exists."))
+        try:
+            size_bytes = path.stat().st_size
+        except OSError:
+            checks.append(_check("artifact_size", "fail", "Candidate artifact size could not be read."))
+        else:
+            candidate["file_size_bytes"] = size_bytes
+            if size_bytes <= 0:
+                checks.append(_check("artifact_size", "fail", "Candidate artifact is empty."))
+            else:
+                checks.append(_check("artifact_size", "pass", "Candidate artifact is non-empty."))
+        try:
+            candidate["sha256"] = model_inspector.calculate_sha256(path)
+        except OSError:
+            checks.append(_check("sha256", "fail", "Candidate checksum could not be computed."))
+        else:
+            checks.append(_check("sha256", "pass", "Candidate checksum was computed."))
+
+        try:
+            loader = yolo_loader or model_inspector._get_yolo_loader()
+            model = loader(str(path))
+        except Exception:
+            checks.append(_check("model_load", "fail", "Candidate model could not be loaded."))
+        else:
+            checks.append(_check("model_load", "pass", "Candidate model loaded."))
+
+    class_names: dict[int, str] | None = None
+    if model is not None:
+        try:
+            task = getattr(model, "task")
+        except Exception:
+            warnings.append("Model task metadata was unavailable.")
+            checks.append(_check("detection_task", "warning", "Model task metadata was unavailable."))
+        else:
+            candidate["task"] = task if isinstance(task, str) else None
+            if task == "detect":
+                checks.append(_check("detection_task", "pass", "Model task is detection."))
+            elif task is None:
+                warnings.append("Model task metadata was unavailable.")
+                checks.append(_check("detection_task", "warning", "Model task metadata was unavailable."))
+            else:
+                checks.append(_check("detection_task", "fail", "Model task is not detection."))
+
+        try:
+            raw_class_names = model.names
+            if not _has_strict_class_ids(raw_class_names):
+                raise model_inspector.InspectionError("Model class IDs are malformed.")
+            class_names = model_inspector.normalise_class_names(raw_class_names)
+        except Exception:
+            checks.append(
+                _check("class_metadata", "fail", "Model class metadata is missing or malformed.")
+            )
+        else:
+            candidate["class_count"] = len(class_names)
+            candidate["class_id_to_name"] = {
+                str(class_id): name for class_id, name in class_names.items()
+            }
+            candidate["ordered_class_names"] = [
+                class_names[class_id] for class_id in sorted(class_names)
+            ]
+            if len(class_names) == len(APPROVED_TAXONOMY):
+                checks.append(
+                    _check("class_count", "pass", "Model class count is exactly eight.")
+                )
+            else:
+                checks.append(
+                    _check("class_count", "fail", "Model class count is not exactly eight.")
+                )
+            actual_taxonomy = list(class_names.items())
+            if actual_taxonomy == list(APPROVED_TAXONOMY):
+                checks.append(
+                    _check("approved_taxonomy", "pass", "Class IDs and ordered names match the approved taxonomy.")
+                )
+            else:
+                checks.append(
+                    _check(
+                        "approved_taxonomy",
+                        "fail",
+                        "Class IDs and ordered names do not match the approved taxonomy.",
+                    )
+                )
+
+    try:
+        _safe_json(candidate)
+    except ValueError:
+        checks.append(
+            _check("report_metadata", "fail", "Model metadata is not safely serialisable.")
+        )
+    else:
+        checks.append(
+            _check("report_metadata", "pass", "Reported metadata is finite and serialisable.")
+        )
+
+    if model is None:
+        checks.append(_check("smoke_inference", "fail", "Smoke inference could not run without a loaded model."))
+    elif smoke_image is None:
+        checks.append(_check("smoke_inference", "fail", "A local smoke image is required to confirm execution."))
+    else:
+        image_path = Path(smoke_image).expanduser().resolve()
+        if not image_path.is_file():
+            checks.append(_check("smoke_inference", "fail", "Smoke image is missing or not a file."))
+        else:
+            try:
+                model.predict(source=str(image_path), save=False, verbose=False)
+            except Exception:
+                checks.append(_check("smoke_inference", "fail", "Candidate smoke inference failed."))
+            else:
+                checks.append(_check("smoke_inference", "pass", "Candidate smoke inference completed."))
+
+    if any(check["status"] == "fail" for check in checks):
+        verdict = "fail"
+    elif warnings:
+        verdict = "pass_with_warnings"
+    else:
+        verdict = "pass"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tool": {"name": TOOL_NAME, "version": TOOL_VERSION},
+        "created_at_utc": _timestamp_utc(),
+        "candidate": candidate,
+        "approved_taxonomy": [
+            {"id": class_id, "name": name} for class_id, name in APPROVED_TAXONOMY
+        ],
+        "checks": checks,
+        "warnings": warnings,
+        "verdict": verdict,
+    }
+
+
+def run_validation(
+    *,
+    candidate_path: str | Path,
+    output_path: str | Path,
+    smoke_image: str | Path | None = None,
+    overwrite: bool = False,
+    yolo_loader: Callable[[str], Any] | None = None,
+) -> dict[str, object]:
+    """Validate and write reports without making any change to model artifacts."""
+    output = prepare_output_directory(output_path, overwrite)
+    report = validate_candidate(
+        candidate_path, smoke_image=smoke_image, yolo_loader=yolo_loader
+    )
+    _write_json(output / "candidate_model_report.json", report)
+    try:
+        _atomic_write_text(
+            output / "candidate_model_report.md", render_markdown_report(report)
+        )
+    except (OSError, UnicodeError) as exc:
+        raise CandidateValidationError("Candidate report Markdown could not be written.") from exc
+    return report
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Offline validation for a candidate WalkBuddy detection model."
+    )
+    parser.add_argument("--model", required=True, help="Local candidate model file.")
+    parser.add_argument("--output", required=True, help="Directory for validation reports.")
+    parser.add_argument(
+        "--smoke-image",
+        required=True,
+        help="Trusted local image used only to confirm model execution.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow report files to replace files in a non-empty output directory.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = run_validation(
+            candidate_path=args.model,
+            output_path=args.output,
+            smoke_image=args.smoke_image,
+            overwrite=args.overwrite,
+        )
+    except CandidateValidationError as exc:
+        print(f"Candidate validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Candidate validation verdict: {report['verdict']}")
+    return 1 if report["verdict"] == "fail" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the missing model-side lifecycle between training a candidate model and considering it for production use.

The new offline workflow supports:

candidate artifact validation
→ versioned evaluation
→ compatible baseline comparison
→ explicit PASS / FAIL / REVIEW recommendation

This complements the existing dataset inspection/release/training pipeline without modifying production model weights or deployment behaviour.

## Candidate validation

Adds a candidate-model validator that checks:

- artifact existence and file validity
- SHA-256 lineage
- Ultralytics loadability
- detection task compatibility
- exact approved 8-class taxonomy
- ordered class names
- contiguous/integral class IDs
- JSON-safe metadata
- inference smoke-test compatibility

The validator never modifies or promotes model weights.

## Evaluation improvements

Evaluation artifacts now include:

- schema/tool versions
- model SHA-256
- ordered class names
- class count
- evaluation mode
- metric semantics
- effective settings
- JSON-safe values

Unlabelled inference audits use the production operating point:

- `conf=0.25`
- `iou=0.45`

Labelled Ultralytics validation retains its normal AP evaluation behaviour rather than forcing those operating thresholds into mAP calculation.

## Comparison and promotion gating

Adds offline comparison of compatible baseline and candidate evaluations including:

- aggregate metric deltas
- per-class metric deltas by class name
- latency comparison
- taxonomy compatibility
- evaluation-setting compatibility
- explicit gate-policy validation

Decision states:

- `PASS` — compatible candidate satisfies every explicitly approved gate
- `FAIL` — structural validation or approved policy gate fails
- `REVIEW` — comparison is incomplete, incompatible, historical, or lacks approved gates

Automatic PASS requires a matching successful candidate-validation report.

## Historical model handling

The current 7-class model is represented only as a:

`historical_reference`

It cannot automatically approve or reject the first 8-class navigation model because the taxonomies differ.

A future human-approved 8-class evaluation can later become the canonical comparison baseline.

## Safety boundaries

This PR does NOT:

- replace `ML_side/models/best.pt`
- copy or rename model weights
- deploy a model
- add `--promote` or `--apply`
- train models
- modify datasets
- modify the approved taxonomy
- define risk/hazard tiers
- modify the production backend or frontend
- introduce automatic gate-policy defaults

`promotion_gates.example.json` is explicitly marked:

`EXAMPLE_NOT_APPROVED_POLICY`

and is never loaded automatically.

## Verification

After adversarial review:

- candidate-validator tests: **21 passed**
- comparison tests: **37 passed**
- evaluator tests: **11 passed**
- focused total: **69 passed**
- full ML suite: **259 passed**
- CLI help checks: passed
- Python compilation: passed
- `git diff --check`: passed
- working tree: clean

## Commit

`8e2481fa48c358dd630fe8a5a71960cb9a16f2ec`

`Add candidate model validation and promotion gating`

## Remaining project decisions

Outside this PR, the ML team still needs to approve:

- real promotion thresholds
- designation of the first canonical 8-class baseline
- representative labelled validation data

Those decisions are deliberately not hardcoded here.