### PR TITLE
Harden temporal detection stabilization

### DIFF
--- a/ML_side/inference/__init__.py
+++ b/ML_side/inference/__init__.py
@@ -1,0 +1,1 @@
+"""Standalone ML inference helpers that are not wired into production yet."""

--- a/ML_side/inference/detection_stabilizer.py
+++ b/ML_side/inference/detection_stabilizer.py
@@ -1,84 +1,395 @@
-"""Temporal persistence + cooldown filter for spoken detection announcements.
+"""Deterministic, policy-neutral temporal stabilization for detections.
 
-Ported from ML_side/notebooks/cohort-1/02_object_detection_training.ipynb,
-the "Live camera with TTS" Gradio demo cell. The demo itself (Gradio webcam
-UI, gTTS) doesn't fit the phone-camera + FastAPI architecture and wasn't
-ported — but the actual filtering logic inside it solves a real, still-open
-problem: `backend/tts_service/message_reasoning.py` currently caps
-`process_detections()` at `max_messages=1` with no debouncing, so a
-flickering detection can re-announce every single frame.
+``DetectionStabilizer`` accepts one frame at a time.  A frame can contain
+plain class-name strings or lightweight mappings with ``class_name`` and an
+optional ``confidence``. A configured class is *stable* when the rolling
+window contains at least the configured number of observations. During
+startup, that rolling window is partial, so a class can become stable as soon
+as it reaches ``required_observations``; after that, only the latest
+``window_size`` frames are retained.
 
