### PR TITLE
Harden external dataset training isolation

### DIFF
--- a/ML_side/tests/test_train_navigation_model.py
+++ b/ML_side/tests/test_train_navigation_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -82,6 +83,23 @@ def write_external_manifest(tmp_path: Path, manifest: dict[str, object]) -> Path
     manifest_path = external_root / "release_manifest.json"
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     return manifest_path
+
+
+def write_workspace_evidence(manifest_path: Path, workspace: Path, identity: str) -> Path:
+    """Emit authoritative checksum evidence describing a workspace's released bytes."""
+    import hashlib as _hashlib
+
+    files = {
+        path.relative_to(workspace).as_posix(): _hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(workspace.rglob("*"))
+        if path.is_file()
+    }
+    evidence = manifest_path.parent / training.CHECKSUM_EVIDENCE_FILENAME
+    evidence.write_text(
+        json.dumps({"algorithm": "sha256", "release_identity": identity, "files": files}),
+        encoding="utf-8",
+    )
+    return evidence
 
 
 def test_valid_dry_run_succeeds_without_trainer_or_artifacts(tmp_path: Path) -> None:
@@ -609,9 +627,11 @@ def test_shipped_smoke_configuration_passes_its_own_preflight(tmp_path: Path) ->
     weights = repository / str(shipped["model"]["initial_weights_path"])
     weights.parent.mkdir(parents=True, exist_ok=True)
     weights.write_bytes(b"local placeholder; preflight never loads model weights")
