### PR TITLE
Report navigation model taxonomy compatibility

### DIFF
--- a/.github/workflows/ml-safety.yml
+++ b/.github/workflows/ml-safety.yml
@@ -38,3 +38,4 @@ jobs:
           ML_side/tests/test_detection_stabilizer.py
           ML_side/tests/test_navigation_scenario_regression.py
           software_side/walkbuddy_reactNative/backend/tests/test_navigation_semantics.py
+          software_side/walkbuddy_reactNative/backend/tests/test_model_taxonomy_compatibility.py

--- a/software_side/walkbuddy_reactNative/backend/docs/ml_inference.md
+++ b/software_side/walkbuddy_reactNative/backend/docs/ml_inference.md
@@ -125,6 +125,34 @@ reports whatever `app.state.yolo.names` contains. Mock mode reports the approved
 contract taxonomy. Reconciling the weights vs. config vs. contract lineage is
 separate follow-up work. See `ML_side/docs/current_model_baseline.md`.
 
+### `taxonomy_compatible` in `GET /ml/model-info`
+
+`ml_runtime` records whether the loaded artifact implements the approved
+navigation taxonomy and exposes the result as `taxonomy_compatible`. The
+expected ordered names are derived from `ml_contract.navigation_semantics`, so
+there is no second taxonomy definition.
+
+- `true` — the loaded model's `names` exactly match the approved ordered
+  eight-class taxonomy in class count, identifier order, and canonical spelling.
+- `false` — the model loaded and its `names` are structurally valid, but the
+  taxonomy differs. A reordered, renamed, extended, reduced, or case-changed
+  taxonomy is incompatible. The legacy `office-chair` alias remains valid when
+  interpreting individual detections, but does not satisfy the production model
+  contract.
+- `null` — compatibility could not be determined, because the model failed to
+  load, its metadata was unavailable, or the runtime is not yet initialised.
+
+`false` and `null` are deliberately distinct: a taxonomy mismatch is not a
+deserialisation failure, and is reported with `loaded: true` and no
+`failure_category`.
+
+**This field is currently observational.** A `false` value does **not** alter
+`GET /ml/ready`, `GET /ml/health`, `POST /ml/navigate`, or the container health
+check in this change. The active `best.pt` is the inherited historical model, so
+enforcing the contract before the approved eight-class model is trained and
+promoted would deliberately make the development backend unhealthy. Enforcement
+is intentionally deferred to a separate change once that model exists.
+
 ## Tests
 
 - `tests/test_ml_inference.py` — router-isolated tests: mounts only this router

--- a/software_side/walkbuddy_reactNative/backend/ml_runtime/model_info.py
+++ b/software_side/walkbuddy_reactNative/backend/ml_runtime/model_info.py
@@ -10,8 +10,15 @@ from importlib.metadata import version
 from pathlib import Path
 from typing import Any
 
+from ml_contract import NAVIGATION_CLASSES
+
 
 CHECKSUM_CHUNK_SIZE = 1024 * 1024
+# Derived from the single canonical contract so this module never becomes a
+# second, independently maintained taxonomy.
+APPROVED_TAXONOMY: tuple[str, ...] = tuple(
+    navigation_class.name for navigation_class in NAVIGATION_CLASSES
+)
 
 
 class ModelMetadataError(ValueError):
@@ -32,6 +39,7 @@ class ModelLineage:
     loaded_at: str
     runtime: dict[str, Any]
     failure_category: str | None = None
+    taxonomy_compatible: bool | None = None
 
     def as_dict(self) -> dict[str, Any]:
         """Return a copy suitable for the operational model-info endpoint."""
@@ -42,6 +50,7 @@ class ModelLineage:
             "size_bytes": self.size_bytes,
             "num_classes": self.num_classes,
             "classes": list(self.classes),
