### PR TITLE
Add held-out dataset split evaluation

### DIFF
--- a/ML_side/docs/current_model_baseline.md
+++ b/ML_side/docs/current_model_baseline.md
@@ -46,6 +46,36 @@ that validation result: precision, recall, mAP50, mAP50-95, per-class metrics,
 validation image count, and timing where available. Missing values are written
 as `null` with an explanation; no values are estimated or fabricated.
 
+### Selecting the evaluated split
+
+Labelled evaluation accepts an optional `--split` argument with the values `val`
+and `test`. The training split is deliberately not selectable.
+
+Validation split, which remains the backward-compatible default when `--split`
+is omitted:
+
+```powershell
+& ".\software_side\walkbuddy_reactNative\backend\.venv\Scripts\python.exe" ".\ML_side\tools\evaluate_current_model.py" --model ".\ML_side\models\best.pt" --dataset-yaml ".\path\to\labelled-dataset.yaml" --split val --output ".\ML_side\evaluation_results\labelled-baseline"
+```
+
+Held-out test split, intended for final candidate reporting:
+
+```powershell
+& ".\software_side\walkbuddy_reactNative\backend\.venv\Scripts\python.exe" ".\ML_side\tools\evaluate_current_model.py" --model ".\ML_side\models\best.pt" --dataset-yaml ".\path\to\labelled-dataset.yaml" --split test --output ".\ML_side\evaluation_results\labelled-heldout"
+```
+
+The selected split is recorded in the generated artifacts as `dataset_split`,
+both at the top level of the labelled summary and inside
+`evaluation_settings.validation_ap`, so metrics can always be attributed to the
+split that produced them. The evaluation `mode` remains `labelled_validation`
+for both splits.
+
+Use the validation split for iterative model selection and tuning. Reserve the
+test split for a single final measurement of a chosen candidate: repeatedly
+tuning against the test split erodes its status as held-out evidence and
+inflates the reported result. `--split` applies only to labelled evaluation and
+is rejected when combined with `--images`.
+
 ## Output files
 
 Each run writes these files to the requested output directory:

--- a/ML_side/tests/test_evaluate_current_model.py
+++ b/ML_side/tests/test_evaluate_current_model.py
@@ -93,6 +93,29 @@ def make_image_folder(tmp_path: Path) -> Path:
     return images
 
 
+def make_dataset_yaml(tmp_path: Path) -> Path:
+    dataset_yaml = tmp_path / "dataset.yaml"
+    dataset_yaml.write_text(
+        "path: local-data\ntrain: images\nval: images\ntest: images\n", encoding="utf-8"
+    )
+    return dataset_yaml
+
+
+def run_labelled_evaluation(
+    tmp_path: Path, model: FakeModel, **kwargs: object
+) -> tuple[dict[str, object], Path]:
+    """Evaluate a labelled dataset through the production entry point with a fake model."""
+    output = tmp_path / "results"
+    summary = evaluator.evaluate(
+        model_path=make_model_file(tmp_path),
+        dataset_yaml=make_dataset_yaml(tmp_path),
+        output_path=output,
+        yolo_loader=lambda _: model,
+        **kwargs,
+    )
+    return summary, output
+
+
 def test_discovers_supported_images_and_skips_unsupported_files(tmp_path: Path) -> None:
     images = make_image_folder(tmp_path)
 
