### PR TITLE
Add navigation scenario regression harness

### DIFF
--- a/ML_side/docs/navigation_scenario_regression.md
+++ b/ML_side/docs/navigation_scenario_regression.md
@@ -1,0 +1,153 @@
+# Navigation Scenario Regression Harness
+
+`evaluate_navigation_scenarios.py` is an offline, class-presence regression
+harness for controlled WalkBuddy navigation scenarios. It complements rather
+than replaces labelled mAP evaluation and candidate-model promotion gating.
+It never starts a backend service, calls an HTTP endpoint, loads a model, or
+changes model artifacts.
+
+The harness imports the approved eight-class taxonomy from
+`ML_side/tools/validate_dataset_manifest.py`. This keeps ML tooling dependent
+on the existing ML-side source of truth rather than creating an ML-to-backend
+dependency. The required order is:
+
+| ID | Class |
+|---:|---|
+| 0 | person |
+| 1 | stairs |
+| 2 | door |
+| 3 | chair |
+| 4 | table |
+| 5 | pole |
+| 6 | bicycle |
+| 7 | vehicle |
+
+## Inputs
+
+A case-suite JSON file uses schema version `1.0.0`:
+
+```json
+{
+  "schema_version": "1.0.0",
+  "suite_id": "indoor-navigation-v1",
+  "unexpected_detection_policy": "report_only",
+  "cases": [
+    {
+      "scenario_id": "stairs-ahead",
+      "description": "Stairs directly ahead in a controlled navigation scene.",
+      "image": "images/stairs-ahead.jpg",
+      "expected_classes": ["stairs"],
+      "allowed_classes": ["person"],
+      "notes": "Real scenario image supplied separately."
+    }
+  ]
+}
+```
+
+`image` is metadata only in fixture mode. It must be a relative, traversal-free
+path; no image bytes, absolute paths, credentials, or remote URIs are allowed.
+Class names are exact canonical names, and duplicates are rejected. Empty
+`expected_classes` is allowed for a controlled negative scenario.
+
+The prediction fixture must name every scenario exactly once:
+
+```json
+{
+  "schema_version": "1.0.0",
+  "suite_id": "indoor-navigation-v1",
+  "model": {
+    "filename": "candidate-navigation.pt",
+    "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  },
+  "predictions": {
+    "stairs-ahead": [
+      {"class_name": "stairs", "confidence": 0.91},
+      {"class_name": "person", "confidence": 0.88}
+    ]
+  }
+}
+```
+
+Fixtures contain normalized detector outputs only. They enable repeatable
+regression tests without Ultralytics, model weights, images, a GPU, or a
+network connection. An optional model identity records a filename and lowercase
+SHA-256 only; the harness does not read the model artifact.
+
+## Scoring and pass/fail behaviour
+
+Scoring is class presence per scenario, not bounding-box matching:
+
+- TP: a required expected class was detected.
+- FN: a required expected class was not detected.
+- FP: a detected class was neither expected nor explicitly allowed.
+- An allowed class is reported separately and does not count as TP or FP.
+
+Duplicate detections of the same class in one scenario are represented as one
+class-presence outcome. Precision is `null` when there are no predicted classes;
+recall is `null` when there are no required classes; F1 is `null` only when its
+own denominator is zero. This avoids fabricated values for undefined metrics.
+
+Every scenario fails when an expected class is missed. The suite field
+`unexpected_detection_policy` is explicit: `report_only` (the default) reports
+FPs without failing the scenario, while `fail` also fails scenarios with FPs.
+This is a detection-correctness rule, not a WalkBuddy safety policy.
+
+`--confidence-threshold` is explicit and appears in both reports. It filters
+fixture detections as a detector operating point only; it is not a risk,
+proximity, distance, or safety-gate threshold.
+Detections with confidence **greater than or equal to** the supplied threshold
+are included.
+
+## Run fixture replay
+
+Use an output directory outside the repository so generated reports cannot be
+committed accidentally.
+
+```powershell
+$env:PYTHONPATH = (Resolve-Path ML_side).Path
+python ML_side/tools/evaluate_navigation_scenarios.py `
+  --cases C:\evaluation-inputs\navigation-scenarios.json `
+  --predictions C:\evaluation-inputs\candidate-predictions.json `
+  --output C:\evaluation-results\scenario-regression
+```
+
+On macOS or Linux:
+
+```bash
+PYTHONPATH=ML_side python ML_side/tools/evaluate_navigation_scenarios.py \
+  --cases /path/to/navigation-scenarios.json \
+  --predictions /path/to/candidate-predictions.json \
+  --output /path/to/scenario-regression
+```
+
+The output directory contains deterministic substantive data in:
+
+- `scenario_evaluation.json` for machine comparison;
+- `scenario_evaluation.md` for review.
+
+Each report records the suite identity, input filenames and checksums, optional
+model identity, inference setting, taxonomy, per-scenario TP/FP/FN details,
+missed and unexpected class names, aggregate micro metrics, and per-class
+metrics. It deliberately omits absolute paths and timestamps so fixture replay
+can be compared byte-for-byte when inputs and settings are unchanged.
+
+## Relationship to older and promotion tooling
+
+The legacy `ML_side/testing_pipeline` is retained as historical evidence but
+is deliberately bypassed: its runner imports `requests` and depends on a local
+service plus obsolete `/detect` and `/two_brain` endpoints. This harness reuses
+only the basic TP/FP/FN idea at a well-defined class-presence level; it does not
+reuse network, endpoint, response-shape, direction, or safety assumptions.
+
+`validate_candidate_model.py` and `compare_model_evaluations.py` remain the
+authoritative candidate-validation and promotion-review tools. Scenario reports
+are additional evidence only and cannot promote a model automatically.
+
+## Current limitation
+
+This initial implementation intentionally supports saved prediction fixtures,
+not direct local YOLO inference. A future narrowly scoped adapter may load an
+explicit caller-supplied local model and produce the same normalized fixture
+format, after separate review. Real scenario images and labelled validation data
+must be supplied and reviewed separately; no bundled case is evidence of model
+quality or navigation safety.

--- a/ML_side/scenario_regression/__init__.py
+++ b/ML_side/scenario_regression/__init__.py
@@ -1,0 +1,25 @@
+"""Offline scenario-level regression evaluation for WalkBuddy detections."""
+
+from .evaluator import (
+    APPROVED_TAXONOMY,
+    SCHEMA_VERSION,
+    TOOL_NAME,
+    TOOL_VERSION,
+    ScenarioRegressionError,
+    evaluate_suite,
+    load_case_suite,
+    load_prediction_fixture,
+    run_fixture_evaluation,
+)
+
+__all__ = [
+    "APPROVED_TAXONOMY",
+    "SCHEMA_VERSION",
+    "TOOL_NAME",
+    "TOOL_VERSION",
+    "ScenarioRegressionError",
+    "evaluate_suite",
+    "load_case_suite",
+    "load_prediction_fixture",
+    "run_fixture_evaluation",
+]

--- a/ML_side/scenario_regression/evaluator.py
+++ b/ML_side/scenario_regression/evaluator.py
@@ -1,0 +1,613 @@
+"""Pure, offline scenario-regression scoring for navigation detections.
+
+This module evaluates canonical class presence per scenario. It does not load
+models, inspect images, make network requests, or implement navigation-risk,
+proximity, temporal-stabilization, or promotion policy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any
+from urllib.parse import unquote
+from uuid import uuid4
+
+from tools.validate_dataset_manifest import APPROVED_TAXONOMY
+
+
+SCHEMA_VERSION = "1.0.0"
+TOOL_NAME = "evaluate_navigation_scenarios"
+TOOL_VERSION = "1.0.0"
+CANONICAL_CLASS_NAMES = tuple(name for _, name in APPROVED_TAXONOMY)
+_CLASS_ORDER = {name: class_id for class_id, name in APPROVED_TAXONOMY}
+_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_UNEXPECTED_POLICIES = frozenset({"report_only", "fail"})
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+class ScenarioRegressionError(ValueError):
+    """Raised for an invalid suite, fixture, or report invocation."""
+
+
+class _DuplicateJsonKeyError(ValueError):
+    """Raised internally when an input JSON object repeats a field name."""
+
+
+@dataclass(frozen=True)
+class ScenarioCase:
+    """One controlled class-presence regression scenario."""
+
+    scenario_id: str
+    description: str
+    image: str
+    expected_classes: tuple[str, ...]
+    allowed_classes: tuple[str, ...]
+    notes: str | None
+
+
+@dataclass(frozen=True)
+class ScenarioSuite:
+    """A versioned collection of controlled scenario cases."""
+
+    suite_id: str
+    unexpected_detection_policy: str
+    cases: tuple[ScenarioCase, ...]
+
+
+@dataclass(frozen=True)
+class NormalizedDetection:
+    """The minimal detector output used for deterministic class-level scoring."""
+
+    class_name: str
+    confidence: float
+
+
+@dataclass(frozen=True)
+class PredictionFixture:
+    """Saved normalized detections aligned to a scenario suite."""
+
+    suite_id: str
+    predictions: Mapping[str, tuple[NormalizedDetection, ...]]
+    model: Mapping[str, str] | None
+
+
+def _error(location: str, message: str) -> ScenarioRegressionError:
+    return ScenarioRegressionError(f"{location}: {message}")
+
+
+def _require_mapping(value: object, location: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise _error(location, "must be an object.")
+    if not all(isinstance(key, str) for key in value):
+        raise _error(location, "must use string field names.")
+    return value
+
+
+def _require_identifier(value: object, location: str) -> str:
+    if not isinstance(value, str) or not _IDENTIFIER_PATTERN.fullmatch(value):
+        raise _error(location, "must use lowercase letters, numbers, and single hyphens.")
+    return value
+
+
+def _require_text(value: object, location: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise _error(location, "must be a non-empty string.")
+    return value
+
+
+def _decode_until_stable(value: str) -> str:
+    decoded = value
+    for _ in range(3):
+        next_value = unquote(decoded)
+        if next_value == decoded:
+            return decoded
+        decoded = next_value
+    return decoded
+
+
+def normalise_relative_image_path(value: object, location: str = "image") -> str:
+    """Validate a portable relative image path without reading the image file."""
+
+    if not isinstance(value, str) or not value or value != value.strip() or "\x00" in value:
+        raise _error(location, "must be a non-empty, whitespace-trimmed relative path.")
+
+    decoded = _decode_until_stable(value)
+    if "\x00" in decoded:
+        raise _error(location, "must not contain null bytes.")
+    windows_path = PureWindowsPath(decoded)
+    if (
+        decoded.startswith(("/", "\\"))
+        or windows_path.is_absolute()
+        or windows_path.drive
+        or re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*:", decoded)
+    ):
+        raise _error(location, "must be a controlled local relative path, not an absolute path or URI.")
+
+    normalized = decoded.replace("\\", "/")
+    posix_path = PurePosixPath(normalized)
+    if posix_path.is_absolute() or not posix_path.parts or any(part in {".", ".."} for part in posix_path.parts):
+        raise _error(location, "must not contain path traversal.")
+    return posix_path.as_posix()
+
+
+def _canonical_classes(value: object, location: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise _error(location, "must be an array of exact canonical class names.")
+    if not all(isinstance(name, str) for name in value):
+        raise _error(location, "must contain only string class names.")
+    names = tuple(value)
+    unknown = sorted(set(names) - set(CANONICAL_CLASS_NAMES))
+    if unknown:
+        raise _error(location, f"contains unknown class names: {', '.join(unknown)}.")
+    if len(set(names)) != len(names):
+        raise _error(location, "must not contain duplicate class names.")
+    return tuple(sorted(names, key=_CLASS_ORDER.__getitem__))
+
+
+def _check_fields(data: Mapping[str, object], allowed: set[str], location: str) -> None:
+    unexpected = sorted(set(data) - allowed)
+    if unexpected:
+        raise _error(location, f"contains unsupported field(s): {', '.join(unexpected)}.")
+
+
+def _parse_case(value: object, index: int) -> ScenarioCase:
+    location = f"cases[{index}]"
+    case = _require_mapping(value, location)
+    _check_fields(
+        case,
+        {"scenario_id", "description", "image", "expected_classes", "allowed_classes", "notes"},
+        location,
+    )
+    required = ("scenario_id", "description", "image", "expected_classes")
+    for field in required:
+        if field not in case:
+            raise _error(location, f"is missing required field {field!r}.")
+    expected = _canonical_classes(case["expected_classes"], f"{location}.expected_classes")
+    allowed = _canonical_classes(case.get("allowed_classes", []), f"{location}.allowed_classes")
+    overlap = sorted(set(expected) & set(allowed), key=_CLASS_ORDER.__getitem__)
+    if overlap:
+        raise _error(location, f"must not repeat expected classes as allowed classes: {', '.join(overlap)}.")
+    notes = case.get("notes")
+    if notes is not None:
+        notes = _require_text(notes, f"{location}.notes")
+    return ScenarioCase(
+        scenario_id=_require_identifier(case["scenario_id"], f"{location}.scenario_id"),
+        description=_require_text(case["description"], f"{location}.description"),
+        image=normalise_relative_image_path(case["image"], f"{location}.image"),
+        expected_classes=expected,
+        allowed_classes=allowed,
+        notes=notes,
+    )
+
+
+def parse_case_suite(value: object) -> ScenarioSuite:
+    """Validate a versioned, Git-safe suite of controlled scenarios."""
+
+    suite = _require_mapping(value, "suite")
+    _check_fields(suite, {"schema_version", "suite_id", "unexpected_detection_policy", "cases"}, "suite")
+    for field in ("schema_version", "suite_id", "cases"):
+        if field not in suite:
+            raise _error("suite", f"is missing required field {field!r}.")
+    if suite["schema_version"] != SCHEMA_VERSION:
+        raise _error("suite.schema_version", f"must equal {SCHEMA_VERSION!r}.")
+    policy = suite.get("unexpected_detection_policy", "report_only")
+    if not isinstance(policy, str) or policy not in _UNEXPECTED_POLICIES:
+        raise _error("suite.unexpected_detection_policy", "must be 'report_only' or 'fail'.")
+    cases_value = suite["cases"]
+    if not isinstance(cases_value, list) or not cases_value:
+        raise _error("suite.cases", "must be a non-empty array.")
+    cases = tuple(_parse_case(case, index) for index, case in enumerate(cases_value))
+    scenario_ids = [case.scenario_id for case in cases]
+    if len(set(scenario_ids)) != len(scenario_ids):
+        raise _error("suite.cases", "must not contain duplicate scenario_id values.")
+    return ScenarioSuite(
+        suite_id=_require_identifier(suite["suite_id"], "suite.suite_id"),
+        unexpected_detection_policy=policy,
+        cases=cases,
+    )
+
+
+def _parse_detection(value: object, location: str) -> NormalizedDetection:
+    detection = _require_mapping(value, location)
+    _check_fields(detection, {"class_name", "confidence"}, location)
+    for field in ("class_name", "confidence"):
+        if field not in detection:
+            raise _error(location, f"is missing required field {field!r}.")
+    class_name = detection["class_name"]
+    if not isinstance(class_name, str) or class_name not in CANONICAL_CLASS_NAMES:
+        raise _error(f"{location}.class_name", "must be an exact approved canonical class name.")
+    confidence = detection["confidence"]
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not math.isfinite(float(confidence)):
+        raise _error(f"{location}.confidence", "must be a finite number between 0 and 1.")
+    if not 0 <= float(confidence) <= 1:
+        raise _error(f"{location}.confidence", "must be between 0 and 1.")
+    return NormalizedDetection(class_name=class_name, confidence=float(confidence))
+
+
+def _parse_model_identity(value: object) -> Mapping[str, str]:
+    model = _require_mapping(value, "prediction_fixture.model")
+    _check_fields(model, {"filename", "sha256"}, "prediction_fixture.model")
+    for field in ("filename", "sha256"):
+        if field not in model:
+            raise _error("prediction_fixture.model", f"is missing required field {field!r}.")
+    filename = model["filename"]
+    sha256 = model["sha256"]
+    if (
+        not isinstance(filename, str)
+        or not filename
+        or PurePosixPath(filename).name != filename
+        or PureWindowsPath(filename).name != filename
+    ):
+        raise _error("prediction_fixture.model.filename", "must be a filename without path components.")
+    if not isinstance(sha256, str) or not _SHA256_PATTERN.fullmatch(sha256):
+        raise _error("prediction_fixture.model.sha256", "must be a lowercase 64-character SHA-256 checksum.")
+    return {"filename": filename, "sha256": sha256}
+
+
+def parse_prediction_fixture(value: object, suite: ScenarioSuite) -> PredictionFixture:
+    """Validate normalized, replayable predictions for every suite scenario."""
+
+    fixture = _require_mapping(value, "prediction_fixture")
+    _check_fields(fixture, {"schema_version", "suite_id", "predictions", "model"}, "prediction_fixture")
+    for field in ("schema_version", "suite_id", "predictions"):
+        if field not in fixture:
+            raise _error("prediction_fixture", f"is missing required field {field!r}.")
+    if fixture["schema_version"] != SCHEMA_VERSION:
+        raise _error("prediction_fixture.schema_version", f"must equal {SCHEMA_VERSION!r}.")
+    if fixture["suite_id"] != suite.suite_id:
+        raise _error("prediction_fixture.suite_id", "must exactly match suite.suite_id.")
+    predictions_value = _require_mapping(fixture["predictions"], "prediction_fixture.predictions")
+    expected_ids = {case.scenario_id for case in suite.cases}
+    actual_ids = set(predictions_value)
+    if actual_ids != expected_ids:
+        missing = sorted(expected_ids - actual_ids)
+        unexpected = sorted(actual_ids - expected_ids)
+        details = []
+        if missing:
+            details.append(f"missing scenario IDs: {', '.join(missing)}")
+        if unexpected:
+            details.append(f"unknown scenario IDs: {', '.join(unexpected)}")
+        raise _error("prediction_fixture.predictions", "; ".join(details) + ".")
+    predictions: dict[str, tuple[NormalizedDetection, ...]] = {}
+    for case in suite.cases:
+        entries = predictions_value[case.scenario_id]
+        if not isinstance(entries, list):
+            raise _error(f"prediction_fixture.predictions.{case.scenario_id}", "must be an array.")
+        predictions[case.scenario_id] = tuple(
+            _parse_detection(entry, f"prediction_fixture.predictions.{case.scenario_id}[{index}]")
+            for index, entry in enumerate(entries)
+        )
+    model = fixture.get("model")
+    return PredictionFixture(
+        suite_id=suite.suite_id,
+        predictions=predictions,
+        model=_parse_model_identity(model) if model is not None else None,
+    )
+
+
+def _metric_summary(true_positives: int, false_positives: int, false_negatives: int) -> dict[str, float | None]:
+    precision_denominator = true_positives + false_positives
+    recall_denominator = true_positives + false_negatives
+    f1_denominator = (2 * true_positives) + false_positives + false_negatives
+    return {
+        "precision": (true_positives / precision_denominator) if precision_denominator else None,
+        "recall": (true_positives / recall_denominator) if recall_denominator else None,
+        "f1": (2 * true_positives / f1_denominator) if f1_denominator else None,
+    }
+
+
+def _ordered_classes(classes: set[str]) -> list[str]:
+    return sorted(classes, key=_CLASS_ORDER.__getitem__)
+
+
+def _validate_confidence_threshold(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+        raise ScenarioRegressionError("confidence_threshold must be a finite number between 0 and 1.")
+    threshold = float(value)
+    if not 0 <= threshold <= 1:
+        raise ScenarioRegressionError("confidence_threshold must be between 0 and 1.")
+    return threshold
+
+
+def evaluate_suite(
+    suite: ScenarioSuite,
+    fixture: PredictionFixture,
+    *,
+    confidence_threshold: float = 0.0,
+) -> dict[str, object]:
+    """Score fixture detections with deterministic class-presence semantics."""
+
+    if fixture.suite_id != suite.suite_id:
+        raise ScenarioRegressionError("prediction fixture suite_id does not match the supplied suite.")
+    threshold = _validate_confidence_threshold(confidence_threshold)
+    scenario_results: list[dict[str, object]] = []
+    totals = {"true_positives": 0, "false_positives": 0, "false_negatives": 0}
+    per_class_counts = {
+        class_name: {"true_positives": 0, "false_positives": 0, "false_negatives": 0}
+        for class_name in CANONICAL_CLASS_NAMES
+    }
+
+    for case in suite.cases:
+        detections = fixture.predictions[case.scenario_id]
+        detected = {item.class_name for item in detections if item.confidence >= threshold}
+        expected = set(case.expected_classes)
+        allowed = set(case.allowed_classes)
+        true_positive_classes = expected & detected
+        missed_classes = expected - detected
+        unexpected_classes = detected - expected - allowed
+        allowed_detected_classes = detected & allowed
+        passed = not missed_classes and (
+            suite.unexpected_detection_policy == "report_only" or not unexpected_classes
+        )
+        counts = {
+            "true_positives": len(true_positive_classes),
+            "false_positives": len(unexpected_classes),
+            "false_negatives": len(missed_classes),
+        }
+        for key, count in counts.items():
+            totals[key] += count
+        for class_name in true_positive_classes:
+            per_class_counts[class_name]["true_positives"] += 1
+        for class_name in unexpected_classes:
+            per_class_counts[class_name]["false_positives"] += 1
+        for class_name in missed_classes:
+            per_class_counts[class_name]["false_negatives"] += 1
+        scenario_results.append(
+            {
+                "scenario_id": case.scenario_id,
+                "description": case.description,
+                "image": case.image,
+                "notes": case.notes,
+                "expected_classes": list(case.expected_classes),
+                "allowed_classes": list(case.allowed_classes),
+                "detected_classes": _ordered_classes(detected),
+                "allowed_detected_classes": _ordered_classes(allowed_detected_classes),
+                "true_positive_classes": _ordered_classes(true_positive_classes),
+                "missed_classes": _ordered_classes(missed_classes),
+                "unexpected_classes": _ordered_classes(unexpected_classes),
+                "filtered_out_detection_count": len(detections) - sum(
+                    item.confidence >= threshold for item in detections
+                ),
+                **counts,
+                "metrics": _metric_summary(**counts),
+                "passed": passed,
+            }
+        )
+
+    scenarios_passed = sum(result["passed"] is True for result in scenario_results)
+    aggregate = {
+        "scenario_count": len(scenario_results),
+        "scenarios_passed": scenarios_passed,
+        "scenarios_failed": len(scenario_results) - scenarios_passed,
+        **totals,
+        **_metric_summary(**totals),
+    }
+    per_class = {
+        class_name: {**counts, **_metric_summary(**counts)}
+        for class_name, counts in per_class_counts.items()
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tool": {"name": TOOL_NAME, "version": TOOL_VERSION},
+        "case_suite": {
+            "suite_id": suite.suite_id,
+            "unexpected_detection_policy": suite.unexpected_detection_policy,
+        },
+        "model": dict(fixture.model) if fixture.model is not None else None,
+        "inference_settings": {
+            "confidence_threshold": threshold,
+            "threshold_semantics": "Detector operating threshold only; not a navigation-risk, proximity, or safety-policy threshold.",
+        },
+        "taxonomy": [{"id": class_id, "name": name} for class_id, name in APPROVED_TAXONOMY],
+        "scenarios": scenario_results,
+        "aggregate": aggregate,
+        "per_class": per_class,
+    }
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise ScenarioRegressionError("Input checksum could not be computed.") from exc
+    return digest.hexdigest()
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    """Reject JSON duplicate keys before a parser can silently overwrite one."""
+
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError(key)
+        result[key] = value
+    return result
+
+
+def _load_json(path: str | Path, label: str) -> tuple[Path, object]:
+    source = Path(path).expanduser().resolve()
+    if not source.exists() or not source.is_file():
+        raise ScenarioRegressionError(f"{label} file is missing or is not a file.")
+    try:
+        return source, json.loads(
+            source.read_text(encoding="utf-8"), object_pairs_hook=_unique_json_object
+        )
+    except _DuplicateJsonKeyError as exc:
+        raise ScenarioRegressionError(f"{label} file contains duplicate JSON field {exc.args[0]!r}.") from exc
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ScenarioRegressionError(f"{label} file could not be read as UTF-8 JSON.") from exc
+
+
+def load_case_suite(path: str | Path) -> tuple[Path, ScenarioSuite]:
+    """Load a case suite from local JSON without reading image data."""
+
+    source, payload = _load_json(path, "Case suite")
+    return source, parse_case_suite(payload)
+
+
+def load_prediction_fixture(path: str | Path, suite: ScenarioSuite) -> tuple[Path, PredictionFixture]:
+    """Load saved normalized detections from local JSON."""
+
+    source, payload = _load_json(path, "Prediction fixture")
+    return source, parse_prediction_fixture(payload, suite)
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def prepare_output_directory(output_path: str | Path, *, overwrite: bool) -> Path:
+    """Create an external report directory so generated output cannot enter Git."""
+
+    output = Path(output_path).expanduser().resolve()
+    if _is_within(output, _REPOSITORY_ROOT):
+        raise ScenarioRegressionError("Report output must be outside the repository.")
+    if output.exists() and not output.is_dir():
+        raise ScenarioRegressionError("Report output path is not a directory.")
+    if output.exists() and any(output.iterdir()) and not overwrite:
+        raise ScenarioRegressionError("Report output directory is not empty. Use --overwrite to replace reports.")
+    try:
+        output.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ScenarioRegressionError("Report output directory could not be created.") from exc
+    return output
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        temporary.write_text(content, encoding="utf-8")
+        os.replace(temporary, path)
+    except (OSError, UnicodeError) as exc:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise ScenarioRegressionError("Scenario report could not be written.") from exc
+
+
+def _display_metric(value: object) -> str:
+    return "n/a" if value is None else f"{float(value):.6f}"
+
+
+def render_markdown_report(report: Mapping[str, object]) -> str:
+    """Render a deterministic human-readable companion to the JSON report."""
+
+    aggregate = report["aggregate"]
+    per_class = report["per_class"]
+    scenarios = report["scenarios"]
+    assert isinstance(aggregate, Mapping) and isinstance(per_class, Mapping) and isinstance(scenarios, list)
+    lines = [
+        "# Navigation Scenario Regression Evaluation",
+        "",
+        f"- Suite: `{report['case_suite']['suite_id']}`",  # type: ignore[index]
+        f"- Unexpected detection policy: `{report['case_suite']['unexpected_detection_policy']}`",  # type: ignore[index]
+        f"- Detector confidence threshold: `{report['inference_settings']['confidence_threshold']}`",  # type: ignore[index]
+        "- Threshold scope: detector operating point only; not navigation risk or proximity policy.",
+        "",
+        "## Aggregate Metrics",
+        "",
+        "| Scenarios | Passed | Failed | TP | FP | FN | Precision | Recall | F1 |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        "| {scenario_count} | {scenarios_passed} | {scenarios_failed} | {true_positives} | {false_positives} | {false_negatives} | {precision} | {recall} | {f1} |".format(
+            **{
+                **aggregate,
+                "precision": _display_metric(aggregate["precision"]),
+                "recall": _display_metric(aggregate["recall"]),
+                "f1": _display_metric(aggregate["f1"]),
+            }
+        ),
+        "",
+        "## Scenario Results",
+        "",
+    ]
+    for result in scenarios:
+        assert isinstance(result, Mapping)
+        lines.extend(
+            [
+                f"### {result['scenario_id']}",
+                "",
+                f"- Result: **{'PASS' if result['passed'] else 'FAIL'}**",
+                f"- Expected: {', '.join(result['expected_classes']) or '(none)'}",  # type: ignore[arg-type]
+                f"- Allowed: {', '.join(result['allowed_classes']) or '(none)'}",  # type: ignore[arg-type]
+                f"- Detected: {', '.join(result['detected_classes']) or '(none)'}",  # type: ignore[arg-type]
+                f"- Missed: {', '.join(result['missed_classes']) or '(none)'}",  # type: ignore[arg-type]
+                f"- Unexpected: {', '.join(result['unexpected_classes']) or '(none)'}",  # type: ignore[arg-type]
+                "- Counts: TP {true_positives}, FP {false_positives}, FN {false_negatives}".format(
+                    **result
+                ),
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "## Per-Class Metrics",
+            "",
+            "| Class | TP | FP | FN | Precision | Recall | F1 |",
+            "|---|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for class_name in CANONICAL_CLASS_NAMES:
+        metrics = per_class[class_name]
+        assert isinstance(metrics, Mapping)
+        lines.append(
+            "| {class_name} | {true_positives} | {false_positives} | {false_negatives} | {precision} | {recall} | {f1} |".format(
+                **{
+                    **metrics,
+                    "class_name": class_name,
+                    "precision": _display_metric(metrics["precision"]),
+                    "recall": _display_metric(metrics["recall"]),
+                    "f1": _display_metric(metrics["f1"]),
+                }
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_reports(report: Mapping[str, object], output_path: str | Path, *, overwrite: bool) -> Path:
+    """Write the two versioned reports without exposing absolute input paths."""
+
+    output = prepare_output_directory(output_path, overwrite=overwrite)
+    try:
+        serialized = json.dumps(report, indent=2, allow_nan=False) + "\n"
+    except (TypeError, ValueError) as exc:
+        raise ScenarioRegressionError("Scenario report is not JSON-safe.") from exc
+    _atomic_write_text(output / "scenario_evaluation.json", serialized)
+    _atomic_write_text(output / "scenario_evaluation.md", render_markdown_report(report))
+    return output
+
+
+def run_fixture_evaluation(
+    *,
+    case_suite_path: str | Path,
+    prediction_fixture_path: str | Path,
+    output_path: str | Path,
+    confidence_threshold: float = 0.0,
+    overwrite: bool = False,
+) -> dict[str, object]:
+    """Load local JSON inputs, replay predictions, and write external reports."""
+
+    case_source, suite = load_case_suite(case_suite_path)
+    fixture_source, fixture = load_prediction_fixture(prediction_fixture_path, suite)
+    report = evaluate_suite(suite, fixture, confidence_threshold=confidence_threshold)
+    report["sources"] = {
+        "case_suite": {"filename": case_source.name, "sha256": _sha256(case_source)},
+        "prediction_fixture": {"filename": fixture_source.name, "sha256": _sha256(fixture_source)},
+    }
+    write_reports(report, output_path, overwrite=overwrite)
+    return report

--- a/ML_side/tests/test_navigation_scenario_regression.py
+++ b/ML_side/tests/test_navigation_scenario_regression.py
@@ -1,0 +1,576 @@
+"""Regression coverage for the offline navigation scenario-evaluation harness."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ML_SIDE_DIR = Path(__file__).resolve().parents[1]
+if str(ML_SIDE_DIR) not in sys.path:
+    sys.path.insert(0, str(ML_SIDE_DIR))
+
+from scenario_regression import evaluator
+
+
+def case(
+    scenario_id: str,
+    expected: list[str],
+    *,
+    allowed: list[str] | None = None,
+    image: str = "images/example.jpg",
+) -> dict[str, object]:
+    return {
+        "scenario_id": scenario_id,
+        "description": f"Controlled {scenario_id} scenario.",
+        "image": image,
+        "expected_classes": expected,
+        **({"allowed_classes": allowed} if allowed is not None else {}),
+    }
+
+
+def suite(
+    cases: list[dict[str, object]] | None = None,
+    *,
+    policy: str = "report_only",
+) -> dict[str, object]:
+    return {
+        "schema_version": evaluator.SCHEMA_VERSION,
+        "suite_id": "navigation-regression-v1",
+        "unexpected_detection_policy": policy,
+        "cases": cases or [case("stairs-ahead", ["stairs"])],
+    }
+
+
+def fixture(
+    predictions: dict[str, list[dict[str, object]]] | None = None,
+    *,
+    model: dict[str, str] | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": evaluator.SCHEMA_VERSION,
+        "suite_id": "navigation-regression-v1",
+        "predictions": (
+            predictions if predictions is not None else {"stairs-ahead": [{"class_name": "stairs", "confidence": 0.9}]}
+        ),
+        **({"model": model} if model is not None else {}),
+    }
+
+
+def evaluate(
+    suite_payload: dict[str, object] | None = None,
+    fixture_payload: dict[str, object] | None = None,
+    *,
+    threshold: float = 0.0,
+) -> dict[str, object]:
+    parsed_suite = evaluator.parse_case_suite(suite_payload or suite())
+    parsed_fixture = evaluator.parse_prediction_fixture(fixture_payload or fixture(), parsed_suite)
+    return evaluator.evaluate_suite(parsed_suite, parsed_fixture, confidence_threshold=threshold)
+
+
+def test_taxonomy_is_exactly_the_approved_navigation_taxonomy() -> None:
+    assert evaluator.APPROVED_TAXONOMY == (
+        (0, "person"),
+        (1, "stairs"),
+        (2, "door"),
+        (3, "chair"),
+        (4, "table"),
+        (5, "pole"),
+        (6, "bicycle"),
+        (7, "vehicle"),
+    )
+
+
+def test_valid_case_normalizes_a_relative_windows_path_to_git_safe_posix() -> None:
+    parsed = evaluator.parse_case_suite(suite([case("stairs-ahead", ["stairs"], image="images\\stairs.jpg")]))
+    assert parsed.cases[0].image == "images/stairs.jpg"
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        ({}, "missing required field"),
+        (suite([{"scenario_id": "stairs-ahead"}]), "missing required field"),
+        ({**suite(), "schema_version": "2.0.0"}, "schema_version"),
+        ({**suite(), "extra": True}, "unsupported field"),
+        ({**suite(), "cases": []}, "non-empty"),
+        (suite([case("", ["stairs"])]), "scenario_id"),
+        (suite([case("   ", ["stairs"])]), "scenario_id"),
+        (suite([case(123, ["stairs"])]), "scenario_id"),  # type: ignore[arg-type]
+        (suite([case("stairs-ahead", ["book"])]), "unknown class"),
+        (suite([case("stairs-ahead", ["Stairs"])]), "unknown class"),
+        (suite([case("stairs-ahead", [" stairs "])]), "unknown class"),
+        (suite([case("stairs-ahead", [""])]), "unknown class"),
+        (suite([case("stairs-ahead", ["stairs", "stairs"])]), "duplicate"),
+        (suite([case("stairs-ahead", "stairs")]), "must be an array"),  # type: ignore[arg-type]
+        (suite([case("stairs-ahead", ["stairs"], allowed="person")]), "must be an array"),  # type: ignore[arg-type]
+        (suite([case("stairs-ahead", ["stairs"], allowed=["stairs"])]), "must not repeat"),
+        (suite([case("stairs-ahead", ["stairs"]), case("stairs-ahead", ["person"])]), "duplicate scenario_id"),
+        ({**suite(), "unexpected_detection_policy": []}, "unexpected_detection_policy"),
+    ],
+)
+def test_malformed_cases_fail_with_readable_context(payload: dict[str, object], message: str) -> None:
+    with pytest.raises(evaluator.ScenarioRegressionError, match=message):
+        evaluator.parse_case_suite(payload)
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        "/absolute/image.jpg",
+        "C:\\images\\stairs.jpg",
+        "C:images\\stairs.jpg",
+        "\\\\server\\share\\stairs.jpg",
+        "../stairs.jpg",
+        "images/../stairs.jpg",
+        "./../stairs.jpg",
+        "images\\..\\stairs.jpg",
+        "images/%2e%2e/stairs.jpg",
+        "https://example.invalid/stairs.jpg",
+    ],
+)
+def test_unsafe_image_paths_are_rejected(image: str) -> None:
+    with pytest.raises(evaluator.ScenarioRegressionError):
+        evaluator.parse_case_suite(suite([case("stairs-ahead", ["stairs"], image=image)]))
+
+
+def test_perfect_true_positive_case_passes_with_unit_metrics() -> None:
+    report = evaluate()
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert result["passed"] is True
+    assert result["true_positives"] == 1
+    assert result["metrics"] == {"precision": 1.0, "recall": 1.0, "f1": 1.0}
+
+
+def test_false_positive_is_reported_without_silently_failing_default_policy() -> None:
+    report = evaluate(fixture_payload=fixture({"stairs-ahead": [{"class_name": "person", "confidence": 0.9}]}))
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert result["passed"] is False
+    assert result["unexpected_classes"] == ["person"]
+    assert result["missed_classes"] == ["stairs"]
+
+
+def test_unexpected_detection_policy_can_fail_an_otherwise_complete_case() -> None:
+    fixture_payload = fixture(
+        {
+            "stairs-ahead": [
+                {"class_name": "stairs", "confidence": 0.9},
+                {"class_name": "person", "confidence": 0.9},
+            ]
+        }
+    )
+    report_only_result = evaluate(fixture_payload=fixture_payload)["scenarios"][0]  # type: ignore[index]
+    assert report_only_result["passed"] is True
+    assert report_only_result["false_positives"] == 1
+    assert report_only_result["unexpected_classes"] == ["person"]
+    report = evaluate(
+        suite([case("stairs-ahead", ["stairs"])], policy="fail"),
+        fixture_payload,
+    )
+    assert report["scenarios"][0]["passed"] is False  # type: ignore[index]
+
+
+def test_false_negative_and_zero_predictions_are_explicit() -> None:
+    report = evaluate(fixture_payload=fixture({"stairs-ahead": []}))
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert result["detected_classes"] == []
+    assert result["missed_classes"] == ["stairs"]
+    assert result["metrics"] == {"precision": None, "recall": 0.0, "f1": 0.0}
+
+
+def test_mixed_tp_fp_fn_and_deterministic_f1() -> None:
+    report = evaluate(
+        suite([case("mixed", ["stairs", "door"])]),
+        fixture({"mixed": [{"class_name": "stairs", "confidence": 0.9}, {"class_name": "person", "confidence": 0.9}]}),
+    )
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert (result["true_positives"], result["false_positives"], result["false_negatives"]) == (1, 1, 1)
+    assert result["metrics"] == {"precision": 0.5, "recall": 0.5, "f1": 0.5}
+
+
+def test_allowed_classes_are_reported_but_not_false_positives() -> None:
+    report = evaluate(
+        suite([case("stairs-person", ["stairs"], allowed=["person"])]),
+        fixture({"stairs-person": [{"class_name": "stairs", "confidence": 0.9}, {"class_name": "person", "confidence": 0.9}]}),
+    )
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert result["allowed_detected_classes"] == ["person"]
+    assert result["unexpected_classes"] == []
+    assert result["passed"] is True
+
+
+def test_allowed_detection_never_satisfies_a_missing_required_class() -> None:
+    report = evaluate(
+        suite([case("stairs-person", ["stairs"], allowed=["person"])]),
+        fixture({"stairs-person": [{"class_name": "person", "confidence": 0.9}]}),
+    )
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert result["allowed_detected_classes"] == ["person"]
+    assert (result["true_positives"], result["false_positives"], result["false_negatives"]) == (0, 0, 1)
+    assert result["passed"] is False
+
+
+def test_negative_scenario_has_undefined_metrics_when_nothing_is_detected() -> None:
+    report = evaluate(suite([case("empty-hallway", [])]), fixture({"empty-hallway": []}))
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert result["passed"] is True
+    assert result["metrics"] == {"precision": None, "recall": None, "f1": None}
+
+
+def test_negative_scenario_reports_false_positives_without_fabricating_recall() -> None:
+    report = evaluate(
+        suite([case("empty-hallway", [])]),
+        fixture({"empty-hallway": [{"class_name": "vehicle", "confidence": 0.9}]}),
+    )
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert result["passed"] is True
+    assert result["unexpected_classes"] == ["vehicle"]
+    assert result["metrics"] == {"precision": 0.0, "recall": None, "f1": 0.0}
+
+
+def test_negative_scenario_with_fail_policy_fails_but_preserves_counts() -> None:
+    report = evaluate(
+        suite([case("empty-hallway", [])], policy="fail"),
+        fixture({"empty-hallway": [{"class_name": "vehicle", "confidence": 0.9}]}),
+    )
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert result["passed"] is False
+    assert (result["true_positives"], result["false_positives"], result["false_negatives"]) == (0, 1, 0)
+
+
+def test_aggregate_and_per_class_metrics_cover_multiple_scenarios() -> None:
+    report = evaluate(
+        suite([case("stairs", ["stairs"]), case("door", ["door"])]),
+        fixture({"stairs": [{"class_name": "stairs", "confidence": 0.9}], "door": [{"class_name": "person", "confidence": 0.9}]}),
+    )
+    assert report["aggregate"] == {  # type: ignore[index]
+        "scenario_count": 2,
+        "scenarios_passed": 1,
+        "scenarios_failed": 1,
+        "true_positives": 1,
+        "false_positives": 1,
+        "false_negatives": 1,
+        "precision": 0.5,
+        "recall": 0.5,
+        "f1": 0.5,
+    }
+    assert report["per_class"]["stairs"]["true_positives"] == 1  # type: ignore[index]
+    assert report["per_class"]["door"]["false_negatives"] == 1  # type: ignore[index]
+    assert report["per_class"]["person"]["false_positives"] == 1  # type: ignore[index]
+
+
+def test_aggregate_uses_micro_counts_not_an_average_of_case_metrics() -> None:
+    report = evaluate(
+        suite([case("stairs", ["stairs"]), case("door-chair", ["door", "chair"])]),
+        fixture(
+            {
+                "stairs": [{"class_name": "stairs", "confidence": 0.9}],
+                "door-chair": [{"class_name": "person", "confidence": 0.9}],
+            }
+        ),
+    )
+    aggregate = report["aggregate"]  # type: ignore[index]
+    assert aggregate["precision"] == 0.5
+    assert aggregate["recall"] == pytest.approx(1 / 3)
+    assert aggregate["f1"] == 0.4
+    assert aggregate["f1"] != pytest.approx(0.5)
+
+
+def test_unobserved_per_class_metrics_are_explicitly_not_applicable() -> None:
+    report = evaluate()
+    vehicle = report["per_class"]["vehicle"]  # type: ignore[index]
+    assert vehicle == {
+        "true_positives": 0,
+        "false_positives": 0,
+        "false_negatives": 0,
+        "precision": None,
+        "recall": None,
+        "f1": None,
+    }
+
+
+def test_detection_lists_are_deduplicated_and_canonically_ordered() -> None:
+    report = evaluate(
+        suite([case("ordered", ["stairs", "vehicle"])]),
+        fixture({"ordered": [{"class_name": "vehicle", "confidence": 0.9}, {"class_name": "stairs", "confidence": 0.9}, {"class_name": "stairs", "confidence": 0.8}]}),
+    )
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert result["detected_classes"] == ["stairs", "vehicle"]
+    assert result["true_positives"] == 2
+    assert list(report["per_class"]) == list(evaluator.CANONICAL_CLASS_NAMES)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "detection, message",
+    [
+        ({"class_name": "book", "confidence": 0.9}, "exact approved"),
+        ({"class_name": "Stairs", "confidence": 0.9}, "exact approved"),
+        ({"class_name": " stairs ", "confidence": 0.9}, "exact approved"),
+        ({"class_name": "", "confidence": 0.9}, "exact approved"),
+        ({"class_name": "stairs"}, "missing required field"),
+        ({"class_name": "stairs", "confidence": "0.9"}, "finite"),
+        ({"class_name": "stairs", "confidence": True}, "finite"),
+        ({"class_name": "stairs", "confidence": math.nan}, "finite"),
+        ({"class_name": "stairs", "confidence": math.inf}, "finite"),
+        ({"class_name": "stairs", "confidence": -0.1}, "between 0 and 1"),
+        ({"class_name": "stairs", "confidence": 1.1}, "between 0 and 1"),
+        ({"class_name": "stairs", "confidence": 0.9, "extra": "field"}, "unsupported field"),
+    ],
+)
+def test_fixture_rejects_unknown_or_invalid_confidence(detection: dict[str, object], message: str) -> None:
+    parsed_suite = evaluator.parse_case_suite(suite())
+    with pytest.raises(evaluator.ScenarioRegressionError, match=message):
+        evaluator.parse_prediction_fixture(fixture({"stairs-ahead": [detection]}), parsed_suite)
+
+
+def test_fixture_requires_exact_scenario_coverage_and_optional_safe_model_identity() -> None:
+    parsed_suite = evaluator.parse_case_suite(
+        suite([case("stairs-ahead", ["stairs"]), case("door-ahead", ["door"]), case("chair-ahead", ["chair"])])
+    )
+    with pytest.raises(evaluator.ScenarioRegressionError, match="missing scenario IDs"):
+        evaluator.parse_prediction_fixture(fixture({"stairs-ahead": []}), parsed_suite)
+    with pytest.raises(evaluator.ScenarioRegressionError, match="unknown scenario IDs"):
+        evaluator.parse_prediction_fixture(
+            fixture(
+                {
+                    "stairs-ahead": [],
+                    "door-ahead": [],
+                    "chair-ahead": [],
+                    "vehicle-ahead": [],
+                }
+            ),
+            parsed_suite,
+        )
+    with pytest.raises(evaluator.ScenarioRegressionError, match="suite_id"):
+        evaluator.parse_prediction_fixture(
+            {**fixture({"stairs-ahead": [], "door-ahead": [], "chair-ahead": []}), "suite_id": "different-suite"},
+            parsed_suite,
+        )
+    with pytest.raises(evaluator.ScenarioRegressionError, match="must be an object"):
+        evaluator.parse_prediction_fixture([], parsed_suite)
+    parsed = evaluator.parse_prediction_fixture(
+        fixture(
+            {"stairs-ahead": [], "door-ahead": [], "chair-ahead": []},
+            model={"filename": "candidate.pt", "sha256": "a" * 64},
+        ),
+        parsed_suite,
+    )
+    assert parsed.model == {"filename": "candidate.pt", "sha256": "a" * 64}
+
+
+def test_confidence_filtering_is_explicit_and_not_a_risk_policy() -> None:
+    report = evaluate(
+        fixture_payload=fixture({"stairs-ahead": [{"class_name": "stairs", "confidence": 0.49}]}),
+        threshold=0.5,
+    )
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert result["filtered_out_detection_count"] == 1
+    assert result["missed_classes"] == ["stairs"]
+    assert "risk" in report["inference_settings"]["threshold_semantics"]  # type: ignore[index]
+
+
+def test_confidence_comparison_includes_equal_values_and_excludes_only_lower_values() -> None:
+    report = evaluate(
+        fixture_payload=fixture(
+            {
+                "stairs-ahead": [
+                    {"class_name": "stairs", "confidence": 0.5},
+                    {"class_name": "person", "confidence": 0.499999},
+                    {"class_name": "door", "confidence": 0.500001},
+                ]
+            }
+        ),
+        threshold=0.5,
+    )
+    result = report["scenarios"][0]  # type: ignore[index]
+    assert result["detected_classes"] == ["stairs", "door"]
+    assert result["filtered_out_detection_count"] == 1
+
+
+@pytest.mark.parametrize(
+    "threshold",
+    [None, -0.01, 1.01, math.nan, math.inf, -math.inf, "0.5", True],
+)
+def test_invalid_confidence_thresholds_are_rejected_cleanly(threshold: object) -> None:
+    parsed_suite = evaluator.parse_case_suite(suite())
+    parsed_fixture = evaluator.parse_prediction_fixture(fixture(), parsed_suite)
+    with pytest.raises(evaluator.ScenarioRegressionError, match="confidence_threshold"):
+        evaluator.evaluate_suite(parsed_suite, parsed_fixture, confidence_threshold=threshold)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("threshold", [0, 0.0, 1, 1.0])
+def test_confidence_threshold_bounds_and_equality_are_deterministic(threshold: float) -> None:
+    report = evaluate(
+        fixture_payload=fixture({"stairs-ahead": [{"class_name": "stairs", "confidence": threshold}]}),
+        threshold=threshold,
+    )
+    assert report["scenarios"][0]["detected_classes"] == ["stairs"]  # type: ignore[index]
+
+
+def test_fixture_replay_writes_json_and_markdown_without_absolute_paths(tmp_path: Path) -> None:
+    cases = tmp_path / "cases.json"
+    predictions = tmp_path / "predictions.json"
+    output = tmp_path / "reports"
+    cases.write_text(json.dumps(suite()), encoding="utf-8")
+    predictions.write_text(json.dumps(fixture()), encoding="utf-8")
+
+    report = evaluator.run_fixture_evaluation(
+        case_suite_path=cases,
+        prediction_fixture_path=predictions,
+        output_path=output,
+    )
+
+    json_report = (output / "scenario_evaluation.json").read_text(encoding="utf-8")
+    markdown_report = (output / "scenario_evaluation.md").read_text(encoding="utf-8")
+    assert (output / "scenario_evaluation.json").is_file()
+    assert (output / "scenario_evaluation.md").is_file()
+    assert str(tmp_path) not in json_report
+    assert list(json.loads(json_report)["per_class"]) == list(evaluator.CANONICAL_CLASS_NAMES)
+    assert report["sources"]["case_suite"]["filename"] == "cases.json"  # type: ignore[index]
+    assert "Missed: (none)" in markdown_report
+    assert "Unexpected: (none)" in markdown_report
+
+
+def test_loader_rejects_duplicate_json_prediction_keys_and_malformed_json(tmp_path: Path) -> None:
+    cases = tmp_path / "cases.json"
+    duplicate_fixture = tmp_path / "duplicate-fixture.json"
+    malformed_fixture = tmp_path / "malformed-fixture.json"
+    cases.write_text(json.dumps(suite()), encoding="utf-8")
+    duplicate_fixture.write_text(
+        '{"schema_version":"1.0.0","suite_id":"navigation-regression-v1",'
+        '"predictions":{"stairs-ahead":[],"stairs-ahead":[]}}',
+        encoding="utf-8",
+    )
+    malformed_fixture.write_text("{not-json", encoding="utf-8")
+    _, parsed_suite = evaluator.load_case_suite(cases)
+    with pytest.raises(evaluator.ScenarioRegressionError, match="duplicate JSON field"):
+        evaluator.load_prediction_fixture(duplicate_fixture, parsed_suite)
+    with pytest.raises(evaluator.ScenarioRegressionError, match="could not be read"):
+        evaluator.load_prediction_fixture(malformed_fixture, parsed_suite)
+
+
+def test_source_checksums_change_with_input_bytes_and_reports_are_reproducible(tmp_path: Path) -> None:
+    cases = tmp_path / "cases.json"
+    predictions = tmp_path / "predictions.json"
+    first_output = tmp_path / "first"
+    second_output = tmp_path / "second"
+    cases.write_text(json.dumps(suite(), indent=2), encoding="utf-8")
+    predictions.write_text(json.dumps(fixture(), indent=2), encoding="utf-8")
+    first = evaluator.run_fixture_evaluation(
+        case_suite_path=cases,
+        prediction_fixture_path=predictions,
+        output_path=first_output,
+    )
+    second = evaluator.run_fixture_evaluation(
+        case_suite_path=cases,
+        prediction_fixture_path=predictions,
+        output_path=second_output,
+    )
+    assert first["sources"] == second["sources"]
+    assert (first_output / "scenario_evaluation.json").read_bytes() == (
+        second_output / "scenario_evaluation.json"
+    ).read_bytes()
+    assert (first_output / "scenario_evaluation.md").read_bytes() == (
+        second_output / "scenario_evaluation.md"
+    ).read_bytes()
+    cases.write_text(json.dumps({**suite(), "suite_id": "navigation-regression-v2"}), encoding="utf-8")
+    changed_source, _ = evaluator.load_case_suite(cases)
+    assert evaluator._sha256(changed_source) != first["sources"]["case_suite"]["sha256"]  # type: ignore[index]
+
+
+def test_reports_include_exact_missed_and_unexpected_names() -> None:
+    report = evaluate(
+        suite([case("stairs-ahead", ["stairs"], allowed=["chair"])]),
+        fixture({"stairs-ahead": [{"class_name": "person", "confidence": 0.9}]}),
+    )
+    markdown = evaluator.render_markdown_report(report)
+    assert "Allowed: chair" in markdown
+    assert "Missed: stairs" in markdown
+    assert "Unexpected: person" in markdown
+    assert "Counts: TP 0, FP 1, FN 1" in markdown
+
+
+def test_report_output_refuses_the_repository_and_json_is_finite(tmp_path: Path) -> None:
+    report = evaluate()
+    with pytest.raises(evaluator.ScenarioRegressionError, match="outside the repository"):
+        evaluator.write_reports(report, evaluator._REPOSITORY_ROOT / "scenario-results", overwrite=False)
+    assert "NaN" not in json.dumps(report, allow_nan=False)
+
+
+def test_output_directory_refuses_files_and_nonempty_directories_without_overwrite(tmp_path: Path) -> None:
+    report = evaluate()
+    output_file = tmp_path / "output-file"
+    output_file.write_text("not a directory", encoding="utf-8")
+    with pytest.raises(evaluator.ScenarioRegressionError, match="not a directory"):
+        evaluator.write_reports(report, output_file, overwrite=False)
+    nonempty_output = tmp_path / "nonempty-output"
+    nonempty_output.mkdir()
+    (nonempty_output / "unrelated.txt").write_text("preserve", encoding="utf-8")
+    with pytest.raises(evaluator.ScenarioRegressionError, match="not empty"):
+        evaluator.write_reports(report, nonempty_output, overwrite=False)
+    evaluator.write_reports(report, nonempty_output, overwrite=True)
+    assert (nonempty_output / "unrelated.txt").read_text(encoding="utf-8") == "preserve"
+
+
+def test_core_module_has_no_network_client_dependency() -> None:
+    source = inspect.getsource(evaluator)
+    assert "import requests" not in source
+    assert "urllib.request" not in source
+    assert "localhost" not in source
+    assert ":8001" not in source
+
+
+def test_cli_help_runs_without_a_server_or_model() -> None:
+    command = [
+        sys.executable,
+        str(ML_SIDE_DIR / "tools" / "evaluate_navigation_scenarios.py"),
+        "--help",
+    ]
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert result.returncode == 0
+    assert "normalized local detections" in result.stdout
+
+
+def test_cli_replays_a_valid_local_fixture(tmp_path: Path) -> None:
+    cases = tmp_path / "cases.json"
+    predictions = tmp_path / "predictions.json"
+    output = tmp_path / "reports"
+    cases.write_text(json.dumps(suite()), encoding="utf-8")
+    predictions.write_text(json.dumps(fixture()), encoding="utf-8")
+    command = [
+        sys.executable,
+        str(ML_SIDE_DIR / "tools" / "evaluate_navigation_scenarios.py"),
+        "--cases",
+        str(cases),
+        "--predictions",
+        str(predictions),
+        "--output",
+        str(output),
+    ]
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert result.returncode == 0
+    assert "1/1 scenarios passed" in result.stdout
+    assert (output / "scenario_evaluation.json").is_file()
+
+
+def test_cli_reports_expected_input_errors_without_a_traceback(tmp_path: Path) -> None:
+    command = [
+        sys.executable,
+        str(ML_SIDE_DIR / "tools" / "evaluate_navigation_scenarios.py"),
+        "--cases",
+        str(tmp_path / "missing-cases.json"),
+        "--predictions",
+        str(tmp_path / "missing-predictions.json"),
+        "--output",
+        str(tmp_path / "reports"),
+    ]
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert result.returncode == 1
+    assert "Scenario evaluation failed: Case suite file is missing" in result.stderr
+    assert "Traceback" not in result.stderr

--- a/ML_side/tools/evaluate_navigation_scenarios.py
+++ b/ML_side/tools/evaluate_navigation_scenarios.py
@@ -1,0 +1,58 @@
+"""CLI entry point for offline WalkBuddy scenario-regression fixture replay."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ML_SIDE_DIR = Path(__file__).resolve().parents[1]
+if str(ML_SIDE_DIR) not in sys.path:
+    sys.path.insert(0, str(ML_SIDE_DIR))
+
+from scenario_regression.evaluator import ScenarioRegressionError, run_fixture_evaluation
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Replay normalized local detections against WalkBuddy navigation scenarios without a server or model loading."
+    )
+    parser.add_argument("--cases", required=True, help="Versioned scenario-suite JSON file.")
+    parser.add_argument("--predictions", required=True, help="Versioned normalized-prediction fixture JSON file.")
+    parser.add_argument("--output", required=True, help="External directory for scenario_evaluation JSON and Markdown reports.")
+    parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.0,
+        help="Optional detector operating threshold from 0 to 1; it is not a navigation-risk policy.",
+    )
+    parser.add_argument("--overwrite", action="store_true", help="Allow replacement of reports in a non-empty output directory.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = run_fixture_evaluation(
+            case_suite_path=args.cases,
+            prediction_fixture_path=args.predictions,
+            output_path=args.output,
+            confidence_threshold=args.confidence_threshold,
+            overwrite=args.overwrite,
+        )
+    except ScenarioRegressionError as exc:
+        print(f"Scenario evaluation failed: {exc}", file=sys.stderr)
+        return 1
+    aggregate = report["aggregate"]
+    assert isinstance(aggregate, dict)
+    print(
+        "Scenario evaluation complete: "
+        f"{aggregate['scenarios_passed']}/{aggregate['scenario_count']} scenarios passed."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds an offline scenario-level regression evaluation harness for the approved WalkBuddy eight-class navigation taxonomy.

The harness provides deterministic detection-correctness evidence for controlled navigation scenarios without requiring:

- the production backend
- FastAPI
- localhost services
- YOLO/model weights
- GPU
- network access
- proximity policy
- temporal stabilization
- model promotion

It complements the existing aggregate model-evaluation and promotion tooling rather than replacing it.

## Approved taxonomy

The evaluator uses the existing ML-side approved taxonomy:

| ID | Class |
|---|---|
| 0 | person |
| 1 | stairs |
| 2 | door |
| 3 | chair |
| 4 | table |
| 5 | pole |
| 6 | bicycle |
| 7 | vehicle |

No separate conflicting taxonomy is introduced.

## Scenario evaluation

Each scenario can specify:

- required classes
- allowed but non-required classes
- relative image metadata
- description/notes
- explicit unexpected-detection policy

The evaluator uses class-presence semantics.

Repeated detections of the same class do not inflate TP/FP counts.

Allowed classes:

- do not count as TP
- do not count as FP
- cannot satisfy a missing required class

## Metrics

Per scenario:

- TP
- FP
- FN
- precision
- recall
- F1
- missed required classes
- unexpected classes
- pass/fail status

Suite aggregation includes:

- scenario totals
- summed TP/FP/FN
- micro precision
- micro recall
- micro F1
- per-class metrics

Undefined metrics are represented as `null`, never NaN or Infinity.

## Unexpected detection policy

Supports explicit:

- `report_only`
- fail-on-unexpected behavior

Missing required classes always fail the scenario.

The policy affects scenario status only; it does not hide or rewrite FP evidence.

## Fixture replay

Normalized prediction fixtures can be evaluated completely offline.

Suite and fixture scenario IDs must match exactly:

- missing prediction scenarios fail validation
- extra prediction scenarios fail validation

Missing fixture coverage is never silently treated as zero detections.

## Confidence handling

An optional explicit confidence threshold is supported.

It is documented and reported only as a detector operating point.

It is NOT:

- a safety threshold
- a risk threshold
- a proximity threshold
- a distance estimate

Filtering uses inclusive `>= threshold` semantics.

## Input and output safety

The harness:

- rejects unsafe absolute/traversal paths
- rejects malformed and duplicate JSON keys
- validates exact fixture/case structures
- rejects unknown taxonomy classes
- rejects non-finite confidence values
- stores only source filenames and SHA-256 checksums
- avoids absolute machine paths
- writes reports atomically
- refuses unsafe/non-empty output directories unless explicitly overwritten

## Deterministic reports

Produces:

- `scenario_evaluation.json`
- `scenario_evaluation.md`

Identical inputs produce byte-identical substantive reports.

Reports contain no random IDs or runtime timestamps.

## Legacy testing pipeline

The old `ML_side/testing_pipeline` was inspected.

It depends on obsolete localhost port `8001` endpoints such as `/detect` and `/two_brain`.

This work reuses only the useful TP/FP/FN evaluation concept.

No legacy HTTP dependencies or response assumptions were carried forward.

## Scope boundaries

This PR does NOT:

- modify production backend code
- modify frontend code
- add/change routes
- modify datasets
- train a model
- modify model weights
- implement model inference
- implement proximity/distance logic
- wire temporal stabilization
- modify candidate-model promotion gates
- automatically approve/promote a model

Scenario PASS/FAIL represents regression-test evidence only.

## Verification

After adversarial review:

- focused scenario-regression tests: **81 passed**
- full ML suite: **398 passed**
- Python compilation: passed
- package import: passed
- CLI `--help`: passed
- valid fixture replay: passed
- invalid-input CLI handling: passed without traceback
- deterministic report check: passed
- `git diff --check`: passed
- upstream feature-diff check: passed
- working tree: clean

## Commit

`07e5eeb2d59e43a62ed70cd178a5633563dabddb`

`Add navigation scenario regression harness`