### PR TITLE
Add ML safety CI

### DIFF
--- a/.github/workflows/ml-safety.yml
+++ b/.github/workflows/ml-safety.yml
@@ -1,0 +1,40 @@
+name: ML safety
+
+on:
+  pull_request:
+    branches:
+      - t2-2026-development
+  push:
+    branches:
+      - t2-2026-development
+
+permissions:
+  contents: read
+
+jobs:
+  ml-safety:
+    name: Fast ML safety contracts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install lightweight test dependencies
+        run: python -m pip install -r ML_side/requirements-ci.txt
+
+      - name: Run model-free ML safety contracts
+        run: >
+          python -m pytest -q
+          ML_side/tests/test_dataset_manifest_validation.py
+          ML_side/tests/test_build_navigation_dataset_release.py
+          ML_side/tests/test_train_navigation_model.py
+          ML_side/tests/test_validate_candidate_model.py
+          ML_side/tests/test_compare_model_evaluations.py
+          ML_side/tests/test_detection_stabilizer.py
+          ML_side/tests/test_navigation_scenario_regression.py
+          software_side/walkbuddy_reactNative/backend/tests/test_navigation_semantics.py

--- a/ML_side/requirements-ci.txt
+++ b/ML_side/requirements-ci.txt
@@ -1,0 +1,3 @@
+# Dependencies for the fast, model-free ML safety workflow only.
+pytest==9.1.1
+PyYAML==6.0.3


### PR DESCRIPTION
## Summary

Adds the first lightweight GitHub Actions gate for fast, model-free ML safety contracts.

## What the workflow runs

- Navigation dataset manifest validation
- Controlled dataset release-builder checks using only temporary fictional fixtures
- Training-pipeline preflight and dry-run checks with mocked training
- Candidate-model validation and promotion-comparison logic with mocked model loading
- Temporal detection stabilization
- Navigation scenario regression fixtures
- Canonical backend navigation-semantics contract checks

The workflow uses Python 3.11 and installs only `pytest==9.1.1` and `PyYAML==6.0.3` from `ML_side/requirements-ci.txt`.

## Safety and scope

The selected suite does not require model weights, real datasets, GPUs, Docker, external APIs, Teams/SharePoint assets, or network access from the tested code. It runs on every pull request targeting `t2-2026-development` and every push to that branch, with no path filter so shared-contract changes cannot bypass it.

## Local verification

```text
379 passed in 12.14s
```

Verified in a fresh Python 3.11 environment containing only the declared CI dependencies. Workflow YAML was parsed locally; GitHub Actions has not run yet.

## Intentionally excluded

- Real-model inference, evaluator, and artifact-inspection tests
- Dataset/image inspection tests that can require local data assets
- Backend ML runtime and inference integration tests that require FastAPI/runtime dependencies
- Rishikaandh's unmerged E2E ML pipeline work
- Anish's unmerged model-registry work

Those can be added in later dedicated CI expansions once their dependencies and merge state are established.