+            "taxonomy_compatible": self.taxonomy_compatible,
             "load_duration_ms": self.load_duration_ms,
             "loaded_at": self.loaded_at,
             "runtime": dict(self.runtime),
@@ -85,6 +94,17 @@ def normalise_class_names(names: object) -> list[str]:
     if not class_names:
         raise ModelMetadataError("model.names is missing or malformed")
     return [class_names[class_id] for class_id in sorted(class_names)]
+
+
+def is_taxonomy_compatible(class_names: Sequence[str]) -> bool:
+    """Report whether ordered class names exactly match the approved taxonomy.
+
+    Matching is deliberately exact in count, identifier order, and canonical
+    spelling. Legacy aliases such as ``office-chair`` remain valid when
+    interpreting individual detections, but must never allow a differently
+    trained artifact to satisfy the production model contract.
+    """
+    return tuple(class_names) == APPROVED_TAXONOMY
 
 
 def runtime_details() -> dict[str, Any]:
@@ -148,6 +168,7 @@ def capture_model_lineage(
         load_duration_ms=round(float(load_duration_ms), 3),
         loaded_at=datetime.now(timezone.utc).isoformat(),
         runtime=runtime_details(),
+        taxonomy_compatible=is_taxonomy_compatible(class_names),
     )
 
 

--- a/software_side/walkbuddy_reactNative/backend/ml_runtime/state.py
+++ b/software_side/walkbuddy_reactNative/backend/ml_runtime/state.py
@@ -54,6 +54,7 @@ class MLRuntimeState:
                     "size_bytes": None,
                     "num_classes": None,
                     "classes": [],
+                    "taxonomy_compatible": None,
                     "load_duration_ms": None,
                     "loaded_at": None,
                     "runtime": {},

--- a/software_side/walkbuddy_reactNative/backend/tests/test_ml_runtime.py
+++ b/software_side/walkbuddy_reactNative/backend/tests/test_ml_runtime.py
@@ -24,10 +24,12 @@ if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
 from ml_runtime.metrics import InferenceMetrics
+from ml_contract import NAVIGATION_CLASSES
 from ml_runtime.model_info import (
     ModelMetadataError,
     calculate_sha256,
     capture_model_lineage,
+    is_taxonomy_compatible,
     normalise_class_names,
     runtime_details,
 )
@@ -45,6 +47,17 @@ class FakeModel:
         5: "table",
         6: "tv",
     }
+
+
+def canonical_class_names() -> list[str]:
+    """Derive the approved ordered names from the single canonical contract."""
+    return [navigation_class.name for navigation_class in NAVIGATION_CLASSES]
+
+
+class CanonicalTaxonomyModel:
+    """A model whose names exactly match the approved navigation taxonomy."""
+
+    names = {index: name for index, name in enumerate(canonical_class_names())}
 
 
 def _app_with_runtime(*, yolo: object | None, ocr_reader: object | None) -> FastAPI:
@@ -772,3 +785,128 @@ def test_successful_websocket_detection_result_shape_is_preserved(
         "inference_time_ms", "server_timestamp_ms",
     }
     assert app.state.ml_runtime.metrics.snapshot()["successful_inferences"] == 1