@@ -296,3 +319,200 @@ def test_main_reports_a_readable_error(tmp_path: Path, capsys: pytest.CaptureFix
 
     assert result == 1
     assert "Evaluation failed: Model file is missing" in capsys.readouterr().err
+
+
+def test_labelled_evaluation_defaults_to_the_validation_split(tmp_path: Path) -> None:
+    model = FakeModel()
+
+    summary, _ = run_labelled_evaluation(tmp_path, model)
+
+    assert model.validation_arguments is not None
+    assert model.validation_arguments["split"] == "val"
+    assert summary["dataset_split"] == "val"
+    assert summary["evaluation_settings"]["validation_ap"]["dataset_split"] == "val"
+
+
+def test_omitted_split_preserves_existing_validation_settings(tmp_path: Path) -> None:
+    model = FakeModel()
+
+    summary, _ = run_labelled_evaluation(tmp_path, model)
+
+    arguments = model.validation_arguments
+    assert arguments is not None
+    assert arguments["plots"] is False
+    assert arguments["save_json"] is False
+    assert arguments["verbose"] is False
+    assert arguments["exist_ok"] is True
+    assert arguments["name"] == "ultralytics_validation"
+    assert "conf" not in arguments
+    assert "iou" not in arguments
+    assert summary["mode"] == "labelled_validation"
+
+
+@pytest.mark.parametrize("split", ["val", "test"])
+def test_selected_split_is_forwarded_and_recorded(tmp_path: Path, split: str) -> None:
+    model = FakeModel()
+
+    summary, output = run_labelled_evaluation(tmp_path, model, dataset_split=split)
+
+    assert model.validation_arguments is not None
+    assert model.validation_arguments["split"] == split
+    assert summary["dataset_split"] == split
+    assert summary["mode"] == "labelled_validation"
+
+    metrics_artifact = json.loads(
+        (output / "validation_metrics.json").read_text(encoding="utf-8")
+    )
+    assert metrics_artifact["evaluation_settings"]["validation_ap"]["dataset_split"] == split
+    summary_artifact = json.loads((output / "summary.json").read_text(encoding="utf-8"))
+    assert summary_artifact["dataset_split"] == split
+    assert summary_artifact["evaluation_settings"]["validation_ap"]["dataset_split"] == split
+
+
+def test_held_out_split_preserves_labelled_metric_extraction(tmp_path: Path) -> None:
+    model = FakeModel()
+
+    summary, output = run_labelled_evaluation(tmp_path, model, dataset_split="test")
+
+    metrics = json.loads(
+        (output / "validation_metrics.json").read_text(encoding="utf-8")
+    )["validation_metrics"]
+    assert metrics["precision"] == 0.625
+    assert metrics["recall"] == 0.5
+    assert metrics["mAP50"] == 0.575
+    assert metrics["mAP50_95"] == 0.425
+    assert metrics["validation_image_count"] == 3
+    assert summary["metric_semantics"] == evaluator.LABELLED_VALIDATION_METRIC_SEMANTICS
+
+
+@pytest.mark.parametrize("split", ["train", "TEST", "", "validation"])
+def test_unsupported_python_api_split_is_rejected(tmp_path: Path, split: str) -> None:
+    with pytest.raises(evaluator.EvaluationError, match="Dataset split must be one of"):
+        evaluator.evaluate(
+            model_path=make_model_file(tmp_path),
+            dataset_yaml=make_dataset_yaml(tmp_path),
+            dataset_split=split,
+            output_path=tmp_path / "results",
+            yolo_loader=lambda _: pytest.fail("loader must not be called"),
+        )
+
+
+def test_split_is_rejected_for_unlabelled_image_evaluation(tmp_path: Path) -> None:
+    with pytest.raises(evaluator.EvaluationError, match="only to labelled dataset evaluation"):
+        evaluator.evaluate(
+            model_path=make_model_file(tmp_path),
+            images_path=make_image_folder(tmp_path),
+            dataset_split="test",
+            output_path=tmp_path / "results",
+            yolo_loader=lambda _: pytest.fail("loader must not be called"),
+        )
+
+
+def test_unlabelled_evaluation_is_unchanged_and_records_no_split(tmp_path: Path) -> None:
+    model = FakeModel()
+    output = tmp_path / "results"
+
+    summary = evaluator.evaluate(
+        model_path=make_model_file(tmp_path),
+        images_path=make_image_folder(tmp_path),
+        output_path=output,
+        yolo_loader=lambda _: model,
+    )
+
+    assert summary["mode"] == "unlabelled_inference_audit"
+    assert summary["evaluation_settings"]["validation_ap"] is None
+    assert "dataset_split" not in summary
+    assert model.validation_arguments is None
+    predictions = json.loads((output / "predictions.json").read_text(encoding="utf-8"))
+    assert predictions["evaluation_settings"]["validation_ap"] is None
+
+
+@pytest.mark.parametrize("split", ["val", "test"])
+def test_argparse_accepts_supported_splits(split: str) -> None:
+    arguments = evaluator.parse_args(
+        ["--model", "m.pt", "--dataset-yaml", "d.yaml", "--split", split, "--output", "out"]
+    )
+
+    assert arguments.split == split
+
+
+def test_argparse_defaults_split_to_none_for_backward_compatibility() -> None:
+    arguments = evaluator.parse_args(
+        ["--model", "m.pt", "--dataset-yaml", "d.yaml", "--output", "out"]
+    )
+
+    assert arguments.split is None
+
+
+@pytest.mark.parametrize("split", ["train", "TEST", "holdout"])
+def test_argparse_rejects_unsupported_splits(split: str) -> None:
+    with pytest.raises(SystemExit):
+        evaluator.parse_args(
+            ["--model", "m.pt", "--dataset-yaml", "d.yaml", "--split", split, "--output", "out"]
+        )
+
+
+def test_cli_forwards_the_selected_split_without_real_weights(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    model = FakeModel()
+    monkeypatch.setattr(
+        evaluator.model_inspector, "_get_yolo_loader", lambda: (lambda _: model)
+    )
+    output = tmp_path / "results"
+
+    exit_code = evaluator.main(
+        [
+            "--model",
+            str(make_model_file(tmp_path)),
+            "--dataset-yaml",
+            str(make_dataset_yaml(tmp_path)),
+            "--split",
+            "test",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code == 0
+    assert model.validation_arguments is not None
+    assert model.validation_arguments["split"] == "test"
+    summary_artifact = json.loads((output / "summary.json").read_text(encoding="utf-8"))
+    assert summary_artifact["dataset_split"] == "test"
+
+
+def test_cli_rejects_split_with_images_before_loading_a_model(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    exit_code = evaluator.main(
+        [
+            "--model",
+            str(make_model_file(tmp_path)),
+            "--images",
+            str(make_image_folder(tmp_path)),
+            "--split",
+            "test",
+            "--output",
+            str(tmp_path / "results"),
+        ]
+    )
+
+    assert exit_code == 1
+    assert "only to labelled dataset evaluation" in capsys.readouterr().err
+    assert not (tmp_path / "results").exists()
+
+
+@pytest.mark.parametrize("split", ["val", "test"])
+def test_artifacts_do_not_expose_absolute_dataset_paths(tmp_path: Path, split: str) -> None:
+    model = FakeModel()
+
+    _, output = run_labelled_evaluation(tmp_path, model, dataset_split=split)
+
+    dataset_yaml = tmp_path / "dataset.yaml"
+    for artifact in ("summary.json", "validation_metrics.json", "model_metadata.json"):
+        text = (output / artifact).read_text(encoding="utf-8")
+        assert str(dataset_yaml) not in text
+        assert dataset_yaml.as_posix() not in text
+        assert str(tmp_path) not in text
+    summary_artifact = json.loads((output / "summary.json").read_text(encoding="utf-8"))
+    assert summary_artifact["dataset_yaml_filename"] == "dataset.yaml"

--- a/ML_side/tools/evaluate_current_model.py
+++ b/ML_side/tools/evaluate_current_model.py
@@ -24,7 +24,9 @@ DEFAULT_MODEL_PATH = Path(__file__).resolve().parents[1] / "models" / "best.pt"
 SUPPORTED_IMAGE_EXTENSIONS = frozenset({".jpg", ".jpeg", ".png"})
 EVALUATION_SCHEMA_VERSION = "1.0.0"
 TOOL_NAME = "evaluate_current_model"
-TOOL_VERSION = "2.0.0"
+TOOL_VERSION = "2.1.0"
+SUPPORTED_DATASET_SPLITS = ("val", "test")
+DEFAULT_DATASET_SPLIT = "val"
 DEFAULT_OPERATING_CONFIDENCE = 0.25
 DEFAULT_OPERATING_IOU = 0.45
 LABELLED_VALIDATION_METRIC_SEMANTICS = {
@@ -55,6 +57,14 @@ def _finite_float(value: object) -> float:
     if not math.isfinite(numeric):
         raise ValueError("Expected a finite numeric value.")
     return numeric
+
+
+def _validate_dataset_split(split: str) -> str:
+    """Accept only the held-out splits this evaluator is allowed to report on."""
+    if split not in SUPPORTED_DATASET_SPLITS:
+        supported = ", ".join(SUPPORTED_DATASET_SPLITS)
+        raise EvaluationError(f"Dataset split must be one of: {supported}.")
+    return split
 
 
 def _validate_operating_point(confidence: float, iou: float) -> None:
@@ -502,6 +512,7 @@ def evaluate(
     output_path: str | Path,
     images_path: str | Path | None = None,
     dataset_yaml: str | Path | None = None,
+    dataset_split: str | None = None,
     overwrite: bool = False,
     operating_confidence: float = DEFAULT_OPERATING_CONFIDENCE,
     operating_iou: float = DEFAULT_OPERATING_IOU,
@@ -510,6 +521,13 @@ def evaluate(
     """Evaluate a local model in exactly one safe, explicit mode."""
     if (images_path is None) == (dataset_yaml is None):
         raise EvaluationError("Provide exactly one of an image folder or a dataset YAML file.")
+    if dataset_split is not None:
+        _validate_dataset_split(dataset_split)
+        if images_path is not None:
+            raise EvaluationError(
+                "Dataset split selection applies only to labelled dataset evaluation."
+            )
+    selected_split = DEFAULT_DATASET_SPLIT if dataset_split is None else dataset_split
     _validate_operating_point(operating_confidence, operating_iou)
 
     model = validate_model_path(model_path)
@@ -567,6 +585,7 @@ def evaluate(
         try:
             validation_result = yolo_model.val(
                 data=str(dataset),
+                split=selected_split,
                 project=str(output),
                 name="ultralytics_validation",
                 exist_ok=True,
@@ -582,6 +601,7 @@ def evaluate(
             "operating_point_inference": None,
             "validation_ap": {
                 "engine": "ultralytics_model_val",
+                "dataset_split": selected_split,
                 "confidence": "ultralytics_default_sweep",
                 "iou": "ultralytics_default",
                 "plots": False,
@@ -600,6 +620,7 @@ def evaluate(
             ),
             "mode": "labelled_validation",
             "dataset_yaml_filename": dataset.name,
+            "dataset_split": selected_split,
             "validation_metrics": validation_metrics,
         }
         _write_json(output / "model_metadata.json", metadata_payload)
@@ -637,6 +658,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--images", help="Folder of local .jpg, .jpeg, or .png images.")
     mode.add_argument("--dataset-yaml", help="Local labelled YOLO dataset YAML for validation.")
+    parser.add_argument(
+        "--split",
+        choices=SUPPORTED_DATASET_SPLITS,
+        default=None,
+        help=(
+            "Labelled dataset split to evaluate; defaults to "
+            f"{DEFAULT_DATASET_SPLIT!r}. Not valid with --images."
+        ),
+    )
     parser.add_argument("--output", required=True, help="Directory for generated result files.")
     parser.add_argument(
         "--operating-confidence",
@@ -667,6 +697,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             output_path=args.output,
             images_path=args.images,
             dataset_yaml=args.dataset_yaml,
+            dataset_split=args.split,
             overwrite=args.overwrite,
             operating_confidence=args.operating_confidence,
             operating_iou=args.operating_iou,


### PR DESCRIPTION
## Summary

Labelled model evaluation can now explicitly target either the `val` or the `test` split of a local dataset YAML. When `--split` is omitted the evaluator continues to use `val`, so existing callers and existing artifacts are unaffected.

Previously the labelled path called Ultralytics validation without a `split` argument, so evaluation always fell back to the Ultralytics default validation split. There was no way to report metrics on a held-out test split.

## Why

Final navigation-candidate reporting needs the controlled release's held-out test split, not the validation split used for model selection. Validation metrics are influenced by checkpoint selection during training and are not appropriate as the sole evidence for a candidate decision. This change makes the evaluated split an explicit, recorded choice rather than an implicit default.

The training split is deliberately not selectable.

## Changes

- adds an optional `--split` CLI argument restricted to `val` and `test`
- adds a `dataset_split` parameter to the `evaluate()` Python API, validated independently of argparse so direct callers cannot bypass the check
- forwards the selected split explicitly to `yolo_model.val(split=...)`
- records the selected split as `dataset_split` in the labelled summary and in `evaluation_settings.validation_ap`
- rejects `--split` when combined with `--images`, before any model is loaded
- bumps `TOOL_VERSION` to `2.1.0`
- documents both splits and the intended use of the held-out split

Unrelated Ultralytics evaluation settings are unchanged: `plots`, `save_json`, and `verbose` remain `False`, and the operating confidence and IoU are still not injected into AP evaluation.

## Compatibility

- `mode` remains `labelled_validation` for both splits and is not renamed
- `val` remains the default when `--split` is omitted
- `EVALUATION_SCHEMA_VERSION` remains `1.0.0`; the change is additive, not schema-breaking
- `metric_semantics` is unchanged, so `compare_model_evaluations._has_compatible_metric_semantics` continues to accept the artifacts
- existing consumers that ignore the new field remain compatible

`compare_model_evaluations._settings_match` compares `evaluation_settings` by equality. Because the split is recorded there, comparing a `val` baseline against a `test` candidate now resolves to `incompatible_evaluation_settings` and returns `REVIEW` rather than a promotion recommendation. This is the intended safety behaviour and required no change to the comparison tool.

Note for reviewers: for the same reason, an evaluation artifact generated before this change will not compare settings-equal to one generated after it. No canonical eight-class baseline artifact exists yet, so there is no practical impact today.

## Tests

- focused evaluator tests: 32 passed
- full ML suite with `PYTHONPATH=ML_side`: 419 passed
- `git diff --check`: PASS

Coverage added for: default `val` behaviour, exact forwarding of the selected split, artifact recording in both the summary and `validation_metrics.json`, rejection of unsupported splits through both the Python API and argparse, rejection of `--split` with `--images`, unchanged unlabelled behaviour, unchanged labelled metric extraction, and absence of absolute dataset paths in generated artifacts.

All tests use fixtures and a fake model. No real model weights and no controlled release are required.

## Scope

- no model training
- no dataset changes
- no model-weight changes
- no production backend changes
- no frontend changes
- no taxonomy changes
- no promotion-threshold or promotion-policy changes
- no promotion decision
- no generated reports committed

This change only makes the evaluated split explicit and recorded. It makes no claim about model quality or safety.
