### PR TITLE
Fix Predictive Path package import

### DIFF
--- a/software_side/walkbuddy_reactNative/backend/predictive_path/test_predictive_path.py
+++ b/software_side/walkbuddy_reactNative/backend/predictive_path/test_predictive_path.py
@@ -19,8 +19,9 @@ import sys
 import math
 import traceback
  
-# Make sure imports resolve to the project folder
-sys.path.insert(0, os.path.dirname(__file__))
+# Make sure imports resolve to the predictive_path package (backend/), not just this file's directory,
+# so `predictive_path.predictive_path` resolves the same way under pytest and direct execution.
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
  
 PASS = "  [PASS]"
 FAIL = "  [FAIL]"

--- a/software_side/walkbuddy_reactNative/backend/predictive_path/test_predictive_path.py
+++ b/software_side/walkbuddy_reactNative/backend/predictive_path/test_predictive_path.py
@@ -123,7 +123,7 @@ def test_path_predictor() -> int:
     errors = 0
  
     try:
-        from predictive_path import PathPredictor
+        from predictive_path.predictive_path import PathPredictor
         pp = PathPredictor(dt=0.5, steps=5)
         path = pp.predict_path(speed=1.2, heading=90.0, gyro=0.02)
  
@@ -155,7 +155,7 @@ def test_risk_evaluator() -> int:
     errors = 0
  
     try:
-        from predictive_path import PathPredictor, RiskEvaluator
+        from predictive_path.predictive_path import PathPredictor, RiskEvaluator
  
         pp = PathPredictor(dt=0.5, steps=1)
         re = RiskEvaluator()
@@ -190,7 +190,7 @@ def test_alert_logic() -> int:
     errors = 0
  
     try:
-        from predictive_path import PredictivePathSystem
+        from predictive_path.predictive_path import PredictivePathSystem
  
         system = PredictivePathSystem(dt=0.5, steps=5)
  
@@ -232,7 +232,7 @@ def test_alert_logic() -> int:
 def test_full_scenarios() -> int:
     section("TEST 7 — Full Scenario Walkthrough")
  
-    from predictive_path import PredictivePathSystem
+    from predictive_path.predictive_path import PredictivePathSystem
     system = PredictivePathSystem(dt=0.5, steps=5)
  
     scenarios = [


### PR DESCRIPTION
Fixes a pre-existing import mismatch in the legacy Predictive Path tests. PredictivePathSystem, PathPredictor and RiskEvaluator are defined in predictive_path.predictive_path, while the tests attempted to import them from the empty package root.

This updates the tests to use the concrete-module import convention already used by the Predictive Path router and package-import regression tests.

Verification:

Former failing scenario test: 1 passed
Predictive Path test file: 7 passed
Package import regression tests: 4 passed
git diff --check: passed

Full backend pytest could not be completed locally because the existing backend .venv references a removed Python installation and the temporary verifier does not include OpenCV/Ultralytics. No production code, dependencies, ML files, model artifacts or /ml/navigate files were changed.