### PR TITLE
Centralize navigation ML semantics

### DIFF
--- a/software_side/walkbuddy_reactNative/backend/adapters/vision_adapter.py
+++ b/software_side/walkbuddy_reactNative/backend/adapters/vision_adapter.py
@@ -3,44 +3,20 @@ import cv2
 from ultralytics import YOLO
 from opentelemetry import trace
 from tts_service.message_reasoning import calculate_spatial_position # reuse existing direction logic
+from ml_contract.navigation_semantics import BaseSeverity, get_base_severity, severity_rank
 
 tracer = trace.get_tracer("vision.adapter")
 
-# ============================================================================
-# PRIORITY MAPPING - Priority Assignment to Detected Objects
-# ============================================================================
-# Priority tiers for navigation safety (per task requirements):
-# 🔴 HIGH — moving vehicles, stairs, open doors, wet floors, people in path
-# 🟡 MEDIUM — furniture, poles, bins, parked bikes
-# 🟢 LOW — walls, background objects, decorations
-#
-# Note: Our YOLO model only detects indoor objects:
-# book, books, monitor, office-chair, whiteboard, table, tv
-# We map these to the closest priority tier based on physical danger.
+# Canonical MVP labels use their centralized base severities. Unknown legacy
+# labels retain the existing LOW fallback without acquiring MVP semantics.
 
-PRIORITY_MAP = {
-    # HIGH - Potential fall hazards / high risk for visually impaired
-    "chair": "HIGH",
-    "office-chair": "HIGH",
-    "table": "HIGH",
-    "monitor": "HIGH",
-    "tv": "HIGH",
-    
-    # MEDIUM - Notable but less immediately dangerous
-    "whiteboard": "MEDIUM",
-    
-    # LOW - Minimal hazard
-    "book": "LOW",
-    "books": "LOW",
-}
-
-# Default priority for unknown classes
-DEFAULT_PRIORITY = "LOW"
+DEFAULT_PRIORITY = BaseSeverity.LOW.name
 
 
 def get_priority(category: str) -> str:
-    """Get priority level for a detected category."""
-    return PRIORITY_MAP.get(category.lower(), DEFAULT_PRIORITY)
+    """Get the contract base severity, preserving ``LOW`` for unknown labels."""
+    severity = get_base_severity(category)
+    return severity.name if severity is not None else DEFAULT_PRIORITY
 
 
 def vision_adapter(model: YOLO, image_path: str) -> dict:
@@ -93,9 +69,11 @@ def vision_adapter(model: YOLO, image_path: str) -> dict:
                 "priority": priority,  # NEW: Priority field
             })
 