-    external_manifest = write_external_manifest(
-        tmp_path, json.loads((repository / "manifest.json").read_text(encoding="utf-8"))
-    )
+    identity = "b" * 64
+    manifest = json.loads((repository / "manifest.json").read_text(encoding="utf-8"))
+    manifest["quality"]["checksums"] = {"release_identity": f"sha256:{identity}"}
+    external_manifest = write_external_manifest(tmp_path, manifest)
+    write_workspace_evidence(external_manifest, dataset_root, identity)
 
     plan = training.load_training_plan(
         SHIPPED_SMOKE_CONFIG,
@@ -638,25 +658,55 @@ def materialise_samples(manifest: dict[str, object], root: Path) -> None:
                     target.write_text("fixture", encoding="utf-8")
 
 
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def write_release_checksums(release_root: Path, identity: str) -> Path:
+    """Emit checksum evidence exactly as the release builder does.
+
+    The builder computes checksums before writing this file, so the evidence
+    deliberately does not checksum itself.
+    """
+    files = {
+        path.relative_to(release_root).as_posix(): sha256_file(path)
+        for path in sorted(release_root.rglob("*"))
+        if path.is_file() and path.name != training.CHECKSUM_EVIDENCE_FILENAME
+    }
+    evidence = release_root / training.CHECKSUM_EVIDENCE_FILENAME
+    evidence.write_text(
+        json.dumps({"algorithm": "sha256", "release_identity": identity, "files": files}),
+        encoding="utf-8",
+    )
+    return evidence
+
+
 def create_released_fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
     """Build an authoritative release plus a separate faithful training workspace.
 
-    The release hosts its own manifest, matching the approved controlled-release
-    layout. The workspace holds the same dataset bytes and no manifest.
+    The release hosts its own manifest and checksum evidence, matching the
+    approved controlled-release layout. The workspace holds the same dataset
+    bytes, including the manifest copy the checksum evidence covers.
     """
     repository = tmp_path / "repository"
     release_root = tmp_path / "release"
     workspace = tmp_path / "workspace"
     for directory in (repository, release_root, workspace):
         directory.mkdir()
+    identity = "a" * 64
     manifest = json.loads(SAMPLE_MANIFEST.read_text(encoding="utf-8"))
     manifest["dataset"]["release_decision"] = "approved_for_training"
     manifest["licence"]["review_decision"] = "approved"
+    manifest["quality"]["checksums"] = {"release_identity": f"sha256:{identity}"}
+    manifest_text = json.dumps(manifest)
     for root in (release_root, workspace):
         materialise_samples(manifest, root)
         write_yaml(root / "dataset.yaml")
+        (root / "release_manifest.json").write_text(manifest_text, encoding="utf-8")
     release_manifest = release_root / "release_manifest.json"
-    release_manifest.write_text(json.dumps(manifest), encoding="utf-8")
+    write_release_checksums(release_root, identity)
     (repository / "architecture.yaml").write_text("nc: 8\n", encoding="utf-8")
     config = {
         "schema_version": "1.0.0",
@@ -988,3 +1038,287 @@ def test_successful_run_metadata_contains_no_absolute_paths(tmp_path: Path) -> N
         assert plan.dataset_root.as_posix() not in document
         assert str(plan.manifest_path) not in document
         assert plan.manifest_path.as_posix() not in document
+
+
+# ------------------------------------------------- workspace integrity
+
+
+def corrupt_file(path: Path) -> None:
+    """Change one file's bytes while keeping it structurally parseable.
+
+    A structurally valid mutation proves the checksum gate rejects the file
+    rather than an earlier syntax check firing first.
+    """
+    path.write_bytes(path.read_bytes() + b"\n# tampered\n")
+
+
+def load_evidence(release_root: Path) -> dict[str, object]:
+    return json.loads((release_root / training.CHECKSUM_EVIDENCE_FILENAME).read_text(encoding="utf-8"))
+
+
+def save_evidence(release_root: Path, payload: object) -> None:
+    (release_root / training.CHECKSUM_EVIDENCE_FILENAME).write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def load_released_plan(
+    repository: Path, workspace: Path, release_manifest: Path, config_path: Path
+) -> training.TrainingPlan:
+    return training.load_training_plan(
+        config_path,
+        dataset_root_override=workspace,
+        manifest_path_override=release_manifest,
+        repository_root=repository,
+    )
+
+
+def test_faithful_workspace_passes_checksum_verification(tmp_path: Path) -> None:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+
+    plan = load_released_plan(repository, workspace, release_manifest, config_path)
+
+    assert training.dry_run(plan)["status"] == "dry_run_valid"
+    assert plan.release_checksums_reference == training.EXTERNAL_CHECKSUM_REFERENCE
+    assert plan.release_checksums_checksum is not None
+    assert len(plan.release_checksums_checksum) == 64
+
+
+@pytest.mark.parametrize(
+    "relative",
+    ["dataset.yaml", "release_manifest.json", "train/images/person_001.jpg", "train/labels/person_001.txt"],
+)
+def test_modified_workspace_file_fails_verification(tmp_path: Path, relative: str) -> None:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    corrupt_file(workspace / relative)
+
+    with pytest.raises(training.TrainingPipelineError, match="does not match the approved release checksum"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+def test_missing_checksummed_workspace_file_fails_verification(tmp_path: Path) -> None:
+    """Delete a file only the checksum gate covers, so this proves that gate."""
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    (workspace / "release_manifest.json").unlink()
+
+    with pytest.raises(training.TrainingPipelineError, match="missing a released file"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+def test_missing_checksum_evidence_is_rejected(tmp_path: Path) -> None:
+    repository, release_root, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    (release_root / training.CHECKSUM_EVIDENCE_FILENAME).unlink()
+
+    with pytest.raises(training.TrainingPipelineError, match="require release_checksums.json"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+def test_malformed_checksum_evidence_is_rejected(tmp_path: Path) -> None:
+    repository, release_root, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    (release_root / training.CHECKSUM_EVIDENCE_FILENAME).write_text("not json", encoding="utf-8")
+
+    with pytest.raises(training.TrainingPipelineError, match="not valid JSON"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+def test_non_object_checksum_evidence_is_rejected(tmp_path: Path) -> None:
+    repository, release_root, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    save_evidence(release_root, ["not", "an", "object"])
+
+    with pytest.raises(training.TrainingPipelineError, match="root must be an object"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+def test_unsupported_checksum_algorithm_is_rejected(tmp_path: Path) -> None:
+    repository, release_root, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    evidence = load_evidence(release_root)
+    evidence["algorithm"] = "md5"
+    save_evidence(release_root, evidence)
+
+    with pytest.raises(training.TrainingPipelineError, match="sha256 algorithm"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+@pytest.mark.parametrize("digest", ["", "abc", "z" * 64, "A" * 63, 12345, None])
+def test_invalid_checksum_digest_is_rejected(tmp_path: Path, digest: object) -> None:
+    repository, release_root, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    evidence = load_evidence(release_root)
+    evidence["files"]["dataset.yaml"] = digest  # type: ignore[index]
+    save_evidence(release_root, evidence)
+
+    with pytest.raises(training.TrainingPipelineError, match="invalid SHA-256 digest"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+@pytest.mark.parametrize("unsafe", ["../escape.txt", "C:/absolute/escape.txt", "/absolute/escape.txt", "\\\\server\\share\\x.txt", "https://example.invalid/x.png"])
+def test_unsafe_checksum_paths_are_rejected(tmp_path: Path, unsafe: str) -> None:
+    repository, release_root, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    evidence = load_evidence(release_root)
+    evidence["files"][unsafe] = "c" * 64  # type: ignore[index]
+    save_evidence(release_root, evidence)
+
+    with pytest.raises(training.TrainingPipelineError, match="release checksum path"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+def test_empty_checksum_file_list_is_rejected(tmp_path: Path) -> None:
+    repository, release_root, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    evidence = load_evidence(release_root)
+    evidence["files"] = {}
+    save_evidence(release_root, evidence)
+
+    with pytest.raises(training.TrainingPipelineError, match="at least one checksummed file"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+@pytest.mark.parametrize("identity", ["d" * 64, "not-a-digest", ""])
+def test_release_identity_mismatch_is_rejected(tmp_path: Path, identity: str) -> None:
+    repository, release_root, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    evidence = load_evidence(release_root)
+    evidence["release_identity"] = identity
+    save_evidence(release_root, evidence)
+
+    with pytest.raises(training.TrainingPipelineError):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+def test_manifest_without_recorded_identity_is_rejected(tmp_path: Path) -> None:
+    repository, release_root, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    manifest = json.loads(release_manifest.read_text(encoding="utf-8"))
+    manifest["quality"].pop("checksums")
+    text = json.dumps(manifest)
+    release_manifest.write_text(text, encoding="utf-8")
+    (workspace / "release_manifest.json").write_text(text, encoding="utf-8")
+    write_release_checksums(release_root, "a" * 64)
+
+    with pytest.raises(training.TrainingPipelineError, match="release identity to cross-check"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+# ------------------------------------------------------- extra-file policy
+
+
+@pytest.mark.parametrize(
+    "relative", ["train/images/unlisted.png", "train/images/unlisted.jpg", "train/labels/unlisted.txt"]
+)
+def test_unexpected_training_files_are_rejected(tmp_path: Path, relative: str) -> None:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    (workspace / relative).write_text("smuggled", encoding="utf-8")
+
+    with pytest.raises(training.TrainingPipelineError, match="approved release does not include"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+@pytest.mark.parametrize("relative", ["train/labels.cache", "train/images/train.cache", "train/labels/val.cache"])
+def test_ultralytics_cache_files_are_allowed(tmp_path: Path, relative: str) -> None:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    (workspace / relative).write_text("simulated cache", encoding="utf-8")
+
+    plan = load_released_plan(repository, workspace, release_manifest, config_path)
+
+    assert training.dry_run(plan)["status"] == "dry_run_valid"
+
+
+def test_unrelated_non_training_files_are_tolerated(tmp_path: Path) -> None:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    (workspace / "train" / "images" / "notes.md").write_text("operator note", encoding="utf-8")
+
+    plan = load_released_plan(repository, workspace, release_manifest, config_path)
+
+    assert training.dry_run(plan)["status"] == "dry_run_valid"
+
+
+# --------------------------------------------- release immutability / gating
+
+
+def test_verification_leaves_the_authoritative_release_unchanged(tmp_path: Path) -> None:
+    repository, release_root, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    before = {
+        path.relative_to(release_root).as_posix(): (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in sorted(release_root.rglob("*"))
+        if path.is_file()
+    }
+
+    training.dry_run(load_released_plan(repository, workspace, release_manifest, config_path))
+
+    after = {
+        path.relative_to(release_root).as_posix(): (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in sorted(release_root.rglob("*"))
+        if path.is_file()
+    }
+    assert after == before
+    assert not list(release_root.rglob("*.cache"))
+
+
+def test_dry_run_rejects_a_corrupted_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    corrupt_file(workspace / "train" / "images" / "person_001.jpg")
+    monkeypatch.setattr(training, "REPOSITORY_ROOT", repository)
+
+    exit_code = training.main([
+        "--config", str(config_path),
+        "--dataset-root", str(workspace),
+        "--manifest-path", str(release_manifest),
+        "--dry-run",
+    ])
+
+    assert exit_code == 1
+    assert "does not match the approved release checksum" in capsys.readouterr().err
+
+
+def test_confirmed_training_rejects_the_same_corrupted_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    corrupt_file(workspace / "train" / "images" / "person_001.jpg")
+    monkeypatch.setattr(training, "REPOSITORY_ROOT", repository)
+    monkeypatch.setattr(
+        training, "default_trainer", lambda _: pytest.fail("trainer must not be invoked")
+    )
+
+    exit_code = training.main([
+        "--config", str(config_path),
+        "--dataset-root", str(workspace),
+        "--manifest-path", str(release_manifest),
+        "--confirm-training",
+    ])
+
+    assert exit_code == 1
+    assert "does not match the approved release checksum" in capsys.readouterr().err
+    assert not (repository / "artifacts").exists()
+
+
+def test_integrity_failure_happens_before_any_trainer_import(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    corrupt_file(workspace / "train" / "labels" / "person_001.txt")
+    monkeypatch.setitem(sys.modules, "ultralytics", None)
+
+    with pytest.raises(training.TrainingPipelineError, match="does not match the approved release checksum"):
+        load_released_plan(repository, workspace, release_manifest, config_path)
+
+
+def test_release_checksum_evidence_is_recorded_in_run_metadata(tmp_path: Path) -> None:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    plan = load_released_plan(repository, workspace, release_manifest, config_path)
+
+    training.run_training(plan, lambda _: {"ok": True})
+
+    metadata = json.loads((plan.run_directory / "run_metadata.json").read_text(encoding="utf-8"))
+    assert metadata["release_checksums_reference"] == training.EXTERNAL_CHECKSUM_REFERENCE
+    assert metadata["release_checksums_checksum_sha256"] == plan.release_checksums_checksum
+    assert str(release_manifest.parent) not in json.dumps(metadata)
+
+
+def test_local_manifest_flow_does_not_require_checksum_evidence(tmp_path: Path) -> None:
+    """The repository-relative, non-released flow is unchanged by this gate."""
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+
+    plan = load_plan(repository, dataset_root, config_path)
+
+    assert training.dry_run(plan)["status"] == "dry_run_valid"
+    assert plan.release_checksums_reference is None
+    assert plan.release_checksums_checksum is None

--- a/ML_side/tests/test_train_navigation_model.py
+++ b/ML_side/tests/test_train_navigation_model.py
@@ -624,3 +624,367 @@ def test_shipped_smoke_configuration_passes_its_own_preflight(tmp_path: Path) ->
     assert plan.config["training"]["workers"] == shipped["training"]["workers"]  # type: ignore[index]
     assert training.trainer_arguments(plan)["workers"] == shipped["training"]["workers"]
     assert not plan.run_directory.exists()
+
+
+def materialise_samples(manifest: dict[str, object], root: Path) -> None:
+    """Write placeholder bytes for every manifest sample beneath one root."""
+    for split in manifest["splits"].values():  # type: ignore[attr-defined]
+        for sample in split["samples"]:
+            for field in ("image_path", "label_path"):
+                value = sample.get(field)
+                if value:
+                    target = root / value
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_text("fixture", encoding="utf-8")
+
+
+def create_released_fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
+    """Build an authoritative release plus a separate faithful training workspace.
+
+    The release hosts its own manifest, matching the approved controlled-release
+    layout. The workspace holds the same dataset bytes and no manifest.
+    """
+    repository = tmp_path / "repository"
+    release_root = tmp_path / "release"
+    workspace = tmp_path / "workspace"
+    for directory in (repository, release_root, workspace):
+        directory.mkdir()
+    manifest = json.loads(SAMPLE_MANIFEST.read_text(encoding="utf-8"))
+    manifest["dataset"]["release_decision"] = "approved_for_training"
+    manifest["licence"]["review_decision"] = "approved"
+    for root in (release_root, workspace):
+        materialise_samples(manifest, root)
+        write_yaml(root / "dataset.yaml")
+    release_manifest = release_root / "release_manifest.json"
+    release_manifest.write_text(json.dumps(manifest), encoding="utf-8")
+    (repository / "architecture.yaml").write_text("nc: 8\n", encoding="utf-8")
+    config = {
+        "schema_version": "1.0.0",
+        "experiment_name": "Navigation Released Test",
+        "dataset": {"yaml_path": "dataset.yaml", "inspection_report_path": None, "stage": "released"},
+        "model": {"architecture_path": "architecture.yaml", "initial_weights_path": None},
+        "training": {
+            "epochs": 1, "image_size": 640, "batch_size": 2, "device": "auto", "workers": 0,
+            "seed": 42, "optimizer": "AdamW", "learning_rate": 0.001, "confidence": 0.001,
+            "iou": 0.7, "deterministic": True, "fraction": 0.002, "val": False,
+            "resume_behavior": "never",
+        },
+        "output": {"root": "artifacts/navigation_mvp"},
+        "notes": "Fictional released test configuration.",
+    }
+    config_path = repository / "training.yaml"
+    save_config(config_path, config)
+    return repository, release_root, workspace, release_manifest, config_path
+
+
+def released_plan(tmp_path: Path) -> training.TrainingPlan:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    return training.load_training_plan(
+        config_path,
+        dataset_root_override=workspace,
+        manifest_path_override=release_manifest,
+        repository_root=repository,
+    )
+
+
+def runtime_dataset_root(plan: training.TrainingPlan, descriptor: Path) -> Path:
+    return Path(yaml.safe_load(descriptor.read_text(encoding="utf-8"))["path"])
+
+
+# --------------------------------------------------------- CWD independence
+
+
+def test_runtime_descriptor_resolves_absolute_root_from_relative_path(tmp_path: Path) -> None:
+    plan = released_plan(tmp_path)
+
+    assert yaml.safe_load(plan.dataset_yaml_path.read_text(encoding="utf-8"))["path"] == "."
+    with training.runtime_dataset_descriptor(plan) as descriptor:
+        resolved = runtime_dataset_root(plan, descriptor)
+
+    assert resolved.is_absolute()
+    assert resolved == plan.dataset_root.resolve()
+
+
+def test_runtime_descriptor_is_independent_of_process_working_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = released_plan(tmp_path)
+    unrelated = tmp_path / "unrelated-cwd"
+    unrelated.mkdir()
+    monkeypatch.chdir(unrelated)
+
+    with training.runtime_dataset_descriptor(plan) as descriptor:
+        resolved = runtime_dataset_root(plan, descriptor)
+
+    assert resolved == plan.dataset_root.resolve()
+    assert not str(resolved).startswith(str(unrelated))
+
+
+def test_runtime_descriptor_preserves_splits_and_taxonomy(tmp_path: Path) -> None:
+    plan = released_plan(tmp_path)
+    original = yaml.safe_load(plan.dataset_yaml_path.read_text(encoding="utf-8"))
+
+    with training.runtime_dataset_descriptor(plan) as descriptor:
+        runtime = yaml.safe_load(descriptor.read_text(encoding="utf-8"))
+
+    assert runtime["train"] == original["train"]
+    assert runtime["val"] == original["val"]
+    assert runtime["test"] == original["test"]
+    assert runtime["names"] == original["names"]
+    assert set(runtime) == set(original)
+
+
+def test_trainer_receives_the_resolved_runtime_descriptor(tmp_path: Path) -> None:
+    plan = released_plan(tmp_path)
+    received: dict[str, object] = {}
+
+    def trainer(active_plan: training.TrainingPlan) -> object:
+        with training.runtime_dataset_descriptor(active_plan) as descriptor:
+            arguments = training.runtime_trainer_arguments(active_plan, descriptor)
+            received["data"] = arguments["data"]
+            received["root"] = str(runtime_dataset_root(active_plan, descriptor))
+        return {"ok": True}
+
+    training.run_training(plan, trainer)
+
+    assert Path(str(received["data"])).name == "dataset.yaml"
+    assert received["root"] == str(plan.dataset_root.resolve())
+    assert training.trainer_arguments(plan)["data"] == str(plan.dataset_yaml_path)
+
+
+# ----------------------------------------------------- ephemeral descriptor
+
+
+def test_original_dataset_yaml_is_not_modified(tmp_path: Path) -> None:
+    plan = released_plan(tmp_path)
+    before = plan.dataset_yaml_path.read_bytes()
+
+    with training.runtime_dataset_descriptor(plan):
+        pass
+
+    assert plan.dataset_yaml_path.read_bytes() == before
+
+
+def test_runtime_descriptor_is_removed_after_success(tmp_path: Path) -> None:
+    plan = released_plan(tmp_path)
+
+    with training.runtime_dataset_descriptor(plan) as descriptor:
+        assert descriptor.is_file()
+        captured = descriptor
+
+    assert not captured.exists()
+    assert not captured.parent.exists()
+
+
+def test_runtime_descriptor_is_removed_after_trainer_failure(tmp_path: Path) -> None:
+    plan = released_plan(tmp_path)
+    captured: dict[str, Path] = {}
+
+    with pytest.raises(RuntimeError):
+        with training.runtime_dataset_descriptor(plan) as descriptor:
+            captured["path"] = descriptor
+            raise RuntimeError("simulated trainer failure")
+
+    assert not captured["path"].exists()
+    assert not captured["path"].parent.exists()
+
+
+def test_runtime_descriptor_is_not_written_inside_the_dataset(tmp_path: Path) -> None:
+    plan = released_plan(tmp_path)
+
+    with training.runtime_dataset_descriptor(plan) as descriptor:
+        with pytest.raises(ValueError):
+            descriptor.relative_to(plan.dataset_root)
+
+
+# ------------------------------------------------- released-root isolation
+
+
+def test_released_manifest_inside_supplied_dataset_root_is_rejected(tmp_path: Path) -> None:
+    repository, release_root, _, release_manifest, config_path = create_released_fixture(tmp_path)
+
+    with pytest.raises(training.TrainingPipelineError, match="must not be used directly"):
+        training.load_training_plan(
+            config_path,
+            dataset_root_override=release_root,
+            manifest_path_override=release_manifest,
+            repository_root=repository,
+        )
+
+
+def test_separate_workspace_with_authoritative_manifest_is_accepted(tmp_path: Path) -> None:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+
+    plan = training.load_training_plan(
+        config_path,
+        dataset_root_override=workspace,
+        manifest_path_override=release_manifest,
+        repository_root=repository,
+    )
+
+    assert training.dry_run(plan)["status"] == "dry_run_valid"
+    assert plan.manifest_reference == training.EXTERNAL_MANIFEST_REFERENCE
+    assert plan.dataset_root == workspace.resolve()
+
+
+def test_incomplete_workspace_fails_manifest_validation(tmp_path: Path) -> None:
+    repository, _, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    manifest = json.loads(release_manifest.read_text(encoding="utf-8"))
+    missing = workspace / manifest["splits"]["train"]["samples"][0]["image_path"]
+    missing.unlink()
+
+    with pytest.raises(training.TrainingPipelineError, match="manifest validation failed"):
+        training.load_training_plan(
+            config_path,
+            dataset_root_override=workspace,
+            manifest_path_override=release_manifest,
+            repository_root=repository,
+        )
+
+
+def test_dry_run_enforces_the_same_isolation_requirement(tmp_path: Path) -> None:
+    """The isolation gate lives in preflight, so dry-run cannot diverge from training."""
+    repository, release_root, _, release_manifest, config_path = create_released_fixture(tmp_path)
+
+    # Dry-run and confirmed training share load_training_plan, so a rejected
+    # release root can never reach either path.
+    with pytest.raises(training.TrainingPipelineError, match="must not be used directly"):
+        training.load_training_plan(
+            config_path,
+            dataset_root_override=release_root,
+            manifest_path_override=release_manifest,
+            repository_root=repository,
+        )
+    assert not (repository / "artifacts").exists()
+
+
+def test_repository_relative_manifest_flow_is_unaffected(tmp_path: Path) -> None:
+    """A repository-relative manifest is never treated as an external release root."""
+    repository, dataset_root, config_path = create_fixture(tmp_path)
+
+    plan = load_plan(repository, dataset_root, config_path)
+
+    assert training.dry_run(plan)["status"] == "dry_run_valid"
+    assert plan.manifest_reference == "manifest.json"
+
+
+# ------------------------------------------------------------ cache boundary
+
+
+def test_simulated_label_cache_lands_only_in_the_workspace(tmp_path: Path) -> None:
+    repository, release_root, workspace, release_manifest, config_path = create_released_fixture(tmp_path)
+    release_snapshot = {
+        path.relative_to(release_root).as_posix(): path.read_bytes()
+        for path in sorted(release_root.rglob("*"))
+        if path.is_file()
+    }
+    plan = training.load_training_plan(
+        config_path,
+        dataset_root_override=workspace,
+        manifest_path_override=release_manifest,
+        repository_root=repository,
+    )
+
+    def cache_writing_trainer(active_plan: training.TrainingPlan) -> object:
+        with training.runtime_dataset_descriptor(active_plan) as descriptor:
+            root = runtime_dataset_root(active_plan, descriptor)
+            # Emulate Ultralytics writing a label cache beside the label directory.
+            cache = root / "train" / "labels.cache"
+            cache.parent.mkdir(parents=True, exist_ok=True)
+            cache.write_text("simulated cache", encoding="utf-8")
+            return {"cache": str(cache)}
+
+    training.run_training(plan, cache_writing_trainer)
+
+    assert (workspace / "train" / "labels.cache").is_file()
+    assert not (release_root / "train" / "labels.cache").exists()
+    assert not list(release_root.rglob("*.cache"))
+    after = {
+        path.relative_to(release_root).as_posix(): path.read_bytes()
+        for path in sorted(release_root.rglob("*"))
+        if path.is_file()
+    }
+    assert after == release_snapshot
+
+
+# ------------------------------------------------------ failure sanitisation
+
+
+def test_failure_summary_is_sanitised_of_local_paths(tmp_path: Path) -> None:
+    plan = released_plan(tmp_path)
+    leaked = (
+        f"Dataset '{plan.dataset_yaml_path}' images not found, missing path "
+        f"'{plan.dataset_root}\\images\\val'. Manifest {plan.manifest_path.as_posix()} "
+        f"and repository {plan.repository_root} and run {plan.run_directory}."
+    )
+
+    def failing_trainer(_: training.TrainingPlan) -> object:
+        raise RuntimeError(leaked)
+
+    with pytest.raises(training.TrainingPipelineError):
+        training.run_training(plan, failing_trainer)
+
+    metadata = json.loads((plan.run_directory / "run_metadata.json").read_text(encoding="utf-8"))
+    summary = metadata["failure_summary"]
+    assert metadata["status"] == "failed"
+    assert "RuntimeError" in summary
+    assert "images not found" in summary
+    for absolute in (
+        str(plan.dataset_root),
+        plan.dataset_root.as_posix(),
+        str(plan.manifest_path),
+        plan.manifest_path.as_posix(),
+        str(plan.repository_root),
+        plan.repository_root.as_posix(),
+        str(tmp_path),
+        tmp_path.as_posix(),
+    ):
+        assert absolute not in summary
+    assert "<dataset-root>" in summary or "<local-path>" in summary
+
+
+@pytest.mark.parametrize("template", [
+    "missing path '{native}\\images\\val'",
+    "missing path '{posix}/images/val'",
+    "Dataset '{doubled}/dataset.yaml' error",
+    "cache written to {native}\\labels\\train.cache",
+])
+def test_path_variants_are_all_sanitised(tmp_path: Path, template: str) -> None:
+    plan = released_plan(tmp_path)
+    root = plan.dataset_root
+    posix = root.as_posix()
+    text = template.format(
+        native=str(root), posix=posix, doubled=f"{posix[:2]}//{posix[3:]}"
+    )
+
+    sanitised = training._sanitise_local_paths(text, plan)
+
+    assert str(root) not in sanitised
+    assert posix not in sanitised
+    assert "C:" not in sanitised.replace("<", "").replace(">", "")
+
+
+def test_runtime_descriptor_path_is_sanitised_from_failure_text(tmp_path: Path) -> None:
+    plan = released_plan(tmp_path)
+    with training.runtime_dataset_descriptor(plan) as descriptor:
+        text = f"RuntimeError: Dataset '{descriptor}' error"
+        sanitised = training._sanitise_local_paths(text, plan, descriptor)
+
+    assert str(descriptor) not in sanitised
+    assert descriptor.as_posix() not in sanitised
+    assert "RuntimeError" in sanitised
+
+
+def test_successful_run_metadata_contains_no_absolute_paths(tmp_path: Path) -> None:
+    plan = released_plan(tmp_path)
+
+    training.run_training(plan, lambda _: {"ok": True})
+
+    metadata = (plan.run_directory / "run_metadata.json").read_text(encoding="utf-8")
+    resolved = (plan.run_directory / "resolved_training_config.json").read_text(encoding="utf-8")
+    reference = (plan.run_directory / "dataset_reference.json").read_text(encoding="utf-8")
+    for document in (metadata, resolved, reference):
+        assert str(plan.dataset_root) not in document
+        assert plan.dataset_root.as_posix() not in document
+        assert str(plan.manifest_path) not in document
+        assert plan.manifest_path.as_posix() not in document

--- a/ML_side/training/README.md
+++ b/ML_side/training/README.md
@@ -12,6 +12,58 @@ By default, `dataset.manifest_path` remains a repository-relative configuration 
 
 The versioned configuration records the experiment name; manifest/YAML references; explicit stage; exactly one local model source; epochs, image size, batch, device, workers, seed, optimiser, learning rate, confidence, IoU, deterministic preference, resume behaviour, output root, and notes. Unknown fields are rejected. Epochs, image size, batch, and seed are positive non-boolean integers, while workers is a non-negative non-boolean integer so that zero selects main-process data loading; learning rate, confidence, and IoU are finite non-negative numbers. Device values are deliberately limited to `cpu`, `auto`, `mps`, `cuda`, `cuda:<index>`, or a numeric GPU index. Dataset roots are intentionally supplied at execution with `--dataset-root` rather than committed.
 
+## Immutable release and mutable training workspace
+
+An approved released dataset is read-only evidence. Ultralytics writes label
+cache files such as `labels/train.cache` beside each label directory whenever it
+loads a dataset, and the `cache` training argument does not disable that
+behaviour, so pointing a trainer at the authoritative release would modify it.
+
+Preflight therefore rejects an external `--manifest-path` whose manifest sits
+inside the supplied `--dataset-root` when the configured stage is `released`.
+Both `--dry-run` and confirmed training share this gate, so a run that passes
+preflight cannot fail the isolation contract later.
+
+Before real training, create a mutable local copy of the release and pass the
+copy as the dataset root while keeping the authoritative manifest:
+
+```powershell
+& "C:\path\to\python.exe" ".\ML_side\training\train_navigation_model.py" --config ".\ML_side\config\training_navigation_smoke.yaml" --dataset-root "C:\path\to\mutable-training-workspace" --manifest-path "C:\path\to\WalkBuddy-Controlled-Releases\...\release_manifest.json" --dry-run
+```
+
+The wrapper does not create, copy, link, or mutate that workspace. Preparing it
+is a deliberate, explicit step performed outside the tool. Full
+`validate_manifest(..., check_files=True)` validation still runs against the
+workspace, so an incomplete or misplaced copy fails before training starts.
+
+Note that the manifest contract verifies sample presence and structure rather
+than per-file content hashes, so workspace fidelity beyond file existence is not
+established by this check alone.
+
+## Working-directory independence
+
+The approved dataset YAML may declare a relative `path` such as `.`. Ultralytics
+resolves that against the process working directory rather than against the YAML
+file, so a relative root would otherwise make training depend on where the tool
+was invoked.
+
+For confirmed training the tool writes an ephemeral trainer-only dataset
+descriptor into a temporary directory, identical to the approved YAML except
+that `path` is the absolute root already resolved by preflight. The approved YAML
+is never modified, the temporary file is never written inside the dataset, and it
+is removed after the trainer succeeds or fails. Persisted metadata continues to
+record the sanitised original dataset reference, not the temporary descriptor.
+
+## Failure metadata sanitisation
+
+Third-party trainer exceptions can embed absolute local paths. Before a failure
+is persisted, known locations are replaced with `<dataset-root>`,
+`<external-manifest>`, `<repository-root>`, `<run-directory>`, and
+`<runtime-dataset>`, in both backslash and forward-slash spellings, and any
+residual absolute path is replaced with `<local-path>`. Enough of the message
+survives to identify the failure. Console output is unchanged for the local
+operator.
+
 ## Dry run
 
 Use an existing controlled local dataset root. The root is not recorded in output metadata.

--- a/ML_side/training/README.md
+++ b/ML_side/training/README.md
@@ -9,6 +9,10 @@ Start from [`../config/training_navigation_mvp.yaml`](../config/training_navigat
 The manifest must pass the bundled validator with `--check-files` semantics, use the approved eight-class taxonomy, have `dataset.release_decision: approved_for_training`, and record an approved licence review that permits machine-learning use. Of the manifest decisions, only `approved_for_training` is accepted; `draft`, `under_review`, `rejected`, `retired`, and `example_only` are rejected. The configuration stage must be `approved_for_internal_training` or `released`; `candidate`, `in_review`, and `rejected` are deliberately ineligible. The YOLO YAML must use the exact same ordered taxonomy and physically contain each manifest sample beneath its declared split. If an inspection report is supplied, its verdict must not be `fail`.
 
 By default, `dataset.manifest_path` remains a repository-relative configuration field. An approved release kept in controlled external storage may instead be supplied at runtime with `--manifest-path`. The override accepts only an existing regular local `.json` file; URLs, URIs, UNC paths, missing files, and non-JSON files are rejected. The manifest is not copied, and preflight still performs full file validation against `--dataset-root`. Persisted run records keep its checksum and the sanitised `external-local/manifest.json` reference rather than the caller's absolute path.
+For released external datasets the checksum evidence is recorded the same way, as
+its own SHA-256 plus the sanitised `external-local/release_checksums.json`
+reference, so the evidence chain covers the release manifest, the release
+checksum manifest, the dataset YAML, and the base model.
 
 The versioned configuration records the experiment name; manifest/YAML references; explicit stage; exactly one local model source; epochs, image size, batch, device, workers, seed, optimiser, learning rate, confidence, IoU, deterministic preference, resume behaviour, output root, and notes. Unknown fields are rejected. Epochs, image size, batch, and seed are positive non-boolean integers, while workers is a non-negative non-boolean integer so that zero selects main-process data loading; learning rate, confidence, and IoU are finite non-negative numbers. Device values are deliberately limited to `cpu`, `auto`, `mps`, `cuda`, `cuda:<index>`, or a numeric GPU index. Dataset roots are intentionally supplied at execution with `--dataset-root` rather than committed.
 
@@ -32,13 +36,49 @@ copy as the dataset root while keeping the authoritative manifest:
 ```
 
 The wrapper does not create, copy, link, or mutate that workspace. Preparing it
-is a deliberate, explicit step performed outside the tool. Full
-`validate_manifest(..., check_files=True)` validation still runs against the
-workspace, so an incomplete or misplaced copy fails before training starts.
+is a deliberate, explicit step performed outside the tool.
 
-Note that the manifest contract verifies sample presence and structure rather
-than per-file content hashes, so workspace fidelity beyond file existence is not
-established by this check alone.
+### Workspace content verification
+
+Full `validate_manifest(..., check_files=True)` validation runs against the
+workspace, and the workspace is additionally verified byte-for-byte against the
+authoritative release.
+
+The release builder emits `release_checksums.json` beside the manifest, recording
+a SHA-256 for every released file. Preflight reads that evidence from the
+**authoritative release directory only**, never from the mutable workspace, and
+requires:
+
+- the evidence is a regular local JSON file, not a symlink
+- `algorithm` is exactly `sha256`
+- `release_identity` is a valid digest and matches the identity recorded in the
+  approved manifest, allowing only the documented `sha256:` prefix difference
+- every listed path is a safe release-relative path, with no traversal, absolute,
+  URL, URI, or UNC form, and no duplicates
+- every digest is a valid SHA-256 hex value
+
+Every listed file is then resolved beneath the workspace and hashed in chunks.
+One differing byte fails preflight. Because the gate lives in shared preflight,
+`--dry-run` and confirmed training reject the same corrupted workspace, and the
+failure occurs before Ultralytics is imported or invoked.
+
+The evidence file deliberately does not checksum itself or the build reports,
+which are written after the checksums are computed; preflight respects that
+contract.
+
+### Additional training files
+
+Trainers read whole split directories rather than the manifest sample list, so an
+unlisted image placed in a split directory would otherwise enter training.
+Preflight scans the directories that hold checksummed images and labels and
+rejects any additional training image or `.txt` label that the approved release
+does not contain.
+
+Ultralytics label caches such as `labels/train.cache` are expected in a mutable
+workspace and are permitted. The invariant is not that the workspace stays
+byte-identical after training, but that every authoritative training-substantive
+file remains present and hash-identical, and that no unexpected training image or
+text label is introduced.
 
 ## Working-directory independence
 

--- a/ML_side/training/train_navigation_model.py
+++ b/ML_side/training/train_navigation_model.py
@@ -17,7 +17,8 @@ import re
 import subprocess
 import sys
 import tempfile
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError, version
@@ -31,8 +32,11 @@ import validate_dataset_manifest as manifest_validator
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-TOOL_VERSION = "1.1.0"
+TOOL_VERSION = "1.2.0"
+# Drive-letter or UNC absolute paths that survive known-location replacement.
+_RESIDUAL_ABSOLUTE_PATH = re.compile(r"(?:[A-Za-z]:[\\/]|\\\\)[^\s'\"<>|]*")
 ELIGIBLE_STAGES = frozenset({"approved_for_internal_training", "released"})
+RELEASED_STAGE = "released"
 ALL_STAGES = frozenset(
     {"candidate", "in_review", "approved_for_internal_training", "rejected", "released"}
 )
@@ -280,6 +284,21 @@ def _validate_manifest_matches_yaml_splits(
             ) from exc
 
 
+def _released_release_root_supplied(manifest_path: Path, dataset_root: Path) -> bool:
+    """Report whether an external manifest sits inside the supplied dataset root.
+
+    An approved release directory that also hosts its own manifest is the
+    authoritative evidence source. Third-party trainers write label caches beside
+    the label directories, so that directory must never be the trainer's dataset
+    root.
+    """
+    try:
+        manifest_path.relative_to(dataset_root)
+    except ValueError:
+        return False
+    return True
+
+
 def _manifest_eligibility(manifest: Mapping[str, object], stage: str) -> None:
     dataset = manifest.get("dataset")
     if not isinstance(dataset, Mapping):
@@ -429,6 +448,17 @@ def load_training_plan(
         first = manifest_issues[0]
         raise TrainingPipelineError(f"manifest validation failed: {first.location}: {first.message}")
     _manifest_eligibility(manifest, stage)
+    if (
+        manifest_path_override is not None
+        and stage == RELEASED_STAGE
+        and _released_release_root_supplied(manifest_path, dataset_root)
+    ):
+        raise TrainingPipelineError(
+            "The approved released dataset must not be used directly for trainer "
+            "execution because third-party tooling may create cache files. Supply a "
+            "verified mutable training workspace as --dataset-root while retaining "
+            "the approved external manifest through --manifest-path."
+        )
     manifest_dataset = manifest.get("dataset")
     assert isinstance(manifest_dataset, Mapping)
     dataset_yaml = _load_yaml(dataset_yaml_path, "Dataset YAML")
@@ -608,6 +638,71 @@ def _write_run_files(plan: TrainingPlan, metadata: Mapping[str, object]) -> None
     )
 
 
+def _effective_dataset_root(plan: TrainingPlan) -> Path:
+    """Resolve the dataset YAML's effective root using the preflight resolution."""
+    dataset_yaml = _load_yaml(plan.dataset_yaml_path, "Dataset YAML")
+    return _resolve_under(plan.dataset_root, dataset_yaml.get("path", "."), "dataset YAML path")
+
+
+@contextmanager
+def runtime_dataset_descriptor(plan: TrainingPlan) -> Iterator[Path]:
+    """Yield a temporary trainer-only dataset YAML with an absolute resolved root.
+
+    The approved descriptor may use a relative ``path``, which third-party
+    trainers resolve against the process working directory rather than against the
+    descriptor's own location. Writing an ephemeral copy with an absolute root
+    makes trainer execution independent of the caller's working directory without
+    modifying the approved dataset YAML. The temporary file never persists.
+    """
+    import yaml
+
+    dataset_yaml = _load_yaml(plan.dataset_yaml_path, "Dataset YAML")
+    runtime_yaml = dict(dataset_yaml)
+    runtime_yaml["path"] = str(_effective_dataset_root(plan))
+    with tempfile.TemporaryDirectory(prefix="walkbuddy-training-dataset-") as directory:
+        descriptor = Path(directory) / plan.dataset_yaml_path.name
+        descriptor.write_text(yaml.safe_dump(runtime_yaml, sort_keys=True), encoding="utf-8")
+        yield descriptor
+
+
+def runtime_trainer_arguments(plan: TrainingPlan, dataset_yaml_path: Path) -> dict[str, object]:
+    """Return trainer arguments pointing at a resolved runtime dataset descriptor."""
+    arguments = trainer_arguments(plan)
+    arguments["data"] = str(dataset_yaml_path)
+    return arguments
+
+
+def _path_variants(path: Path) -> tuple[str, ...]:
+    """Return the spellings a third-party message may use for one local path."""
+    native = str(path)
+    posix = path.as_posix()
+    variants = {native, posix, native.replace("\\", "/"), posix.replace("/", "\\")}
+    if len(posix) > 2 and posix[1] == ":":
+        # Some third-party messages emit a doubled separator after the drive.
+        variants.add(f"{posix[:2]}//{posix[3:]}")
+    return tuple(sorted(variants, key=len, reverse=True))
+
+
+def _sanitise_local_paths(text: str, plan: TrainingPlan, *extra: Path) -> str:
+    """Replace known and residual absolute local paths with stable placeholders."""
+    replacements: list[tuple[Path, str]] = [
+        (plan.run_directory, "<run-directory>"),
+        (plan.dataset_root, "<dataset-root>"),
+        (plan.manifest_path, "<external-manifest>"),
+        (plan.repository_root, "<repository-root>"),
+    ]
+    replacements.extend((path, "<runtime-dataset>") for path in extra)
+    # Longest locations first so nested paths are not partially replaced.
+    replacements.sort(key=lambda item: len(str(item[0])), reverse=True)
+    sanitised = text
+    for path, placeholder in replacements:
+        for variant in _path_variants(path):
+            sanitised = sanitised.replace(variant, placeholder)
+    # Residual sweep for any absolute local path the known locations did not
+    # cover, including temporary directories created by third-party tooling.
+    return _RESIDUAL_ABSOLUTE_PATH.sub("<local-path>", sanitised)
+
+
 def default_trainer(plan: TrainingPlan) -> object:
     """Invoke Ultralytics only for explicitly confirmed real training."""
     os.environ.setdefault("YOLO_OFFLINE", "true")
@@ -617,7 +712,8 @@ def default_trainer(plan: TrainingPlan) -> object:
     except ImportError as exc:
         raise TrainingPipelineError("Ultralytics is unavailable; real training cannot start.") from exc
     model = YOLO(str(plan.model_path))
-    return model.train(**trainer_arguments(plan))
+    with runtime_dataset_descriptor(plan) as runtime_dataset:
+        return model.train(**runtime_trainer_arguments(plan, runtime_dataset))
 
 
 def run_training(plan: TrainingPlan, trainer: Callable[[TrainingPlan], object] | None = None) -> object:
@@ -629,7 +725,8 @@ def run_training(plan: TrainingPlan, trainer: Callable[[TrainingPlan], object] |
         result = (trainer or default_trainer)(plan)
     except Exception as exc:
         completed = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-        failed = _run_metadata(plan, "failed", started_at=started, completed_at=completed, failure=f"{type(exc).__name__}: {exc}")
+        failure = _sanitise_local_paths(f"{type(exc).__name__}: {exc}", plan)
+        failed = _run_metadata(plan, "failed", started_at=started, completed_at=completed, failure=failure)
         _write_run_files(plan, failed)
         raise TrainingPipelineError(f"training failed: {type(exc).__name__}: {exc}") from exc
     completed = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/ML_side/training/train_navigation_model.py
+++ b/ML_side/training/train_navigation_model.py
@@ -37,6 +37,20 @@ TOOL_VERSION = "1.2.0"
 _RESIDUAL_ABSOLUTE_PATH = re.compile(r"(?:[A-Za-z]:[\\/]|\\\\)[^\s'\"<>|]*")
 ELIGIBLE_STAGES = frozenset({"approved_for_internal_training", "released"})
 RELEASED_STAGE = "released"
+CHECKSUM_EVIDENCE_FILENAME = "release_checksums.json"
+CHECKSUM_ALGORITHM = "sha256"
+EXTERNAL_CHECKSUM_REFERENCE = "external-local/release_checksums.json"
+_SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
+# Mirrors Ultralytics 8.4.7 IMG_FORMATS so any image the trainer would ingest is
+# treated as training-substantive. Kept local so preflight never imports it.
+TRAINING_IMAGE_SUFFIXES = frozenset(
+    {
+        ".avif", ".bmp", ".dng", ".heic", ".jp2", ".jpeg", ".jpeg2000",
+        ".jpg", ".mpo", ".png", ".tif", ".tiff", ".webp",
+    }
+)
+TRAINING_LABEL_SUFFIX = ".txt"
+WORKSPACE_CACHE_SUFFIX = ".cache"
 ALL_STAGES = frozenset(
     {"candidate", "in_review", "approved_for_internal_training", "rejected", "released"}
 )
@@ -70,6 +84,8 @@ class TrainingPlan:
     manifest_release_decision: str
     git_commit: str | None
     git_dirty: bool | None
+    release_checksums_reference: str | None = None
+    release_checksums_checksum: str | None = None
 
 
 def _load_yaml(path: Path, label: str) -> dict[str, object]:
@@ -284,6 +300,133 @@ def _validate_manifest_matches_yaml_splits(
             ) from exc
 
 
+def _is_training_substantive(relative_path: str) -> bool:
+    """Report whether a released file would be consumed as training data."""
+    suffix = Path(relative_path).suffix.casefold()
+    return suffix in TRAINING_IMAGE_SUFFIXES or suffix == TRAINING_LABEL_SUFFIX
+
+
+def _load_release_checksums(manifest_path: Path) -> tuple[Path, str, dict[str, str]]:
+    """Load the authoritative checksum evidence stored beside the approved manifest.
+
+    The authoritative release is the trust source, so the evidence is always read
+    from the manifest's own directory and never from the mutable workspace.
+    """
+    evidence_path = manifest_path.parent / CHECKSUM_EVIDENCE_FILENAME
+    if evidence_path.is_symlink():
+        raise TrainingPipelineError(
+            "release checksum evidence must be a regular local JSON file, not a symlink."
+        )
+    if not evidence_path.is_file():
+        raise TrainingPipelineError(
+            "released external datasets require release_checksums.json beside the approved manifest."
+        )
+    try:
+        payload = json.loads(evidence_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TrainingPipelineError(
+            "release checksum evidence is unreadable or is not valid JSON."
+        ) from exc
+    if not isinstance(payload, Mapping):
+        raise TrainingPipelineError("release checksum evidence root must be an object.")
+    if payload.get("algorithm") != CHECKSUM_ALGORITHM:
+        raise TrainingPipelineError(
+            "release checksum evidence must declare the sha256 algorithm."
+        )
+    identity = payload.get("release_identity")
+    if not isinstance(identity, str) or _SHA256_HEX.match(identity.strip().casefold()) is None:
+        raise TrainingPipelineError(
+            "release checksum evidence release_identity must be a SHA-256 digest."
+        )
+    files = payload.get("files")
+    if not isinstance(files, Mapping) or not files:
+        raise TrainingPipelineError(
+            "release checksum evidence must list at least one checksummed file."
+        )
+    checksums: dict[str, str] = {}
+    seen: set[str] = set()
+    for raw_path, raw_checksum in files.items():
+        relative = _safe_relative(raw_path, "release checksum path").replace("\\", "/")
+        if relative.casefold() in seen:
+            raise TrainingPipelineError(
+                "release checksum evidence contains duplicate or ambiguous file paths."
+            )
+        if not isinstance(raw_checksum, str) or _SHA256_HEX.match(raw_checksum.strip().casefold()) is None:
+            raise TrainingPipelineError(
+                "release checksum evidence contains an invalid SHA-256 digest."
+            )
+        seen.add(relative.casefold())
+        checksums[relative] = raw_checksum.strip().casefold()
+    return evidence_path, identity.strip().casefold(), checksums
+
+
+def _cross_check_release_identity(manifest: Mapping[str, object], checksum_identity: str) -> None:
+    """Require the checksum evidence and approved manifest to describe one release."""
+    quality = manifest.get("quality")
+    recorded: object = None
+    if isinstance(quality, Mapping):
+        manifest_checksums = quality.get("checksums")
+        if isinstance(manifest_checksums, Mapping):
+            recorded = manifest_checksums.get("release_identity")
+    if not isinstance(recorded, str) or not recorded.strip():
+        raise TrainingPipelineError(
+            "approved manifest does not record a release identity to cross-check."
+        )
+    value = recorded.strip()
+    prefix = f"{CHECKSUM_ALGORITHM}:"
+    if value.casefold().startswith(prefix):
+        value = value[len(prefix):]
+    if value.strip().casefold() != checksum_identity:
+        raise TrainingPipelineError(
+            "release checksum evidence identity does not match the approved manifest release identity."
+        )
+
+
+def _verify_workspace_checksums(dataset_root: Path, checksums: Mapping[str, str]) -> None:
+    """Require every authoritative released file to be byte-identical in the workspace."""
+    for relative, expected in checksums.items():
+        candidate = _resolve_under(dataset_root, relative, "release checksum path")
+        if candidate.is_symlink() or not candidate.is_file():
+            raise TrainingPipelineError(
+                "training workspace is missing a released file required by the approved checksum evidence."
+            )
+        if _sha256(candidate) != expected:
+            raise TrainingPipelineError(
+                "training workspace content does not match the approved release checksum evidence."
+            )
+
+
+def _reject_unexpected_training_files(dataset_root: Path, checksums: Mapping[str, str]) -> None:
+    """Reject training images or labels the approved release does not contain.
+
+    Trainers read whole split directories rather than the manifest sample list, so
+    an unlisted image would otherwise enter training. Ultralytics label caches are
+    expected in a mutable workspace and are allowed.
+    """
+    expected = {relative.casefold() for relative in checksums}
+    directories = {
+        relative.rsplit("/", 1)[0]
+        for relative in checksums
+        if "/" in relative and _is_training_substantive(relative)
+    }
+    for relative_directory in sorted(directories):
+        directory = _resolve_under(dataset_root, relative_directory, "release checksum path")
+        if not directory.is_dir():
+            continue
+        for entry in sorted(directory.iterdir()):
+            if not entry.is_file():
+                continue
+            suffix = entry.suffix.casefold()
+            if suffix == WORKSPACE_CACHE_SUFFIX:
+                continue
+            if suffix not in TRAINING_IMAGE_SUFFIXES and suffix != TRAINING_LABEL_SUFFIX:
+                continue
+            if f"{relative_directory}/{entry.name}".casefold() not in expected:
+                raise TrainingPipelineError(
+                    "training workspace contains a training image or label that the approved release does not include."
+                )
+
+
 def _released_release_root_supplied(manifest_path: Path, dataset_root: Path) -> bool:
     """Report whether an external manifest sits inside the supplied dataset root.
 
@@ -467,6 +610,15 @@ def load_training_plan(
         raise TrainingPipelineError("dataset YAML taxonomy must exactly match the approved WalkBuddy IDs, names, and order.")
     _validate_manifest_matches_yaml_splits(manifest, dataset_root, dataset_yaml)
     _inspection_evidence(dataset_root, dataset_config.get("inspection_report_path"))
+    release_checksums_reference: str | None = None
+    release_checksums_checksum: str | None = None
+    if manifest_path_override is not None and stage == RELEASED_STAGE:
+        evidence_path, checksum_identity, release_checksums = _load_release_checksums(manifest_path)
+        _cross_check_release_identity(manifest, checksum_identity)
+        _verify_workspace_checksums(dataset_root, release_checksums)
+        _reject_unexpected_training_files(dataset_root, release_checksums)
+        release_checksums_reference = EXTERNAL_CHECKSUM_REFERENCE
+        release_checksums_checksum = _sha256(evidence_path)
     config_checksum = _sha256(config_path)
     manifest_checksum = _sha256(manifest_path)
     yaml_checksum = _sha256(dataset_yaml_path)
@@ -504,6 +656,8 @@ def load_training_plan(
         manifest_release_decision=str(manifest_dataset["release_decision"]),
         git_commit=commit,
         git_dirty=dirty,
+        release_checksums_reference=release_checksums_reference,
+        release_checksums_checksum=release_checksums_checksum,
     )
 
 
@@ -585,6 +739,8 @@ def _run_metadata(plan: TrainingPlan, status: str, *, started_at: str, completed
         "configuration_checksum_sha256": plan.config_checksum,
         "manifest_checksum_sha256": plan.manifest_checksum,
         "manifest_reference": plan.manifest_reference,
+        "release_checksums_reference": plan.release_checksums_reference,
+        "release_checksums_checksum_sha256": plan.release_checksums_checksum,
         "dataset_yaml_checksum_sha256": plan.dataset_yaml_checksum,
         "model_checksum_sha256": plan.model_checksum,
         "model_kind": plan.model_kind,


### PR DESCRIPTION
## Summary

Real training now resolves its dataset independently of the caller's working directory, and an approved released dataset can no longer be used directly as the trainer's dataset root.

For confirmed training the tool writes an ephemeral trainer-only dataset descriptor into a temporary directory, identical to the approved YAML except that `path` is the absolute root already resolved by preflight. The approved YAML is never modified, the temporary file is never written inside the dataset, and it is removed after the trainer succeeds or fails.

Preflight additionally rejects an external `--manifest-path` whose manifest sits inside the supplied `--dataset-root` when the configured stage is `released`, and persisted failure metadata is sanitised of absolute local paths.

## Failure discovered

The first controlled smoke attempt exposed working-directory-dependent dataset resolution **before the first training iteration**. No training was performed and no checkpoint was produced.

The approved release descriptor declares `path: .`. WalkBuddy preflight resolves that against `--dataset-root`, but Ultralytics 8.4.7 resolves it against the process working directory: in `data/utils.py` the guard is `if not path.exists() and not path.is_absolute()`, and `Path(".").exists()` is already true, so the fallback never runs and the relative root stays bound to the CWD. The trainer therefore looked for images beneath the Git worktree and raised before loading any data.

Two further defects were found while diagnosing it:

- Ultralytics `YOLODataset` derives its label cache location from the label directories (`Path(self.label_files[0]).parent.with_suffix(".cache")`), so a successful run would write `labels/train.cache` into the authoritative release. The `cache` training argument controls image RAM/disk caching and does not disable this.
- The failed run persisted the raw trainer exception in `failure_summary`, including the absolute external release path, bypassing the metadata sanitisation boundary.

## Changes

- adds `runtime_dataset_descriptor()`, an ephemeral trainer-only dataset YAML with an absolute resolved `path`, reusing the existing preflight resolution
- adds `runtime_trainer_arguments()` so the trainer receives the resolved descriptor while `trainer_arguments()` and persisted metadata keep the original sanitised dataset reference
- rejects an external released manifest located inside the supplied `--dataset-root`, in both `--dry-run` and confirmed training
- sanitises persisted failure text, replacing known locations with `<dataset-root>`, `<external-manifest>`, `<repository-root>`, `<run-directory>`, and `<runtime-dataset>`, with a residual sweep to `<local-path>`
- verifies the workspace byte-for-byte against the authoritative `release_checksums.json`
- rejects training images or `.txt` labels the approved release does not contain, while permitting Ultralytics label caches
- records the checksum evidence digest and a sanitised `external-local/release_checksums.json` reference in run metadata
- bumps `TOOL_VERSION` from `1.1.0` to `1.2.0`

`EVALUATION`/configuration `schema_version` stays `1.0.0`: the persisted artifact shape is unchanged, so bumping it would break existing consumers for no benefit.

## Release safety

The authoritative release is read-only evidence. The training workspace is a verified mutable copy.

Training must now be invoked with `--manifest-path` pointing at the authoritative release manifest and `--dataset-root` pointing at a separate local workspace holding the same release bytes. Full `validate_manifest(..., check_files=True)` validation still runs against the workspace, so an incomplete or misplaced copy fails before training starts.

The wrapper does **not** copy, link, junction, or mutate anything. Preparing the workspace is a deliberate step performed outside the tool, so no large filesystem operation is hidden inside training.

### Workspace content verification

Manifest validation alone proves file presence and structure, not content, so the workspace is additionally verified byte-for-byte against the authoritative release.

The release builder emits `release_checksums.json` beside the manifest. Preflight reads that evidence from the **authoritative release directory only**, never from the mutable workspace, and requires: a regular local JSON file rather than a symlink; `algorithm` exactly `sha256`; a valid `release_identity` that matches the identity recorded in the approved manifest, allowing only the documented `sha256:` prefix difference; every listed path safe and release-relative with no traversal, absolute, URL, URI, or UNC form and no duplicates; and every digest a valid SHA-256 hex value.

Each listed file is then resolved beneath the workspace and hashed in chunks. One differing byte fails preflight, before Ultralytics is imported or invoked. The evidence deliberately does not checksum itself or the build reports, which are written after the checksums are computed, and preflight respects that contract.

Verified read-only against the real release evidence: `algorithm` `sha256`, identity `62bff1a8…de0e` cross-checking against the manifest's `sha256:62bff1a8…de0e`, 69,944 checksummed files covering `dataset.yaml`, `release_manifest.json`, 34,971 images, and 34,971 labels.

### Additional training files

Trainers read whole split directories rather than the manifest sample list, so an unlisted image would otherwise enter training. Preflight scans the directories holding checksummed images and labels and rejects any extra training image or `.txt` label the approved release does not contain. Ultralytics label caches such as `labels/train.cache` are expected in a mutable workspace and are permitted.

The invariant is not that the workspace stays byte-identical after training, but that every authoritative training-substantive file stays present and hash-identical and no unexpected training image or text label is introduced.

Verification is strictly read-only: the production code path performs no write, mkdir, copy, chmod, or unlink against the release or the evidence.

## Metadata safety

Known locations are replaced in both backslash and forward-slash spellings, including the doubled-separator form some third-party messages emit (`C://Users/...`). Any residual drive-letter or UNC path is replaced with `<local-path>`, which also covers temporary trainer directories. Enough of the message survives to identify the failure, and console output is unchanged for the local operator.

## Tests

- focused training tests: 128 passed (was 68 on the base branch; 60 added)
- full ML suite with `PYTHONPATH=ML_side`: 510 passed
- `git diff --check`: PASS
- changed Python files compile cleanly

A fixture-backed proof run from an unrelated working directory, with a dataset YAML declaring `path: .`, confirms: the authoritative release root is rejected; a separate workspace yields `dry_run_valid`; runtime data resolves to the workspace rather than the CWD; the descriptor is created outside the dataset and removed afterwards; a simulated label cache lands only in the workspace; the release stays byte-identical; and the sanitised failure text retains zero absolute paths.

A second fixture proof covers workspace integrity, with the authoritative release confirmed unchanged in every case:

| Scenario | Result |
|---|---|
| faithful workspace | `dry_run_valid` |
| one-byte image mutation | rejected |
| one-byte label mutation | rejected |
| one-byte `dataset.yaml` mutation | rejected |
| workspace manifest mutation | rejected |
| missing checksummed file | rejected |
| extra training image | rejected |
| extra `.txt` label | rejected |
| `labels.cache` beside labels dir | accepted |
| `.cache` inside a scanned dir | accepted |

## Scope

- no model training
- no model weights
- no dataset modification
- no controlled-release modification
- no promotion
- no backend or frontend changes
- no full training

The failed smoke run's evidence is preserved unchanged and is not represented as successful training.