-This module extracts just that stabilization logic (require a class to
-appear in N of the last M frames before announcing it, then enforce a
-cooldown before announcing again) so it can be wired into the real
-detection pipeline instead of only existing inside a Colab demo. See ML
-README, Future Directions Tier 2 ("Expand TTS to surface multiple
-detections").
+Stability and emission are deliberately separate:
+
+* :meth:`observe` advances temporal state and returns stable classes.
+* :meth:`eligible_for_emission` returns stable classes whose cooldowns allow
+  a new emission.
+* :meth:`mark_emitted` records only classes the caller actually emitted.
+
+Recording an emission never clears temporal history; only later frames and
+an explicit :meth:`reset` change that history.
+
+The caller owns detector invocation, speech, risk policy, and any semantic
+meaning of labels.  This module intentionally has no backend imports,
+network activity, model access, or hard-coded hazard ordering.
 """
 
+from __future__ import annotations
+
+import math
 import time
 from collections import deque
+from collections.abc import Callable, Iterable, Mapping
+
+
+class DetectionStabilizerError(ValueError):
+    """Raised when stabilizer configuration, observations, or clock data are invalid."""
 
 
 class DetectionStabilizer:
-    """Tracks per-class detection history across frames and decides when a
-    class is "persistent" enough, and enough time has passed, to announce.
+    """Keep bounded per-frame class history and independent emission cooldowns.
 
-    Usage:
-        stabilizer = DetectionStabilizer(class_names=["stairs", "person", "door"])
-        for frame_detections in stream:
-            # frame_detections: set/list of class names seen in this frame
-            to_announce = stabilizer.update(frame_detections)
-            if to_announce:
-                speak(to_announce)
+    ``class_names`` defines the classes this instance tracks, in its default
+    deterministic output order, and must be an ordered iterable. Observations
+    for other labels are ignored; callers can track them by including them in
+    ``class_names``. An optional ``priority_order`` may rank a subset of known
+    labels before the remaining labels, but does not assign any WalkBuddy risk
+    or hazard policy.
+
+    ``global_cooldown=False`` (the default) means emitting one class never
+    suppresses another class. With ``global_cooldown=True``, at most one
+    stable class may be emitted per cooldown interval. After an actual global
+    emission, selection rotates deterministically through stable classes so a
+    continually stable first label cannot starve the others.
     """
 
-    def __init__(self, class_names, persist_n=5, persist_m=3, cooldown_sec=3.0):
-        """
-        class_names: iterable of class name strings to track.
-        persist_n: how many recent frames make up the rolling window.
-        persist_m: how many of those N frames must contain the class before
-            it's considered "persistent" (reduces single-frame flicker).
-        cooldown_sec: minimum seconds between two announcements, regardless
-            of class (matches the notebook's single global cooldown, not a
-            per-class one — prevents rapid-fire announcements when several
-            hazards appear at once).
-        """
-        self.persist_n = persist_n
-        self.persist_m = persist_m
-        self.cooldown_sec = cooldown_sec
-        self.last_spoken = 0.0
-        self.hist = {cls: deque(maxlen=persist_n) for cls in class_names}
+    def __init__(
+        self,
+        class_names: Iterable[str],
+        *,
+        window_size: int = 5,
+        required_observations: int = 3,
+        cooldown_seconds: float = 3.0,
+        global_cooldown: bool = False,
+        priority_order: Iterable[str] | None = None,
+        min_confidence: float | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._class_names = self._validate_class_names(class_names)
+        self._known_classes = frozenset(self._class_names)
+        self._class_order = self._build_class_order(priority_order)
+        self._class_index = {
+            class_name: index for index, class_name in enumerate(self._class_order)
+        }
+        self.window_size = self._positive_integer(window_size, "window_size")
+        self.required_observations = self._positive_integer(
+            required_observations, "required_observations"
+        )
+        if self.required_observations > self.window_size:
+            raise DetectionStabilizerError(
+                "required_observations must not exceed window_size"
+            )
+        self.cooldown_seconds = self._nonnegative_number(
+            cooldown_seconds, "cooldown_seconds"
+        )
+        if not isinstance(global_cooldown, bool):
+            raise DetectionStabilizerError("global_cooldown must be a boolean")
+        self.global_cooldown = global_cooldown
+        self.min_confidence = self._validate_min_confidence(min_confidence)
+        if clock is not None and not callable(clock):
+            raise DetectionStabilizerError("clock must be callable")
+        self._clock = time.monotonic if clock is None else clock
+        self.reset()
 
-    def _is_persistent(self, cls):
-        window = self.hist[cls]
-        return len(window) == self.persist_n and sum(window) >= self.persist_m
+    @staticmethod
+    def _validate_class_name(value: object, field_name: str) -> str:
+        if not isinstance(value, str) or not value or value != value.strip():
+            raise DetectionStabilizerError(
+                f"{field_name} must be a non-empty string without surrounding whitespace"
+            )
+        return value
 
-    def update(self, frame_classes):
-        """Call once per frame with the set/list of class names detected in
-        that frame. Returns the class name that should be announced now, or
-        None if nothing qualifies (either nothing is persistent yet, or the
-        cooldown hasn't elapsed).
+    @classmethod
+    def _validate_class_names(cls, class_names: Iterable[str]) -> tuple[str, ...]:
+        if isinstance(class_names, (str, bytes, set, frozenset)):
+            raise DetectionStabilizerError(
+                "class_names must be an ordered iterable of class names"
+            )
+        try:
+            names = tuple(class_names)
+        except TypeError as exc:
+            raise DetectionStabilizerError(
+                "class_names must be an iterable of class names"
+            ) from exc
+        if not names:
+            raise DetectionStabilizerError("class_names must not be empty")
+        validated = tuple(
+            cls._validate_class_name(name, "class_names entry") for name in names
+        )
+        if len(set(validated)) != len(validated):
+            raise DetectionStabilizerError("class_names must not contain duplicates")
+        return validated
 
-        Priority order when multiple classes are persistent simultaneously:
-        whichever was registered first in class_names at construction time
-        (same behaviour as the notebook's dict iteration order — pass
-        class_names in priority order, most urgent first).
-        """
-        frame_classes = set(frame_classes)
-        for cls in self.hist:
-            self.hist[cls].append(1 if cls in frame_classes else 0)
+    @staticmethod
+    def _positive_integer(value: object, field_name: str) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise DetectionStabilizerError(f"{field_name} must be a positive integer")
+        return value
 
-        now = time.time()
-        if now - self.last_spoken <= self.cooldown_sec:
+    @staticmethod
+    def _nonnegative_number(value: object, field_name: str) -> float:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise DetectionStabilizerError(f"{field_name} must be a finite number")
+        number = float(value)
+        if not math.isfinite(number) or number < 0:
+            raise DetectionStabilizerError(
+                f"{field_name} must be a finite non-negative number"
+            )
+        return number
+
+    @classmethod
+    def _validate_min_confidence(cls, value: float | None) -> float | None:
+        if value is None:
             return None
+        confidence = cls._nonnegative_number(value, "min_confidence")
+        if confidence > 1.0:
+            raise DetectionStabilizerError("min_confidence must be between 0 and 1")
+        return confidence
 
-        for cls in self.hist:
-            if self._is_persistent(cls):
-                self.last_spoken = now
-                # clear history so the same class doesn't immediately re-fire
-                for c in self.hist:
-                    self.hist[c].clear()
-                return cls
+    def _build_class_order(self, priority_order: Iterable[str] | None) -> tuple[str, ...]:
+        if priority_order is None:
+            return self._class_names
+        if isinstance(priority_order, (str, bytes, set, frozenset)):
+            raise DetectionStabilizerError(
+                "priority_order must be an ordered iterable of known class names"
+            )
+        try:
+            priorities = tuple(priority_order)
+        except TypeError as exc:
+            raise DetectionStabilizerError(
+                "priority_order must be an iterable of known class names"
+            ) from exc
+        validated = tuple(
+            self._validate_class_name(name, "priority_order entry") for name in priorities
+        )
+        if len(set(validated)) != len(validated):
+            raise DetectionStabilizerError("priority_order must not contain duplicates")
+        unknown = [name for name in validated if name not in self._known_classes]
+        if unknown:
+            raise DetectionStabilizerError(
+                f"priority_order contains unknown class names: {', '.join(unknown)}"
+            )
+        priority_set = frozenset(validated)
+        return validated + tuple(
+            name for name in self._class_names if name not in priority_set
+        )
 
-        return None
+    @property
+    def history_length(self) -> int:
+        """Number of frames retained in the bounded temporal window."""
+
+        return len(self._history)
+
+    def reset(self) -> None:
+        """Clear temporal history, all cooldowns, rotation, and clock state."""
+
+        self._history: deque[frozenset[str]] = deque(maxlen=self.window_size)
+        self._last_emitted_at: dict[str, float] = {}
+        self._last_global_emitted_at: float | None = None
+        self._last_global_emitted_class: str | None = None
+        self._last_clock_value: float | None = None
+
+    def _iter_frame_observations(self, frame_observations: object) -> tuple[object, ...]:
+        if frame_observations is None:
+            return ()
+        if isinstance(frame_observations, (str, Mapping)):
+            return (frame_observations,)
+        if isinstance(frame_observations, bytes):
+            raise DetectionStabilizerError("frame observations must not be bytes")
+        try:
+            return tuple(frame_observations)  # type: ignore[arg-type]
+        except TypeError as exc:
+            raise DetectionStabilizerError(
+                "frame_observations must be an iterable of observations"
+            ) from exc
+
+    def _normalise_observation(self, observation: object) -> tuple[str, float | None]:
+        if isinstance(observation, str):
+            return self._validate_class_name(observation, "observation class_name"), None
+        if not isinstance(observation, Mapping):
+            raise DetectionStabilizerError(
+                "each observation must be a class-name string or mapping with class_name"
+            )
+        if "class_name" not in observation:
+            raise DetectionStabilizerError("observation mapping is missing class_name")
+        class_name = self._validate_class_name(
+            observation["class_name"], "observation class_name"
+        )
+        if "confidence" not in observation:
+            return class_name, None
+        confidence = self._nonnegative_number(observation["confidence"], "confidence")
+        if confidence > 1.0:
+            raise DetectionStabilizerError("confidence must be between 0 and 1")
+        return class_name, confidence
+
+    def _classes_in_frame(self, frame_observations: object) -> frozenset[str]:
+        classes: set[str] = set()
+        for observation in self._iter_frame_observations(frame_observations):
+            class_name, confidence = self._normalise_observation(observation)
+            if self.min_confidence is not None:
+                if confidence is None:
+                    raise DetectionStabilizerError(
+                        "observations require confidence when min_confidence is configured"
+                    )
+                if confidence < self.min_confidence:
+                    continue
+            if class_name in self._known_classes:
+                classes.add(class_name)
+        return frozenset(classes)
+
+    def observe(self, frame_observations: object) -> tuple[str, ...]:
+        """Advance one frame and return all currently stable classes.
+
+        Unknown labels are ignored after validation.  Repeated detections of
+        the same known label count once in a frame.
+        """
+
+        self._history.append(self._classes_in_frame(frame_observations))
+        return self.stable_classes()
+
+    def stable_classes(self) -> tuple[str, ...]:
+        """Return stable labels in deterministic caller-controlled order.
+
+        A startup window is valid as soon as it contains enough frames for
+        ``required_observations``. This avoids delaying an M-of-N result just
+        because the window has not yet reached its maximum size.
+        """
+
+        if len(self._history) < self.required_observations:
+            return ()
+        return tuple(
+            class_name
+            for class_name in self._class_order
+            if sum(class_name in frame for frame in self._history)
+            >= self.required_observations
+        )
+
+    def _current_time(self) -> float:
+        raw_value = self._clock()
+        if isinstance(raw_value, bool) or not isinstance(raw_value, (int, float)):
+            raise DetectionStabilizerError("clock must return a finite number")
+        now = float(raw_value)
+        if not math.isfinite(now):
+            raise DetectionStabilizerError("clock must return a finite number")
+        if self._last_clock_value is not None and now < self._last_clock_value:
+            raise DetectionStabilizerError("clock moved backwards")
+        self._last_clock_value = now
+        return now
+
+    def _eligible_at(self, now: float) -> tuple[str, ...]:
+        stable = self.stable_classes()
+        if not stable:
+            return ()
+        if self.global_cooldown:
+            if (
+                self._last_global_emitted_at is not None
+                and now - self._last_global_emitted_at < self.cooldown_seconds
+            ):
+                return ()
+            return (self._next_global_class(stable),)
+        return tuple(
+            class_name
+            for class_name in stable
+            if class_name not in self._last_emitted_at
+            or now - self._last_emitted_at[class_name] >= self.cooldown_seconds
+        )
+
+    def _next_global_class(self, stable: tuple[str, ...]) -> str:
+        """Choose the next stable label after the last global emission."""
+
+        if self._last_global_emitted_class is None:
+            return stable[0]
+        stable_set = frozenset(stable)
+        start_index = self._class_index[self._last_global_emitted_class]
+        for offset in range(1, len(self._class_order) + 1):
+            candidate = self._class_order[
+                (start_index + offset) % len(self._class_order)
+            ]
+            if candidate in stable_set:
+                return candidate
+        return stable[0]
+
+    def eligible_for_emission(self) -> tuple[str, ...]:
+        """Return stable labels that may be emitted now without changing state."""
+
+        return self._eligible_at(self._current_time())
+
+    def _normalise_emitted_classes(self, class_names: object) -> tuple[str, ...]:
+        if isinstance(class_names, str):
+            raw_names = (class_names,)
+        elif isinstance(class_names, (bytes, set, frozenset)):
+            raise DetectionStabilizerError(
+                "emitted class names must be an ordered iterable of class names"
+            )
+        else:
+            try:
+                raw_names = tuple(class_names)  # type: ignore[arg-type]
+            except TypeError as exc:
+                raise DetectionStabilizerError(
+                    "emitted class names must be a class name or iterable of class names"
+                ) from exc
+        names = tuple(
+            self._validate_class_name(name, "emitted class name") for name in raw_names
+        )
+        if not names:
+            raise DetectionStabilizerError("at least one emitted class name is required")
+        if len(set(names)) != len(names):
+            raise DetectionStabilizerError("emitted class names must not contain duplicates")
+        unknown = [name for name in names if name not in self._known_classes]
+        if unknown:
+            raise DetectionStabilizerError(
+                f"emitted class names are not tracked: {', '.join(unknown)}"
+            )
+        return names
+
+    def mark_emitted(self, class_names: object) -> tuple[str, ...]:
+        """Record one or more labels that the caller actually emitted.
+
+        Labels must currently be eligible.  The caller should invoke this only
+        after it has accepted responsibility for emitting or announcing them.
+        """
+
+        names = self._normalise_emitted_classes(class_names)
+        now = self._current_time()
+        eligible = self._eligible_at(now)
+        if any(name not in eligible for name in names):
+            raise DetectionStabilizerError(
+                "emitted class names must be currently eligible for emission"
+            )
+        if self.global_cooldown and len(names) > 1:
+            raise DetectionStabilizerError(
+                "global_cooldown permits only one emitted class at a time"
+            )
+        for name in names:
+            self._last_emitted_at[name] = now
+        if self.global_cooldown:
+            self._last_global_emitted_at = now
+            self._last_global_emitted_class = names[0]
+        return names
+
+
+def replay_frames(
+    stabilizer: DetectionStabilizer,
+    frames: Iterable[object],
+    *,
+    mark_emitted: bool = True,
+) -> tuple[tuple[str, ...], ...]:
+    """Replay local/synthetic frames and return eligible labels for each frame.
+
+    This pure helper is intended for deterministic tests and offline debugging.
+    When ``mark_emitted`` is true, each frame's eligible labels are recorded as
+    emitted after being returned, so later frames observe the configured
+    cooldown.  It does not perform inference, I/O, or announcement delivery.
+    """
+
+    if not isinstance(stabilizer, DetectionStabilizer):
+        raise DetectionStabilizerError("stabilizer must be a DetectionStabilizer")
+    if isinstance(frames, (str, bytes, Mapping, set, frozenset)):
+        raise DetectionStabilizerError("frames must be an ordered iterable of frames")
+    results: list[tuple[str, ...]] = []
+    for frame in frames:
+        stabilizer.observe(frame)
+        eligible = stabilizer.eligible_for_emission()
+        results.append(eligible)
+        if mark_emitted and eligible:
+            stabilizer.mark_emitted(eligible)
+    return tuple(results)

--- a/ML_side/tests/test_detection_stabilizer.py
+++ b/ML_side/tests/test_detection_stabilizer.py
@@ -1,0 +1,508 @@
+"""Tests for policy-neutral temporal detection stabilization."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ML_SIDE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ML_SIDE))
+
+from inference.detection_stabilizer import (
+    DetectionStabilizer,
+    DetectionStabilizerError,
+    replay_frames,
+)
+
+
+class FakeClock:
+    def __init__(self, now: float = 0.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def make_stabilizer(clock: FakeClock, **overrides: object) -> DetectionStabilizer:
+    options: dict[str, object] = {
+        "class_names": ("chair", "door", "table"),
+        "window_size": 5,
+        "required_observations": 3,
+        "cooldown_seconds": 3.0,
+        "clock": clock,
+    }
+    options.update(overrides)
+    return DetectionStabilizer(**options)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"class_names": ()}, "must not be empty"),
+        ({"class_names": "chair"}, "iterable"),
+        ({"class_names": {"chair"}}, "ordered"),
+        ({"class_names": ("chair", "chair")}, "duplicates"),
+        ({"class_names": (" chair",)}, "whitespace"),
+        ({"class_names": ("chair",), "global_cooldown": 1}, "boolean"),
+        ({"class_names": ("chair",), "clock": object()}, "callable"),
+    ],
+)
+def test_constructor_validation(kwargs: dict[str, object], message: str) -> None:
+    with pytest.raises(DetectionStabilizerError, match=message):
+        DetectionStabilizer(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("window_size", (0, -1, True, 2.5))
+def test_invalid_window_size_is_rejected(window_size: object) -> None:
+    with pytest.raises(DetectionStabilizerError, match="window_size"):
+        DetectionStabilizer(("chair",), window_size=window_size)  # type: ignore[arg-type]
+
+
+def test_required_observations_must_fit_window() -> None:
+    with pytest.raises(DetectionStabilizerError, match="must not exceed"):
+        DetectionStabilizer(("chair",), window_size=2, required_observations=3)
+
+
+def test_one_frame_flicker_is_suppressed() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock)
+
+    for frame in (["chair"], [], [], [], []):
+        assert stabilizer.observe(frame) == ()
+
+
+def test_persistent_class_becomes_stable_at_startup_threshold() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock)
+
+    for _ in range(2):
+        assert stabilizer.observe(["chair"]) == ()
+    assert stabilizer.observe(["chair"]) == ("chair",)
+
+
+@pytest.mark.parametrize(
+    ("window_size", "required_observations", "frames", "expected"),
+    [
+        (1, 1, (["chair"],), ("chair",)),
+        (5, 1, (["chair"],), ("chair",)),
+        (5, 3, (["chair"], ["chair"], ["chair"]), ("chair",)),
+        (5, 5, (["chair"],) * 5, ("chair",)),
+    ],
+)
+def test_n_of_m_thresholds_have_no_unnecessary_startup_delay(
+    window_size: int,
+    required_observations: int,
+    frames: tuple[list[str], ...],
+    expected: tuple[str, ...],
+) -> None:
+    stabilizer = make_stabilizer(
+        FakeClock(),
+        window_size=window_size,
+        required_observations=required_observations,
+    )
+
+    for frame in frames[:-1]:
+        assert stabilizer.observe(frame) == ()
+    assert stabilizer.observe(frames[-1]) == expected
+
+
+def test_one_below_n_of_m_threshold_remains_unstable() -> None:
+    stabilizer = make_stabilizer(
+        FakeClock(), window_size=5, required_observations=3
+    )
+
+    for frame in (["chair"], [], ["chair"]):
+        assert stabilizer.observe(frame) == ()
+
+
+def test_intermittent_class_reaches_n_of_m() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock)
+
+    for frame in (["chair"], [], ["chair"], [], ["chair"]):
+        stable = stabilizer.observe(frame)
+    assert stable == ("chair",)
+
+
+def test_class_disappears_when_its_hits_leave_window() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock)
+
+    for frame in (["chair"], ["chair"], ["chair"], [], [], []):
+        stable = stabilizer.observe(frame)
+    assert stable == ()
+
+
+def test_multiple_classes_are_tracked_independently() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock)
+
+    for frame in (["chair", "door"], ["chair"], ["door"], ["chair", "door"], ["door"]):
+        stable = stabilizer.observe(frame)
+    assert stable == ("chair", "door")
+
+
+def test_history_is_bounded_to_window_size() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock)
+
+    for _ in range(100):
+        stabilizer.observe(["chair"])
+    assert stabilizer.history_length == 5
+
+
+def test_repeated_detections_in_one_frame_count_once() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock, window_size=3, required_observations=2)
+
+    assert stabilizer.observe(["chair"] * 100) == ()
+    assert stabilizer.observe([]) == ()
+    assert stabilizer.observe([]) == ()
+
+
+def test_per_class_cooldown_suppresses_immediate_duplicate_emission() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(
+        clock, window_size=1, required_observations=1, cooldown_seconds=3.0
+    )
+    stabilizer.observe(["chair"])
+
+    assert stabilizer.eligible_for_emission() == ("chair",)
+    assert stabilizer.mark_emitted("chair") == ("chair",)
+    assert stabilizer.eligible_for_emission() == ()
+
+
+def test_class_can_emit_again_after_its_cooldown() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock, window_size=1, required_observations=1)
+    stabilizer.observe(["chair"])
+    stabilizer.mark_emitted("chair")
+
+    clock.advance(3.0)
+    assert stabilizer.eligible_for_emission() == ("chair",)
+
+
+def test_one_class_cooldown_does_not_block_another() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock, window_size=1, required_observations=1)
+    stabilizer.observe(["chair", "door"])
+
+    assert stabilizer.mark_emitted("chair") == ("chair",)
+    assert stabilizer.eligible_for_emission() == ("door",)
+
+
+def test_global_cooldown_rotates_stable_classes_without_starvation() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(
+        clock,
+        window_size=1,
+        required_observations=1,
+        global_cooldown=True,
+    )
+    stabilizer.observe(["chair", "door"])
+
+    assert stabilizer.eligible_for_emission() == ("chair",)
+    stabilizer.mark_emitted("chair")
+    assert stabilizer.eligible_for_emission() == ()
+
+    clock.advance(3.0)
+    assert stabilizer.eligible_for_emission() == ("door",)
+    stabilizer.mark_emitted("door")
+    clock.advance(3.0)
+    assert stabilizer.eligible_for_emission() == ("chair",)
+
+
+def test_global_cooldown_queries_do_not_record_an_emission() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(
+        clock, window_size=1, required_observations=1, global_cooldown=True
+    )
+    stabilizer.observe(["chair", "door"])
+
+    assert stabilizer.eligible_for_emission() == ("chair",)
+    assert stabilizer.eligible_for_emission() == ("chair",)
+
+
+def test_reset_clears_history_and_cooldowns() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock, window_size=1, required_observations=1)
+    stabilizer.observe(["chair"])
+    stabilizer.mark_emitted("chair")
+
+    stabilizer.reset()
+    assert stabilizer.history_length == 0
+    stabilizer.observe(["chair"])
+    assert stabilizer.eligible_for_emission() == ("chair",)
+
+
+def test_reset_begins_a_fresh_clock_session() -> None:
+    clock = FakeClock(100.0)
+    stabilizer = make_stabilizer(clock, window_size=1, required_observations=1)
+    stabilizer.observe(["chair"])
+    stabilizer.eligible_for_emission()
+
+    clock.now = 1.0
+    stabilizer.reset()
+    stabilizer.observe(["chair"])
+    assert stabilizer.eligible_for_emission() == ("chair",)
+
+
+def test_instances_do_not_share_state() -> None:
+    clock = FakeClock()
+    first = make_stabilizer(clock, window_size=1, required_observations=1)
+    second = make_stabilizer(clock, window_size=1, required_observations=1)
+
+    first.observe(["chair"])
+    first.mark_emitted("chair")
+    second.observe(["chair"])
+    assert second.eligible_for_emission() == ("chair",)
+
+
+def test_fake_clock_makes_cooldown_deterministic() -> None:
+    clock = FakeClock(10.0)
+    stabilizer = make_stabilizer(clock, window_size=1, required_observations=1)
+    stabilizer.observe(["chair"])
+    stabilizer.mark_emitted("chair")
+
+    clock.advance(2.99)
+    assert stabilizer.eligible_for_emission() == ()
+    clock.advance(0.01)
+    assert stabilizer.eligible_for_emission() == ("chair",)
+
+
+def test_backwards_or_invalid_clock_values_are_rejected() -> None:
+    clock = FakeClock(2.0)
+    stabilizer = make_stabilizer(clock, window_size=1, required_observations=1)
+    stabilizer.observe(["chair"])
+    stabilizer.eligible_for_emission()
+
+    clock.now = 1.0
+    with pytest.raises(DetectionStabilizerError, match="moved backwards"):
+        stabilizer.eligible_for_emission()
+
+    invalid = make_stabilizer(lambda: math.inf, window_size=1, required_observations=1)
+    invalid.observe(["chair"])
+    with pytest.raises(DetectionStabilizerError, match="finite"):
+        invalid.eligible_for_emission()
+
+
+def test_default_cooldown_uses_elapsed_monotonic_time_semantics() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock, window_size=1, required_observations=1)
+    stabilizer.observe(["chair"])
+    stabilizer.mark_emitted("chair")
+
+    clock.advance(3.000001)
+    assert stabilizer.eligible_for_emission() == ("chair",)
+
+
+def test_stable_output_uses_registered_order() -> None:
+    clock = FakeClock()
+    stabilizer = DetectionStabilizer(
+        ("door", "chair", "table"), window_size=1, required_observations=1, clock=clock
+    )
+
+    assert stabilizer.observe(["table", "chair", "door"]) == (
+        "door",
+        "chair",
+        "table",
+    )
+
+
+def test_priority_order_ranks_known_classes_and_validates_unknown_ones() -> None:
+    clock = FakeClock()
+    stabilizer = DetectionStabilizer(
+        ("chair", "door", "table"),
+        window_size=1,
+        required_observations=1,
+        priority_order=("table", "door"),
+        clock=clock,
+    )
+    assert stabilizer.observe(["chair", "door", "table"]) == (
+        "table",
+        "door",
+        "chair",
+    )
+
+    with pytest.raises(DetectionStabilizerError, match="unknown"):
+        DetectionStabilizer(("chair",), priority_order=("door",))
+    with pytest.raises(DetectionStabilizerError, match="ordered"):
+        DetectionStabilizer(("chair", "door"), priority_order={"door", "chair"})
+
+
+def test_unknown_classes_are_ignored_deterministically() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock, window_size=1, required_observations=1)
+
+    assert stabilizer.observe(["unknown"]) == ()
+    assert stabilizer.history_length == 1
+
+
+@pytest.mark.parametrize(
+    "frame",
+    (
+        [{"confidence": 0.8}],
+        [42],
+        b"chair",
+        [{"class_name": "chair", "confidence": "high"}],
+    ),
+)
+def test_malformed_observations_are_rejected(frame: object) -> None:
+    stabilizer = make_stabilizer(FakeClock())
+    with pytest.raises(DetectionStabilizerError):
+        stabilizer.observe(frame)
+
+
+def test_confidence_threshold_uses_fractional_boundaries() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(
+        clock,
+        window_size=1,
+        required_observations=1,
+        min_confidence=0.8,
+    )
+
+    assert stabilizer.observe([{"class_name": "chair", "confidence": 0.8}]) == (
+        "chair",
+    )
+    assert stabilizer.observe([{"class_name": "chair", "confidence": 0.799}]) == ()
+
+
+def test_confidence_filtering_does_not_discard_other_valid_labels() -> None:
+    stabilizer = make_stabilizer(
+        FakeClock(),
+        window_size=1,
+        required_observations=1,
+        min_confidence=0.8,
+    )
+
+    assert stabilizer.observe(
+        [
+            {"class_name": "chair", "confidence": 0.2},
+            {"class_name": "door", "confidence": 0.8},
+        ]
+    ) == ("door",)
+
+
+def test_confidence_requires_a_fractional_numeric_value_when_configured() -> None:
+    stabilizer = make_stabilizer(
+        FakeClock(),
+        window_size=1,
+        required_observations=1,
+        min_confidence=0.8,
+    )
+
+    with pytest.raises(DetectionStabilizerError, match="require confidence"):
+        stabilizer.observe(["chair"])
+    with pytest.raises(DetectionStabilizerError, match="confidence"):
+        stabilizer.observe([{"class_name": "chair", "confidence": None}])
+    with pytest.raises(DetectionStabilizerError, match="confidence"):
+        stabilizer.observe([{"class_name": "chair", "confidence": True}])
+    assert stabilizer.observe([{"class_name": "chair", "confidence": 1}]) == (
+        "chair",
+    )
+
+
+@pytest.mark.parametrize("confidence", (math.nan, math.inf, -math.inf, -0.1, 1.1))
+def test_nan_inf_and_out_of_range_confidences_are_rejected(confidence: float) -> None:
+    stabilizer = make_stabilizer(FakeClock())
+    with pytest.raises(DetectionStabilizerError, match="confidence"):
+        stabilizer.observe([{"class_name": "chair", "confidence": confidence}])
+
+
+def test_empty_frames_advance_the_temporal_window() -> None:
+    stabilizer = make_stabilizer(FakeClock())
+    assert stabilizer.observe(None) == ()
+    assert stabilizer.observe([]) == ()
+    assert stabilizer.history_length == 2
+
+
+def test_reappearance_requires_persistence_again_after_disappearance() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock, window_size=3, required_observations=2)
+
+    for frame in (["chair"], ["chair"], [], [], []):
+        stabilizer.observe(frame)
+    assert stabilizer.stable_classes() == ()
+    assert stabilizer.observe(["chair"]) == ()
+    assert stabilizer.observe(["chair"]) == ("chair",)
+
+
+def test_emission_is_allowed_at_exact_cooldown_boundary() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock, window_size=1, required_observations=1)
+    stabilizer.observe(["chair"])
+    stabilizer.mark_emitted("chair")
+
+    clock.advance(3.0)
+    assert stabilizer.eligible_for_emission() == ("chair",)
+
+
+def test_emission_is_suppressed_just_before_cooldown_boundary() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock, window_size=1, required_observations=1)
+    stabilizer.observe(["chair"])
+    stabilizer.mark_emitted("chair")
+
+    clock.advance(2.999999)
+    assert stabilizer.eligible_for_emission() == ()
+
+
+def test_emission_is_allowed_just_after_cooldown_boundary() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(clock, window_size=1, required_observations=1)
+    stabilizer.observe(["chair"])
+    stabilizer.mark_emitted("chair")
+
+    clock.advance(3.000001)
+    assert stabilizer.eligible_for_emission() == ("chair",)
+
+
+def test_zero_cooldown_allows_another_explicit_emission_immediately() -> None:
+    stabilizer = make_stabilizer(
+        FakeClock(),
+        window_size=1,
+        required_observations=1,
+        cooldown_seconds=0,
+    )
+    stabilizer.observe(["chair"])
+    stabilizer.mark_emitted("chair")
+
+    assert stabilizer.eligible_for_emission() == ("chair",)
+
+
+def test_replay_harness_returns_deterministic_emission_sequence() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(
+        clock, window_size=3, required_observations=2, cooldown_seconds=5.0
+    )
+
+    emitted = replay_frames(stabilizer, (["chair"], [], ["chair"], ["chair"]))
+
+    assert emitted == ((), (), ("chair",), ())
+
+
+def test_replay_can_be_non_mutating_and_restarts_identically_after_reset() -> None:
+    clock = FakeClock()
+    stabilizer = make_stabilizer(
+        clock, window_size=2, required_observations=1, cooldown_seconds=5.0
+    )
+    frames = (["chair"], ["chair"])
+
+    assert replay_frames(stabilizer, (), mark_emitted=True) == ()
+    assert replay_frames(stabilizer, frames, mark_emitted=False) == (
+        ("chair",),
+        ("chair",),
+    )
+    stabilizer.reset()
+    assert replay_frames(stabilizer, frames) == (
+        ("chair",),
+        (),
+    )


### PR DESCRIPTION
## Summary

Refactors the existing notebook-derived temporal detection stabilizer into a deterministic, policy-neutral ML component suitable for future real-time WalkBuddy integration.

The stabilizer remains completely offline in this PR and is not yet wired into the production backend.

## Changes

- Replace wall-clock timing with monotonic elapsed-time handling.
- Support injected clocks for deterministic testing.
- Implement bounded rolling N-of-M temporal persistence.
- Allow detections to become stable as soon as the required number of observations is reached instead of waiting unnecessarily for the entire window to fill.
- Ensure duplicate detections of the same class in one frame count only once.
- Separate:
  - temporal stability
  - emission eligibility
  - explicit emission recording
- Add per-class cooldown by default.
- Add optional deterministic global cooldown behavior.
- Prevent global cooldown from permanently starving other stable classes through round-robin selection.
- Preserve policy neutrality: no hazard classes, risk levels, or navigation priorities are encoded.
- Support deterministic caller-provided ordering.
- Reject unordered configuration inputs where ordering affects behavior.
- Add explicit `reset()` behavior for session isolation.
- Add bounded state suitable for long-running camera streams.
- Add offline sequence replay support.

## N-of-M semantics

For:

`window_size = N`

`required_observations = M`

a class becomes stable once it has appeared in at least `M` of the latest up-to-`N` observed frames.

The implementation does not wait for all `N` frames merely to fill the history buffer.

Each class counts at most once per frame.

## Cooldown semantics

Per-class cooldown is the default.

Emitting one class does not suppress unrelated classes.

Cooldown state changes only when the caller explicitly records an emission using `mark_emitted()`.

Optional global cooldown remains policy-neutral and uses deterministic rotation so a permanently stable class cannot starve other eligible classes.

## Session safety

- Uses `time.monotonic` by default.
- Injected clocks are supported for testing.
- No module-level mutable session state exists.
- `reset()` clears history, cooldown state, ordering/session state, and clock guards.
- Independent stabilizer instances remain isolated.

## Scope

This PR does NOT:

- modify `software_side/`
- modify frontend/backend APIs
- integrate into WebSocket or REST inference
- change datasets
- change model weights
- train models
- change the approved taxonomy
- define hazard membership
- define risk tiers
- define navigation priority
- modify candidate-model promotion/evaluation tooling

Production integration will be handled separately once the ML safety policy and backend integration boundaries are agreed.

## Verification

After rebasing onto the latest official `t2-2026-development`:

- Stabilizer tests: **58 passed**
- Full ML suite: **317 passed**
- Python compilation: passed
- `git diff --check`: passed
- Feature diff check: passed
- Working tree: clean

## Commit

`2c4bbf206b3dbd751328687f2b1cf70ea90187a6`

`Harden temporal detection stabilization`