-    # Sort by priority first (HIGH > MEDIUM > LOW), then by confidence
-    priority_order = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
-    detections.sort(key=lambda x: (priority_order.get(x["priority"], 3), -x["confidence"]))
+    # Sort by deliberate base-severity ranking, then by confidence.
+    priority_order = {
+        severity.name: -severity_rank(severity) for severity in BaseSeverity
+    }
+    detections.sort(key=lambda x: (priority_order.get(x["priority"], 0), -x["confidence"]))
 
     return {
         "image_id": Path(image_path).stem,

--- a/software_side/walkbuddy_reactNative/backend/ml_contract/__init__.py
+++ b/software_side/walkbuddy_reactNative/backend/ml_contract/__init__.py
@@ -1,0 +1,27 @@
+"""Canonical ML-facing contracts shared by backend consumers."""
+
+from .navigation_semantics import (
+    BaseSeverity,
+    NAVIGATION_CLASSES,
+    NavigationClass,
+    canonicalize_class_name,
+    get_base_severity,
+    get_navigation_class,
+    get_navigation_class_by_id,
+    get_spoken_name,
+    is_potential_hazard,
+    severity_rank,
+)
+
+__all__ = [
+    "BaseSeverity",
+    "NAVIGATION_CLASSES",
+    "NavigationClass",
+    "canonicalize_class_name",
+    "get_base_severity",
+    "get_navigation_class",
+    "get_navigation_class_by_id",
+    "get_spoken_name",
+    "is_potential_hazard",
+    "severity_rank",
+]

--- a/software_side/walkbuddy_reactNative/backend/ml_contract/navigation_semantics.py
+++ b/software_side/walkbuddy_reactNative/backend/ml_contract/navigation_semantics.py
@@ -1,0 +1,144 @@
+"""Immutable, policy-neutral ML semantics for WalkBuddy's approved MVP classes.
+
+This contract owns class identity, base severity, display wording, and the
+fact that each approved class can be a navigation hazard. It deliberately does
+not decide whether any individual detection should produce a warning. Callers
+must apply their own contextual direction, confidence, proximity, and temporal
+stabilization rules before taking action.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+from types import MappingProxyType
+from typing import Mapping
+
+
+class BaseSeverity(IntEnum):
+    """Ordered base severities, with ``LOW`` retained for legacy fallbacks."""
+
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+    CRITICAL = 4
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Prevent mutation of enum-member identity after construction."""
+
+        if name in {"_name_", "_value_"} and hasattr(self, name):
+            raise AttributeError("BaseSeverity members are immutable.")
+        super().__setattr__(name, value)
+
+
+@dataclass(frozen=True)
+class NavigationClass:
+    """One approved navigation class and its invariant ML-facing semantics."""
+
+    class_id: int
+    name: str
+    base_severity: BaseSeverity
+    spoken_name: str
+    potential_hazard: bool
+    aliases: tuple[str, ...] = ()
+
+
+NAVIGATION_CLASSES: tuple[NavigationClass, ...] = (
+    NavigationClass(0, "person", BaseSeverity.HIGH, "person", True),
+    NavigationClass(1, "stairs", BaseSeverity.CRITICAL, "stairs", True),
+    NavigationClass(2, "door", BaseSeverity.MEDIUM, "door", True),
+    NavigationClass(3, "chair", BaseSeverity.MEDIUM, "chair", True, ("office-chair",)),
+    NavigationClass(4, "table", BaseSeverity.MEDIUM, "table", True),
+    NavigationClass(5, "pole", BaseSeverity.HIGH, "pole", True),
+    NavigationClass(6, "bicycle", BaseSeverity.HIGH, "bicycle", True),
+    NavigationClass(7, "vehicle", BaseSeverity.CRITICAL, "vehicle", True),
+)
+
+
+def _build_class_id_lookup(
+    classes: tuple[NavigationClass, ...],
+) -> Mapping[int, NavigationClass]:
+    expected_ids = tuple(range(len(classes)))
+    class_ids = tuple(item.class_id for item in classes)
+    if class_ids != expected_ids:
+        raise RuntimeError("Navigation class IDs must be consecutive and ordered from 0.")
+    if len({item.name for item in classes}) != len(classes):
+        raise RuntimeError("Navigation class names must be unique.")
+    return MappingProxyType({item.class_id: item for item in classes})
+
+
+def _build_class_name_lookup(
+    classes: tuple[NavigationClass, ...],
+) -> Mapping[str, NavigationClass]:
+    lookup: dict[str, NavigationClass] = {}
+    for item in classes:
+        for label in (item.name, *item.aliases):
+            normalized = label.casefold()
+            if normalized in lookup:
+                raise RuntimeError("Navigation class names and aliases must be unique.")
+            lookup[normalized] = item
+    return MappingProxyType(lookup)
+
+
+_BY_ID = _build_class_id_lookup(NAVIGATION_CLASSES)
+_BY_NORMALIZED_NAME = _build_class_name_lookup(NAVIGATION_CLASSES)
+
+
+def _normalize_label(value: object) -> str | None:
+    """Apply documented case/whitespace normalization before an exact lookup."""
+
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().casefold()
+    return normalized or None
+
+
+def get_navigation_class(value: object) -> NavigationClass | None:
+    """Return the canonical class for an exact normalized name or alias."""
+
+    normalized = _normalize_label(value)
+    return _BY_NORMALIZED_NAME.get(normalized) if normalized is not None else None
+
+
+def get_navigation_class_by_id(class_id: object) -> NavigationClass | None:
+    """Return the canonical class for an exact integer MVP class ID."""
+
+    if isinstance(class_id, bool) or not isinstance(class_id, int):
+        return None
+    return _BY_ID.get(class_id)
+
+
+def canonicalize_class_name(value: object) -> str | None:
+    """Return an approved canonical name, or ``None`` for an unknown label."""
+
+    navigation_class = get_navigation_class(value)
+    return navigation_class.name if navigation_class is not None else None
+
+
+def get_base_severity(value: object) -> BaseSeverity | None:
+    """Return a canonical class's agreed base severity, if recognized."""
+
+    navigation_class = get_navigation_class(value)
+    return navigation_class.base_severity if navigation_class is not None else None
+
+
+def get_spoken_name(value: object) -> str | None:
+    """Return a canonical spoken name without heuristic suffixes."""
+
+    navigation_class = get_navigation_class(value)
+    return navigation_class.spoken_name if navigation_class is not None else None
+
+
+def is_potential_hazard(value: object) -> bool:
+    """Whether a recognized class may be hazardous in the right context."""
+
+    navigation_class = get_navigation_class(value)
+    return bool(navigation_class and navigation_class.potential_hazard)
+
+
+def severity_rank(severity: BaseSeverity) -> int:
+    """Return the deliberate numeric ordering for consumers that sort severity."""
+
+    if not isinstance(severity, BaseSeverity):
+        raise TypeError("severity must be a BaseSeverity")
+    return int(severity)

--- a/software_side/walkbuddy_reactNative/backend/slow_lane/safetygate.py
+++ b/software_side/walkbuddy_reactNative/backend/slow_lane/safetygate.py
@@ -1,19 +1,26 @@
 from typing import Dict, List, Optional
 
-# Navigation hazards (general)
-_NAV_HAZARDS = {
-    "stairs", "stair", "wall", "door", "person", "obstacle", "pole", "edge",
-}
+from ml_contract.navigation_semantics import get_spoken_name, is_potential_hazard
 
-# Indoor obstacles detected by the YOLO model (8 trained classes)
-_YOLO_OBSTACLES = {
-    "table", "monitor", "office-chair", "whiteboard", "tv", "couch", "books",
-}
 
-HAZARD_KEYWORDS = _NAV_HAZARDS | _YOLO_OBSTACLES
+# Existing non-MVP labels this gate historically recognized: ``stair``,
+# ``wall``, ``obstacle``, and ``edge`` came from its general-hazard list;
+# ``monitor``, ``whiteboard``, ``tv``, ``couch``, and ``books`` came from its
+# legacy indoor-model list. They are compatibility labels, not aliases, and do
+# not acquire canonical MVP semantics through this fallback.
+_LEGACY_HAZARD_LABELS = frozenset(
+    {"stair", "wall", "obstacle", "edge", "monitor", "whiteboard", "tv", "couch", "books"}
+)
 
-# Only flag detections above this confidence as hazards
+# Potential-hazard identity alone is not activation. Preserve the existing
+# direction/confidence gate; proximity and temporal policy remain future seams.
 HAZARD_CONFIDENCE_THRESHOLD = 0.5
+
+
+def _is_hazard_identity(label: str) -> bool:
+    """Match canonical/aliased MVP labels exactly, with explicit legacy support."""
+
+    return is_potential_hazard(label) or label.strip().casefold() in _LEGACY_HAZARD_LABELS
 
 
 def extract_hazards(events: List[Dict]) -> List[str]:
@@ -31,7 +38,7 @@ def extract_hazards(events: List[Dict]) -> List[str]:
         if not is_ahead:
             continue
 
-        if any(h in label for h in HAZARD_KEYWORDS) and confidence >= HAZARD_CONFIDENCE_THRESHOLD:
+        if _is_hazard_identity(label) and confidence >= HAZARD_CONFIDENCE_THRESHOLD:
             hazards.append(_format_hazard(e))
             continue
 
@@ -41,7 +48,8 @@ def extract_hazards(events: List[Dict]) -> List[str]:
 
 
 def _format_hazard(event: Dict) -> str:
-    label = event.get("label") or event.get("category") or "object"
+    raw_label = event.get("label") or event.get("category") or "object"
+    label = get_spoken_name(raw_label) or raw_label
     direction = event.get("direction", "ahead")
     if event.get("approaching"):
         return f"{label} approaching {direction}"

--- a/software_side/walkbuddy_reactNative/backend/tests/test_navigation_semantics.py
+++ b/software_side/walkbuddy_reactNative/backend/tests/test_navigation_semantics.py
@@ -1,0 +1,300 @@
+"""Tests for the centralized, policy-neutral navigation ML contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from ml_contract import navigation_semantics as semantics
+from ml_contract.navigation_semantics import (
+    BaseSeverity,
+    NAVIGATION_CLASSES,
+    NavigationClass,
+    canonicalize_class_name,
+    get_base_severity,
+    get_navigation_class,
+    get_navigation_class_by_id,
+    get_spoken_name,
+    is_potential_hazard,
+    severity_rank,
+)
+from tts_service.message_reasoning import Detection, format_object_name, generate_guidance_message
+from tts_service.tts_service import RiskLevel
+
+
+EXPECTED_CLASSES = (
+    (0, "person", BaseSeverity.HIGH),
+    (1, "stairs", BaseSeverity.CRITICAL),
+    (2, "door", BaseSeverity.MEDIUM),
+    (3, "chair", BaseSeverity.MEDIUM),
+    (4, "table", BaseSeverity.MEDIUM),
+    (5, "pole", BaseSeverity.HIGH),
+    (6, "bicycle", BaseSeverity.HIGH),
+    (7, "vehicle", BaseSeverity.CRITICAL),
+)
+
+
+def _load_safetygate() -> ModuleType:
+    path = BACKEND_DIR / "slow_lane" / "safetygate.py"
+    spec = importlib.util.spec_from_file_location("navigation_semantics_safetygate", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_vision_adapter(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    fake_cv2 = ModuleType("cv2")
+    fake_ultralytics = ModuleType("ultralytics")
+    fake_ultralytics.YOLO = object
+    fake_trace = SimpleNamespace(get_tracer=lambda _: object())
+    fake_opentelemetry = ModuleType("opentelemetry")
+    fake_opentelemetry.trace = fake_trace
+    fake_tts_package = ModuleType("tts_service")
+    fake_tts_package.__path__ = []
+    fake_reasoning = ModuleType("tts_service.message_reasoning")
+    fake_reasoning.calculate_spatial_position = lambda _bbox, _width: "ahead"
+
+    monkeypatch.setitem(sys.modules, "cv2", fake_cv2)
+    monkeypatch.setitem(sys.modules, "ultralytics", fake_ultralytics)
+    monkeypatch.setitem(sys.modules, "opentelemetry", fake_opentelemetry)
+    monkeypatch.setitem(sys.modules, "tts_service", fake_tts_package)
+    monkeypatch.setitem(sys.modules, "tts_service.message_reasoning", fake_reasoning)
+
+    path = BACKEND_DIR / "adapters" / "vision_adapter.py"
+    spec = importlib.util.spec_from_file_location("navigation_semantics_vision_adapter", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_contract_has_the_exact_approved_taxonomy_and_order() -> None:
+    assert tuple((item.class_id, item.name, item.base_severity) for item in NAVIGATION_CLASSES) == (
+        EXPECTED_CLASSES
+    )
+    for class_id, name, _ in EXPECTED_CLASSES:
+        assert get_navigation_class_by_id(class_id) is get_navigation_class(name)
+    assert get_navigation_class_by_id(True) is None
+    assert get_navigation_class_by_id(8) is None
+
+
+def test_all_approved_classes_are_potential_hazards_with_canonical_spoken_names() -> None:
+    for _, name, _ in EXPECTED_CLASSES:
+        assert is_potential_hazard(name) is True
+        assert get_spoken_name(name) == name
+
+
+def test_office_chair_is_the_only_justified_alias() -> None:
+    assert tuple(item.aliases for item in NAVIGATION_CLASSES) == (
+        (),
+        (),
+        (),
+        ("office-chair",),
+        (),
+        (),
+        (),
+        (),
+    )
+    navigation_class = get_navigation_class("office-chair")
+    assert navigation_class is not None
+    assert navigation_class.name == "chair"
+    assert canonicalize_class_name("office-chair") == "chair"
+    assert get_base_severity("office-chair") == BaseSeverity.MEDIUM
+
+
+def test_contract_normalizes_case_and_whitespace_before_exact_matching() -> None:
+    for label in ("person", "Person", "PERSON", " person", "person ", " person "):
+        assert canonicalize_class_name(label) == "person"
+    assert canonicalize_class_name("  OFFICE-CHAIR  ") == "chair"
+    assert canonicalize_class_name("\tVehicle\n") == "vehicle"
+    assert canonicalize_class_name("") is None
+    assert canonicalize_class_name("   ") is None
+    assert canonicalize_class_name(None) is None
+
+
+@pytest.mark.parametrize(
+    "label",
+    (
+        "chairish",
+        "outdoor",
+        "doorway",
+        "door sign",
+        "flagpole",
+        "pole sign",
+        "timetable",
+        "wheelchair",
+        "officechair",
+        "office chair",
+        "vehicle-sign",
+        "vehicle-2",
+    ),
+)
+def test_contract_uses_no_fuzzy_or_substring_matching(label: str) -> None:
+    assert get_navigation_class(label) is None
+    assert canonicalize_class_name(label) is None
+    assert is_potential_hazard(label) is False
+
+
+@pytest.mark.parametrize("label", ("unknown", "tree", "book", "books", "monitor", "tv", "random-label", ""))
+def test_unknown_labels_do_not_acquire_canonical_semantics(label: str) -> None:
+    assert get_navigation_class(label) is None
+    assert canonicalize_class_name(label) is None
+    assert get_base_severity(label) is None
+    assert get_spoken_name(label) is None
+    assert is_potential_hazard(label) is False
+
+
+def test_contract_is_immutable_and_rejects_duplicate_definitions() -> None:
+    with pytest.raises(FrozenInstanceError):
+        NAVIGATION_CLASSES[0].name = "changed"  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        NAVIGATION_CLASSES[3].aliases += ("officechair",)  # type: ignore[misc]
+    with pytest.raises(TypeError):
+        semantics._BY_ID[0] = NAVIGATION_CLASSES[1]  # type: ignore[index]
+    with pytest.raises(TypeError):
+        semantics._BY_NORMALIZED_NAME["person"] = NAVIGATION_CLASSES[1]  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        BaseSeverity.HIGH.value = 99  # type: ignore[misc]
+    with pytest.raises(AttributeError):
+        BaseSeverity.HIGH._value_ = 99  # type: ignore[misc]
+    with pytest.raises(RuntimeError, match="unique"):
+        semantics._build_class_name_lookup(
+            (
+                NavigationClass(0, "person", BaseSeverity.HIGH, "person", True),
+                NavigationClass(1, "person", BaseSeverity.HIGH, "person", True),
+            )
+        )
+    with pytest.raises(RuntimeError, match="consecutive"):
+        semantics._build_class_id_lookup(
+            (
+                NavigationClass(0, "person", BaseSeverity.HIGH, "person", True),
+                NavigationClass(0, "stairs", BaseSeverity.CRITICAL, "stairs", True),
+            )
+        )
+
+
+def test_severity_order_is_explicit_and_no_approved_class_is_low() -> None:
+    assert [severity_rank(level) for level in BaseSeverity] == [1, 2, 3, 4]
+    assert BaseSeverity.LOW < BaseSeverity.MEDIUM < BaseSeverity.HIGH < BaseSeverity.CRITICAL
+    assert all(item.base_severity is not BaseSeverity.LOW for item in NAVIGATION_CLASSES)
+
+
+def test_vision_priority_consumer_uses_the_agreed_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    vision_adapter = _load_vision_adapter(monkeypatch)
+
+    for _, name, severity in EXPECTED_CLASSES:
+        priority = vision_adapter.get_priority(name)
+        assert isinstance(priority, str)
+        assert priority == severity.name
+    assert vision_adapter.get_priority("office-chair") == BaseSeverity.MEDIUM.name
+    assert vision_adapter.get_priority("unknown") == BaseSeverity.LOW.name
+
+
+def test_spoken_names_do_not_add_sign_heuristics_to_navigation_classes() -> None:
+    for _, name, _ in EXPECTED_CLASSES:
+        assert format_object_name(name) == name
+    assert format_object_name("office-chair") == "chair"
+    assert format_object_name("EXIT") == "exit sign"
+
+
+def test_office_chair_guidance_uses_canonical_chair_semantics() -> None:
+    message = generate_guidance_message(
+        Detection(
+            category="office-chair",
+            confidence=0.9,
+            bbox={"x_min": 0, "y_min": 0, "x_max": 10, "y_max": 10},
+            direction="ahead",
+        )
+    )
+
+    assert message is not None
+    assert message.message == "chair ahead"
+    assert message.risk_level is RiskLevel.MEDIUM
+
+
+@pytest.mark.parametrize(("_class_id", "name", "severity"), EXPECTED_CLASSES)
+def test_guidance_uses_the_contract_base_severity_for_every_canonical_class(
+    _class_id: int,
+    name: str,
+    severity: BaseSeverity,
+) -> None:
+    message = generate_guidance_message(
+        Detection(
+            category=name,
+            confidence=0.9,
+            bbox={"x_min": 0, "y_min": 0, "x_max": 10, "y_max": 10},
+            direction="ahead",
+        )
+    )
+
+    assert message is not None
+    assert message.message == f"{name} ahead"
+    assert message.risk_level is RiskLevel[severity.name]
+
+
+def test_bicycle_and_vehicle_are_recognized_by_the_contract() -> None:
+    assert canonicalize_class_name("bicycle") == "bicycle"
+    assert canonicalize_class_name("vehicle") == "vehicle"
+    assert get_base_severity("bicycle") is BaseSeverity.HIGH
+    assert get_base_severity("vehicle") is BaseSeverity.CRITICAL
+
+
+def test_safetygate_preserves_context_before_a_potential_hazard_warns() -> None:
+    safetygate = _load_safetygate()
+
+    for _, name, _ in EXPECTED_CLASSES:
+        assert safetygate.extract_hazards(
+            [{"label": name, "direction": "left", "confidence": 0.9}]
+        ) == []
+        assert safetygate.extract_hazards(
+            [{"label": name, "direction": "right", "confidence": 0.9}]
+        ) == []
+        assert safetygate.extract_hazards(
+            [{"label": name, "direction": "ahead", "confidence": 0.49}]
+        ) == []
+        assert safetygate.extract_hazards(
+            [{"label": name, "direction": "ahead", "confidence": 0.9}]
+        )
+
+
+def test_safetygate_uses_exact_identity_and_canonical_hazard_wording() -> None:
+    safetygate = _load_safetygate()
+
+    for label in (
+        "outdoor",
+        "doorway",
+        "flagpole",
+        "timetable",
+        "wheelchair",
+        "vehicle-sign",
+    ):
+        assert safetygate.extract_hazards(
+            [{"label": label, "direction": "ahead", "confidence": 0.9}]
+        ) == []
+    assert safetygate.extract_hazards(
+        [{"label": "office-chair", "direction": "ahead", "confidence": 0.9}]
+    ) == ["chair ahead"]
+
+
+@pytest.mark.parametrize(
+    "label",
+    ("stair", "wall", "obstacle", "edge", "monitor", "whiteboard", "tv", "couch", "books"),
+)
+def test_safetygate_retains_only_explicit_historical_non_mvp_labels(label: str) -> None:
+    safetygate = _load_safetygate()
+
+    assert get_navigation_class(label) is None
+    assert safetygate.extract_hazards(
+        [{"label": label, "direction": "ahead", "confidence": 0.9}]
+    ) == [f"{label} ahead"]

--- a/software_side/walkbuddy_reactNative/backend/tts_service/message_reasoning.py
+++ b/software_side/walkbuddy_reactNative/backend/tts_service/message_reasoning.py
@@ -18,6 +18,17 @@ from typing import Dict, Any, List, Optional, Tuple
 from enum import Enum
 from dataclasses import dataclass
 
+try:
+    from ml_contract.navigation_semantics import get_base_severity, get_spoken_name
+except ModuleNotFoundError as exc:
+    if exc.name != "ml_contract":
+        raise
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from ml_contract.navigation_semantics import get_base_severity, get_spoken_name
+
 # Import RiskLevel from tts_service (relative import)
 try:
     from .tts_service import RiskLevel
@@ -58,19 +69,15 @@ class ObjectType(Enum):
     NAVIGATION = "navigation"  # Navigation aids
 
 
-# Object type mapping (from detection categories)
+# Object type mapping for legacy non-MVP categories. Approved navigation
+# classes resolve through ml_contract.navigation_semantics instead.
 OBJECT_TYPE_MAP = {
-    # Obstacles (high priority)
-    "chair": ObjectType.OBSTACLE,
-    "office-chair": ObjectType.OBSTACLE,
-    "table": ObjectType.OBSTACLE,
     "desk": ObjectType.OBSTACLE,
     "monitor": ObjectType.OBSTACLE,
     "tv": ObjectType.OBSTACLE,
     "books": ObjectType.OBSTACLE,
     "bookshelf": ObjectType.OBSTACLE,
     "whiteboard": ObjectType.OBSTACLE,
-    "person": ObjectType.OBSTACLE, ## A person is treated as obstacle because they can block paths, even though they are not dangerous
     
     # Signs (medium priority)
     "exit": ObjectType.SIGN,
@@ -159,15 +166,37 @@ def assess_risk_level(
     Returns:
         Risk level for the detection
     """
-    # Base risk on object type
+    # Legacy object types retain their existing base risks. Approved MVP
+    # classes use _assess_navigation_risk_level below.
     if object_type == ObjectType.OBSTACLE:
         base_risk = RiskLevel.MEDIUM
     elif object_type == ObjectType.SIGN:
         base_risk = RiskLevel.LOW
     else:
         base_risk = RiskLevel.CLEAR
-    
-    # Increase risk if nearby
+
+    return _apply_existing_context_adjustments(
+        base_risk,
+        confidence,
+        proximity,
+        is_moving=is_moving,
+        approaching=approaching,
+        motion_direction=motion_direction,
+    )
+
+
+def _apply_existing_context_adjustments(
+    base_risk: RiskLevel,
+    confidence: float,
+    proximity: str,
+    *,
+    is_moving: bool,
+    approaching: bool,
+    motion_direction: str,
+) -> RiskLevel:
+    """Preserve existing contextual adjustments without defining new policy."""
+
+    # Existing proximity, motion, and confidence behavior remains unchanged.
     if proximity == "nearby":
         if base_risk == RiskLevel.MEDIUM:
             base_risk = RiskLevel.HIGH
@@ -191,6 +220,30 @@ def assess_risk_level(
     return base_risk
 
 
+def _assess_navigation_risk_level(
+    category: str,
+    confidence: float,
+    proximity: str,
+    *,
+    is_moving: bool,
+    approaching: bool,
+    motion_direction: str,
+) -> RiskLevel | None:
+    """Apply existing context adjustments to a canonical contract severity."""
+
+    base_severity = get_base_severity(category)
+    if base_severity is None:
+        return None
+    return _apply_existing_context_adjustments(
+        RiskLevel[base_severity.name],
+        confidence,
+        proximity,
+        is_moving=is_moving,
+        approaching=approaching,
+        motion_direction=motion_direction,
+    )
+
+
 def format_object_name(category: str) -> str:
     """
     Format object category name for natural speech.
@@ -200,26 +253,15 @@ def format_object_name(category: str) -> str:
         "whiteboard" -> "whiteboard"
         "EXIT" -> "exit sign"
     """
-    # Normalize to lowercase
+    spoken_name = get_spoken_name(category)
+    if spoken_name is not None:
+        return spoken_name
+
+    # Preserve explicit legacy sign wording, without substring or length
+    # heuristics that could mislabel navigation classes.
     category_lower = category.lower().strip()
-    
-    # Handle compound names
-    if "chair" in category_lower:
-        return "chair"
-    elif "table" in category_lower:
-        return "table"
-    elif "monitor" in category_lower:
-        return "monitor"
-    elif "book" in category_lower:
-        return "books" if category_lower.endswith("s") else "book"
-    elif "whiteboard" in category_lower:
-        return "whiteboard"
-    elif "exit" in category_lower or "entrance" in category_lower:
+    if category_lower in {"exit", "entrance"}:
         return f"{category_lower} sign"
-    elif category_lower.isupper() or len(category_lower) <= 5:
-        # Likely a sign text
-        return f"{category_lower} sign"
-    
     return category_lower
 
 
@@ -239,37 +281,31 @@ def generate_guidance_message(
     Returns:
         GuidanceMessage or None if detection should be ignored
     """
-    # Get object type
+    # Approved navigation classes use their contract base severity. Legacy
+    # categories retain exact object-type lookup; no fuzzy matching is used.
     category_lower = detection.category.lower().strip()
-    object_type = None
-    
-    # Check direct mapping
-    if category_lower in OBJECT_TYPE_MAP:
-        object_type = OBJECT_TYPE_MAP[category_lower]
-    else:
-        # Try partial matching
-        for key, obj_type in OBJECT_TYPE_MAP.items():
-            if key in category_lower or category_lower in key:
-                object_type = obj_type
-                break
-    
-    # Default to OBSTACLE if unknown (safer assumption)
-    if object_type is None:
-        object_type = ObjectType.OBSTACLE
-    
     # Calculate spatial information
     position = detection.direction or calculate_spatial_position(detection.bbox, image_width)
     proximity = calculate_proximity(detection.bbox, image_width, image_height)
     
-    # Assess risk
-    risk_level = assess_risk_level(
-        object_type,
+    risk_level = _assess_navigation_risk_level(
+        detection.category,
         detection.confidence,
         proximity,
         is_moving=detection.is_moving,
         approaching=detection.approaching,
         motion_direction=detection.motion_direction,
     )
+    if risk_level is None:
+        object_type = OBJECT_TYPE_MAP.get(category_lower, ObjectType.OBSTACLE)
+        risk_level = assess_risk_level(
+            object_type,
+            detection.confidence,
+            proximity,
+            is_moving=detection.is_moving,
+            approaching=detection.approaching,
+            motion_direction=detection.motion_direction,
+        )
     
     # Format object name
     object_name = format_object_name(detection.category)


### PR DESCRIPTION
## Summary

Adds a centralized backend ML semantics contract for the approved WalkBuddy 8-class MVP taxonomy.

This removes conflicting class meanings that were previously spread across vision priority, safety gating, and message reasoning.

## Approved taxonomy

| ID | Class |
|---|---|
| 0 | person |
| 1 | stairs |
| 2 | door |
| 3 | chair |
| 4 | table |
| 5 | pole |
| 6 | bicycle |
| 7 | vehicle |

## Base severity policy

The agreed base class severities are centralized as:

- `person` → HIGH
- `stairs` → CRITICAL
- `door` → MEDIUM
- `chair` → MEDIUM
- `table` → MEDIUM
- `pole` → HIGH
- `bicycle` → HIGH
- `vehicle` → CRITICAL

All eight approved classes are represented as potential hazards.

This does NOT mean every detection automatically triggers a warning. Existing contextual conditions such as direction and confidence remain in place.

## Changes

- Adds immutable `NavigationClass` definitions.
- Adds ordered `BaseSeverity` semantics.
- Adds deterministic canonical lookup helpers.
- Adds explicit legacy alias:
  - `office-chair` → `chair`
- Removes substring/fuzzy class matching.
- Removes spoken-name heuristics that caused labels such as:
  - `door sign`
  - `pole sign`
- Centralizes vision priority.
- Centralizes safety identity matching.
- Centralizes canonical spoken names.

## Production consumers migrated

- `backend/adapters/vision_adapter.py`
- `backend/slow_lane/safetygate.py`
- `backend/tts_service/message_reasoning.py`

## Safety behavior

Safetygate still preserves its existing contextual conditions, including:

- ahead/center direction requirements
- existing confidence requirements
- existing motion/context conditions

No unconditional hazard behavior was introduced.

## Scope boundaries

This PR does NOT:

- modify `routers/ai_service.py`
- change frontend behavior
- introduce proximity/distance thresholds
- claim real-world metre estimation
- integrate temporal stabilization
- change datasets
- change model weights
- train a model
- change model-promotion tooling
- change runtime observability
- introduce custom model architecture work

Proximity/distance logic will be handled separately once the team agrees on the approach.

Temporal stabilization will also be integrated separately.

## Verification

After adversarial review:

- navigation-semantics tests: **49 passed**
- relevant consumer tests: **19 passed**
- full backend suite: **109 passed**
- full ML suite: **317 passed**
- Python compilation: passed
- `git diff --check`: passed
- feature-diff check: passed
- working tree: clean

One existing Starlette deprecation warning remains unrelated to this feature.

## Commit

`c048d17b8e3013373ee3c54b410a2526f4e97288`

`Centralize navigation ML semantics`