+
+
+def test_model_info_before_startup_reports_unknown_taxonomy_compatibility() -> None:
+    runtime = MLRuntimeState()
+
+    model_info = runtime.model_info()
+
+    assert model_info["loaded"] is False
+    assert model_info["failure_category"] == "not_initialized"
+    assert model_info["taxonomy_compatible"] is None
+
+
+def test_model_info_endpoint_serialises_compatible_taxonomy(tmp_path: Path) -> None:
+    artifact = tmp_path / "best.pt"
+    artifact.write_bytes(b"model")
+    app = _app_with_runtime(yolo=object(), ocr_reader=None)
+    app.state.ml_runtime.set_model_lineage(
+        capture_model_lineage(artifact, CanonicalTaxonomyModel(), 3.5)
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/ml/model-info")
+
+    payload = response.json()
+    assert response.status_code == 200
+    assert payload["taxonomy_compatible"] is True
+    assert payload["num_classes"] == len(NAVIGATION_CLASSES)
+    assert payload["classes"] == canonical_class_names()
+    assert payload["loaded"] is True
+    assert payload["failure_category"] is None
+
+
+def test_model_info_endpoint_serialises_incompatible_taxonomy(tmp_path: Path) -> None:
+    artifact = tmp_path / "best.pt"
+    artifact.write_bytes(b"model")
+    app = _app_with_runtime(yolo=object(), ocr_reader=None)
+    app.state.ml_runtime.set_model_lineage(
+        capture_model_lineage(artifact, FakeModel(), 3.5)
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/ml/model-info")
+
+    payload = response.json()
+    assert response.status_code == 200
+    assert payload["taxonomy_compatible"] is False
+    # A taxonomy mismatch must never be reported as a load or metadata failure.
+    assert payload["loaded"] is True
+    assert payload["failure_category"] is None
+    assert payload["num_classes"] == 7
+
+
+def test_model_info_endpoint_preserves_existing_lineage_fields(tmp_path: Path) -> None:
+    artifact = tmp_path / "best.pt"
+    artifact.write_bytes(b"model")
+    app = _app_with_runtime(yolo=object(), ocr_reader=None)
+    app.state.ml_runtime.set_model_lineage(
+        capture_model_lineage(artifact, FakeModel(), 3.5)
+    )
+
+    with TestClient(app) as client:
+        payload = client.get("/ml/model-info").json()
+
+    assert set(payload) == {
+        "loaded",
+        "filename",
+        "sha256",
+        "size_bytes",
+        "num_classes",
+        "classes",
+        "taxonomy_compatible",
+        "load_duration_ms",
+        "loaded_at",
+        "runtime",
+        "failure_category",
+    }
+    assert payload["filename"] == "best.pt"
+    assert payload["sha256"] == calculate_sha256(artifact)
+    assert payload["size_bytes"] == artifact.stat().st_size
+    assert payload["load_duration_ms"] == 3.5
+    assert str(tmp_path) not in json.dumps(payload)
+
+
+def test_incompatible_taxonomy_does_not_change_readiness(tmp_path: Path) -> None:
+    """Scope guard: this PR reports compatibility and must not enforce it."""
+    artifact = tmp_path / "best.pt"
+    artifact.write_bytes(b"model")
+    app = _app_with_runtime(yolo=object(), ocr_reader=object())
+    app.state.ml_runtime.set_model_lineage(
+        capture_model_lineage(artifact, FakeModel(), 3.5)
+    )
+
+    with TestClient(app) as client:
+        ready = client.get("/ml/ready")
+        health = client.get("/ml/health")
+        model_info = client.get("/ml/model-info").json()
+
+    assert model_info["taxonomy_compatible"] is False
+    assert ready.status_code == 200
+    assert ready.json() == {"ready": True}
+    assert health.status_code == 200
+    assert health.json()["status"] == "ok"
+    assert app.state.yolo is not None
+
+
+def test_readiness_still_depends_only_on_the_loaded_model(tmp_path: Path) -> None:
+    artifact = tmp_path / "best.pt"
+    artifact.write_bytes(b"model")
+    app = _app_with_runtime(yolo=None, ocr_reader=None)
+    app.state.ml_runtime.set_model_lineage(
+        capture_model_lineage(artifact, CanonicalTaxonomyModel(), 3.5)
+    )
+
+    with TestClient(app) as client:
+        ready = client.get("/ml/ready")
+        model_info = client.get("/ml/model-info").json()
+
+    assert model_info["taxonomy_compatible"] is True
+    assert ready.status_code == 503
+    assert ready.json() == {"ready": False}
+
+
+def test_taxonomy_compatibility_helper_matches_the_canonical_contract() -> None:
+    assert is_taxonomy_compatible(canonical_class_names()) is True
+    assert is_taxonomy_compatible(list(FakeModel.names.values())) is False

--- a/software_side/walkbuddy_reactNative/backend/tests/test_model_taxonomy_compatibility.py
+++ b/software_side/walkbuddy_reactNative/backend/tests/test_model_taxonomy_compatibility.py
@@ -1,0 +1,217 @@
+"""Model-free tests for navigation-taxonomy compatibility reporting.
+
+This module deliberately avoids importing the ``ml_runtime`` package, whose
+``__init__`` pulls in the FastAPI router. Loading ``model_info`` directly keeps
+these contract tests runnable in the lightweight ML safety workflow without
+FastAPI, PyTorch, Ultralytics, model weights, or network access.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from ml_contract import NAVIGATION_CLASSES
+
+
+def _load_model_info() -> ModuleType:
+    path = BACKEND_DIR / "ml_runtime" / "model_info.py"
+    spec = importlib.util.spec_from_file_location("walkbuddy_model_info", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Registered before execution so the frozen dataclass can resolve its own
+    # postponed annotations.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+model_info = _load_model_info()
+
+HISTORICAL_CLASS_NAMES = [
+    "book",
+    "books",
+    "monitor",
+    "office-chair",
+    "whiteboard",
+    "table",
+    "tv",
+]
+
+
+def canonical_class_names() -> list[str]:
+    """Derive the approved ordered names from the single canonical contract."""
+    return [navigation_class.name for navigation_class in NAVIGATION_CLASSES]
+
+
+def write_artifact(tmp_path: Path) -> Path:
+    artifact = tmp_path / "best.pt"
+    artifact.write_bytes(b"walkbuddy-model")
+    return artifact
+
+
+class NamedModel:
+    def __init__(self, names: object) -> None:
+        self.names = names
+
+
+def test_approved_taxonomy_is_derived_from_the_navigation_contract() -> None:
+    assert model_info.APPROVED_TAXONOMY == tuple(canonical_class_names())
+    assert list(model_info.APPROVED_TAXONOMY) == [
+        "person",
+        "stairs",
+        "door",
+        "chair",
+        "table",
+        "pole",
+        "bicycle",
+        "vehicle",
+    ]
+
+
+def test_exact_canonical_taxonomy_is_compatible() -> None:
+    assert model_info.is_taxonomy_compatible(canonical_class_names()) is True
+
+
+def test_historical_seven_class_taxonomy_is_incompatible() -> None:
+    assert model_info.is_taxonomy_compatible(HISTORICAL_CLASS_NAMES) is False
+
+
+def test_reordered_canonical_taxonomy_is_incompatible() -> None:
+    reordered = canonical_class_names()
+    reordered[0], reordered[1] = reordered[1], reordered[0]
+
+    assert model_info.is_taxonomy_compatible(reordered) is False
+
+
+def test_legacy_alias_does_not_satisfy_the_production_contract() -> None:
+    aliased = canonical_class_names()
+    aliased[aliased.index("chair")] = "office-chair"
+
+    assert model_info.is_taxonomy_compatible(aliased) is False
+
+
+def test_additional_class_is_incompatible() -> None:
+    extended = canonical_class_names() + ["kerb"]
+
+    assert model_info.is_taxonomy_compatible(extended) is False
+
+
+def test_missing_class_is_incompatible() -> None:
+    reduced = canonical_class_names()
+    reduced.remove("pole")
+
+    assert model_info.is_taxonomy_compatible(reduced) is False
+
+
+@pytest.mark.parametrize("replacement", ["Person", "PERSON", "person "])
+def test_case_and_spacing_variants_are_incompatible(replacement: str) -> None:
+    variant = canonical_class_names()
+    variant[0] = replacement
+
+    assert model_info.is_taxonomy_compatible(variant) is False
+
+
+def test_empty_class_names_are_incompatible() -> None:
+    assert model_info.is_taxonomy_compatible([]) is False
+
+
+def test_mapping_model_names_produce_a_compatible_lineage(tmp_path: Path) -> None:
+    names = {index: name for index, name in enumerate(canonical_class_names())}
+
+    lineage = model_info.capture_model_lineage(
+        write_artifact(tmp_path), NamedModel(names), 12.5
+    )
+
+    assert lineage.loaded is True
+    assert lineage.taxonomy_compatible is True
+    assert lineage.num_classes == len(NAVIGATION_CLASSES)
+    assert lineage.classes == canonical_class_names()
+    assert lineage.as_dict()["taxonomy_compatible"] is True
+
+
+def test_sequence_model_names_produce_a_compatible_lineage(tmp_path: Path) -> None:
+    lineage = model_info.capture_model_lineage(
+        write_artifact(tmp_path), NamedModel(canonical_class_names()), 12.5
+    )
+
+    assert lineage.taxonomy_compatible is True
+    assert lineage.classes == canonical_class_names()
+
+
+def test_loaded_model_with_historical_taxonomy_is_reported_incompatible(
+    tmp_path: Path,
+) -> None:
+    names = {index: name for index, name in enumerate(HISTORICAL_CLASS_NAMES)}
+
+    lineage = model_info.capture_model_lineage(
+        write_artifact(tmp_path), NamedModel(names), 12.5
+    )
+
+    payload = lineage.as_dict()
+    assert payload["loaded"] is True
+    assert payload["taxonomy_compatible"] is False
+    assert payload["failure_category"] is None
+    assert payload["num_classes"] == len(HISTORICAL_CLASS_NAMES)
+
+
+@pytest.mark.parametrize("names", [None, "person", 7, {}, [], {0: ""}, {-1: "person"}])
+def test_malformed_model_names_still_raise_metadata_error(
+    tmp_path: Path, names: object
+) -> None:
+    with pytest.raises(model_info.ModelMetadataError):
+        model_info.capture_model_lineage(
+            write_artifact(tmp_path), NamedModel(names), 12.5
+        )
+
+
+def test_failed_model_lineage_reports_unknown_compatibility() -> None:
+    lineage = model_info.unavailable_model_lineage(
+        Path("best.pt"), 5.0, "model_artifact_missing"
+    )
+
+    payload = lineage.as_dict()
+    assert payload["loaded"] is False
+    assert payload["taxonomy_compatible"] is None
+    assert payload["failure_category"] == "model_artifact_missing"
+
+
+def test_metadata_unavailable_lineage_reports_unknown_compatibility() -> None:
+    lineage = model_info.metadata_unavailable_model_lineage(Path("best.pt"), 5.0)
+
+    payload = lineage.as_dict()
+    assert payload["loaded"] is True
+    assert payload["taxonomy_compatible"] is None
+    assert payload["failure_category"] == "model_metadata_unavailable"
+
+
+def test_lineage_payload_preserves_existing_fields(tmp_path: Path) -> None:
+    lineage = model_info.capture_model_lineage(
+        write_artifact(tmp_path), NamedModel(canonical_class_names()), 12.5
+    )
+
+    payload = lineage.as_dict()
+    assert set(payload) == {
+        "loaded",
+        "filename",
+        "sha256",
+        "size_bytes",
+        "num_classes",
+        "classes",
+        "taxonomy_compatible",
+        "load_duration_ms",
+        "loaded_at",
+        "runtime",
+        "failure_category",
+    }
+    assert payload["filename"] == "best.pt"
+    assert str(tmp_path) not in repr(payload)


### PR DESCRIPTION
## Summary

`GET /ml/model-info` now reports `taxonomy_compatible`, an explicit signal for whether the loaded YOLO artifact implements the approved WalkBuddy navigation taxonomy.

The expected ordered class names are derived from `ml_contract.navigation_semantics.NAVIGATION_CLASSES`, so this change introduces no second taxonomy definition.

## Why

Model loadability alone does not prove that the active artifact implements the approved navigation contract. The runtime already captured `num_classes` and `classes`, but nothing compared them to the approved taxonomy, so an artifact with an entirely different class set loaded and reported as ready with no visible signal.

The currently active `best.pt` is the inherited historical seven-class model. Making that mismatch explicit and testable now is a prerequisite for enforcing the contract later, once the approved eight-class model has been trained, validated, and promoted.

## Behaviour

`taxonomy_compatible` is three-valued, and `false` and `null` are deliberately distinct:

- **`true`** — the loaded model's `names` exactly match the approved ordered eight-class taxonomy: identical class count, identifier order, and canonical spelling.
- **`false`** — the model loaded and its `names` are structurally valid, but the taxonomy differs. Reordered, renamed, extended, reduced, and case-changed taxonomies are all incompatible. The legacy `office-chair` alias stays valid for interpreting individual detections but does not satisfy the production model contract.
- **`null`** — compatibility could not be determined: the model failed to load, its metadata was unavailable, or the runtime is not yet initialised.

A taxonomy mismatch is reported with `loaded: true` and `failure_category: null`. It is never described as a deserialisation or metadata failure.

## Safety

**This PR does not change readiness or inference behaviour.**

- `GET /ml/ready` status codes are unchanged and still depend only on `app.state.yolo`
- `GET /ml/health` status logic is unchanged
- `POST /ml/navigate` is unchanged
- the container health check (`Dockerfile` → `/ml/ready`) is unaffected
- `app.state.yolo` is never set to `None` for a taxonomy mismatch
- model loading, SHA-256 behaviour, and existing lineage fields are unchanged
- `main.py` and `ml_runtime/router.py` are not modified

A regression test constructs a loaded model with `taxonomy_compatible: false` and asserts `/ml/ready` still returns `200` and `/ml/health` still returns `ok`. This exists specifically to protect the scope boundary and prevent this change from silently becoming the enforcement change.

Enforcement is intentionally deferred to a separate PR after the approved eight-class model exists. Enforcing it now would deliberately make the development backend unhealthy.

## Tests

- new model-free taxonomy compatibility tests: 24 passed
- `tests/test_ml_runtime.py`: 42 passed, 2 errors (both pre-existing; the same 2 occur unchanged on the base commit and are environment-only, caused by heavy optional backend imports being unavailable)
- collectible backend test suite: 138 passed, same 2 pre-existing errors (107 passed on the base commit)
- `tests/test_navigation_semantics.py`: 49 passed
- ML safety workflow command as configured, including the new module: 403 passed
- `git diff --check`: PASS
- changed Python files compile cleanly

`tests/test_ml_inference.py` and `tests/test_ml_inference_integration.py` could not be collected locally because they require `cv2` and `ultralytics`. That is a local environment limitation, not a change in behaviour, and it is identical on the base commit. This PR does not modify the inference router.

## CI

The new `tests/test_model_taxonomy_compatibility.py` is added to the existing ML safety workflow. It deliberately loads `ml_runtime/model_info.py` by file path rather than importing the `ml_runtime` package, whose `__init__` pulls in the FastAPI router. The module therefore needs only the workflow's existing `pytest` and `PyYAML` dependencies — no FastAPI, PyTorch, Ultralytics, model weights, network access, or external services. This was verified by running the exact workflow command in an interpreter with only those dependencies installed.

The FastAPI-dependent endpoint tests remain in `tests/test_ml_runtime.py` and are not added to that workflow.

## Scope

- no model training
- no dataset changes
- no model-weight changes
- no promotion
- no readiness enforcement
- no inference-policy changes
- no frontend changes
- no taxonomy changes

This change adds observability only. It makes no claim about model quality or safety.
