### PR TITLE
Fix exterior nav map controls, path color, header alignment, and Visi…

### DIFF
--- a/software_side/walkbuddy_reactNative/frontend_reactNative/app/(tabs)/exterior.tsx
+++ b/software_side/walkbuddy_reactNative/frontend_reactNative/app/(tabs)/exterior.tsx
@@ -824,6 +824,7 @@ export default function ExteriorNavigationScreen() {
             routeGeometry={route?.geometry}
             destination={destination || undefined}
             showMap={settings.showMapVisuals}
+            routeColor={GOLD}
           />
         </View>
       </View>
@@ -1136,10 +1137,9 @@ const styles = StyleSheet.create({
   wrap: { flex: 1, backgroundColor: "#1B263B" },
 
   header: {
-    position: "relative",
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
+    gap: 12,
     paddingHorizontal: 16,
     paddingTop: 14,
     paddingBottom: 8,
@@ -1147,9 +1147,6 @@ const styles = StyleSheet.create({
     borderBottomColor: GOLD,
   },
   backBtnFloating: {
-    position: "absolute",
-    top: 4,
-    left: 8,
     width: 44,
     height: 44,
     borderRadius: 22,
@@ -1158,17 +1155,14 @@ const styles = StyleSheet.create({
     borderColor: GOLD,
     alignItems: "center",
     justifyContent: "center",
-    zIndex: 20,
   },
   headerTitle: {
     color: GOLD,
     fontSize: 20,
     fontWeight: "800",
     flex: 1,
-    paddingLeft: 52,
   },
   headerEditBtn: {
-    position: "absolute", right: 14, top: 14,
     width: 40, height: 40, borderRadius: 12,
     alignItems: "center", justifyContent: "center",
     backgroundColor: "#10233d", borderWidth: 1.5,

--- a/software_side/walkbuddy_reactNative/frontend_reactNative/app/(tabs)/index.tsx
+++ b/software_side/walkbuddy_reactNative/frontend_reactNative/app/(tabs)/index.tsx
@@ -19,8 +19,6 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import Icon from "react-native-vector-icons/FontAwesome";
 
 import HomeHeader from "../HomeHeader";
-import ModelWebView from "../../src/components/ModelWebView";
-import { API_BASE } from "../../src/config";
 import { useSession } from "../../src/context/SessionContext";
 
 type DestinationType = "I" | "E";
@@ -40,9 +38,6 @@ export default function HomePage() {
   const greeting = `Hi ${displayName}`;
 
   const [visionEnabled, setVisionEnabled] = useState(true);
-  const [visionPreviewOn, setVisionPreviewOn] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [rev, setRev] = useState(0);
   const [showSearch, setShowSearch] = useState(false);
   const [query, setQuery] = useState("");
   const [destinationType, setDestinationType] = useState<DestinationType | null>(null);
@@ -66,37 +61,15 @@ export default function HomePage() {
   const goToCameraOCR = () =>
     router.push({ pathname: "/camera", params: { mode: "ocr" } } as any);
 
+  const goToCameraVision = () =>
+    router.push({ pathname: "/camera", params: { mode: "vision" } } as any);
+
   const goToScreenReader = () => {
     const title = "Coming soon";
     const msg = "Screen Reader is not implemented yet.";
     Platform.OS === "web"
       ? (globalThis as any).alert?.(`${title}\n\n${msg}`)
       : Alert.alert(title, msg);
-  };
-
-  useEffect(() => {
-    if (!visionEnabled) {
-      setVisionPreviewOn(false);
-      setLoading(false);
-    }
-  }, [visionEnabled]);
-
-  useEffect(() => {
-    if (!visionPreviewOn) {
-      setLoading(false);
-      return;
-    }
-    setLoading(true);
-    setRev((x) => x + 1);
-    const t = setTimeout(() => setLoading(false), 800);
-    return () => clearTimeout(t);
-  }, [visionPreviewOn]);
-
-  const visionUrl = `${API_BASE}/vision/?v=${rev}`;
-
-  const toggleVisionPreview = () => {
-    if (!visionEnabled) return;
-    setVisionPreviewOn((prev) => !prev);
   };
 
   const openSearch = () => {
@@ -183,12 +156,7 @@ export default function HomePage() {
           </View>
 
           {/* VISION */}
-          <View
-            style={[
-              styles.visionWrapper,
-              visionPreviewOn && styles.visionActive,
-            ]}
-          >
+          <View style={styles.visionWrapper}>
             <View style={styles.visionRow}>
               <Text style={styles.visionTitle}>VISION ASSIST</Text>
 
@@ -207,26 +175,23 @@ export default function HomePage() {
             </View>
 
             <Pressable
-              onPress={toggleVisionPreview}
+              onPress={goToCameraVision}
+              disabled={!visionEnabled}
               style={({ pressed }) => [
                 styles.visionCard,
                 pressed && styles.pressed,
               ]}
             >
               <View style={styles.visionInner}>
-                {visionEnabled && visionPreviewOn ? (
-                  <ModelWebView url={visionUrl} loading={loading} />
-                ) : (
-                  <View style={styles.previewPlaceholder}>
-                    <Icon name="eye" size={28} color={tokens.muted} />
-                    <Text style={styles.previewText}>
-                      {visionEnabled ? "Tap to start camera" : "Vision disabled"}
-                    </Text>
-                    <Text style={styles.previewSubtext}>
-                      Starting camera gives live surroundings
-                    </Text>
-                  </View>
-                )}
+                <View style={styles.previewPlaceholder}>
+                  <Icon name="eye" size={28} color={tokens.muted} />
+                  <Text style={styles.previewText}>
+                    {visionEnabled ? "Tap to start camera" : "Vision disabled"}
+                  </Text>
+                  <Text style={styles.previewSubtext}>
+                    Starting camera gives live surroundings
+                  </Text>
+                </View>
               </View>
             </Pressable>
           </View>
@@ -333,7 +298,6 @@ export default function HomePage() {
 
 /* COMPONENTS */
 
-// Search button component with press animation
 function BounceButton({ label, onPress, search }: { label: string; onPress: () => void; search?: boolean }) {
   const scale = useRef(new Animated.Value(1)).current;
   const overlayOpacity = useRef(new Animated.Value(0)).current;
@@ -385,7 +349,7 @@ function BounceButton({ label, onPress, search }: { label: string; onPress: () =
         />
         <Icon
           name="search"
-          size={18}
+          size={16}
           color={tokens.text}
           style={styles.searchIcon}
         />
@@ -395,7 +359,6 @@ function BounceButton({ label, onPress, search }: { label: string; onPress: () =
   );
 }
 
-// Feature card component with press animation
 function ActionTile({
   icon,
   label,
@@ -459,7 +422,7 @@ function ActionTile({
 
             <Icon
               name={icon}
-              size={28}
+              size={24}
               color="#071a2a"
               style={styles.tileIcon}
             />
@@ -519,45 +482,39 @@ const styles = StyleSheet.create({
     paddingTop: 10,
   },
 
-  // Search button styling
   searchButton: {
-   width: "100%",
-  backgroundColor: "#12314a",
-  borderWidth: 2,
-  borderColor: tokens.gold,
-  borderRadius: 18,
-  paddingVertical: 18,
-  paddingHorizontal: 20,
-  flexDirection: "row",
-  alignItems: "center",
-  justifyContent: "center",
-  gap: 10,
-  marginBottom: 12,
-  overflow: "hidden",
-  shadowColor: "#000",
-  shadowOffset: { width: 0, height: 3 },
-  shadowOpacity: 0.18,
-  shadowRadius: 8,
-  elevation: 5,
+    width: "100%",
+    backgroundColor: "#12314a",
+    borderWidth: 2,
+    borderColor: tokens.gold,
+    borderRadius: 50,
+    paddingVertical: 20,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
+    marginBottom: 20,
+    overflow: "hidden",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.18,
+    shadowRadius: 6,
+    elevation: 4,
   },
 
-  // Search button icon
   searchIcon: {
     marginRight: 2,
   },
 
-  // Press animation overlay
   searchPressOverlay: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: "rgba(255,255,255,0.10)",
   },
 
-  // Search button text
   searchText: {
     color: tokens.text,
-    fontSize: 17,
-    fontWeight: "800",
-    letterSpacing: 0.5,
+    fontSize: 18,
+    fontWeight: "900",
   },
 
   sectionCard: {
@@ -581,32 +538,28 @@ const styles = StyleSheet.create({
     gap: 10,
   },
 
-  // Feature card container
   tile: {
     width: "48%",
-    marginBottom:8,
   },
 
-  // Feature card outer border
   tileOuter: {
     borderWidth: 2,
     borderColor: tokens.gold,
-    borderRadius: 20,
+    borderRadius: 22,
     shadowColor: tokens.gold,
     shadowOffset: { width: 0, height: 0 },
-    shadowOpacity: 0.3,
-    shadowRadius: 10,
+    shadowOpacity: 0.6,
+    shadowRadius: 16,
     elevation: 6,
   },
 
-  // Feature card content
   tileInner: {
     width: "100%",
     backgroundColor: tokens.gold,
     borderRadius: 20,
-    minHeight: 120,
-    paddingVertical: 20,
-    paddingHorizontal: 12,
+    minHeight: 108,
+    paddingVertical: 18,
+    paddingHorizontal: 8,
     alignItems: "center",
     gap: 8,
     overflow: "hidden",
@@ -617,68 +570,47 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(255,255,255,0.15)",
   },
 
-  // Feature card icon
   tileIcon: {},
 
-  // Feature card title
   tileText: {
     color: "#071a2a",
-    fontSize: 13,
+    fontSize: 12,
     fontWeight: "800",
     textAlign: "center",
+    letterSpacing: 0.3,
+  },
+
+  visionWrapper: {
+    backgroundColor: tokens.card,
+    borderRadius: 16,
+    padding: 12,
+  },
+
+  visionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 8,
+  },
+
+  visionTitle: {
+    color: tokens.text,
+    fontSize: 15,
+    fontWeight: "900",
     letterSpacing: 0.5,
   },
 
-// Vision Assist section container
- visionWrapper: {
-  backgroundColor: "#0b1520",
-  borderRadius: 20,
-  padding: 16,
-  marginTop: 8,
-  marginBottom: 12,
+  visionToggle: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
 
-  shadowColor: "#000",
-  shadowOffset: { width: 0, height: 4 },
-  shadowOpacity: 0.25,
-  shadowRadius: 8,
-  elevation: 5,
-},
-
-  // Highlight Vision Assist when active
-visionActive: {
-  borderWidth: 2,
-  borderColor: tokens.gold,
-},
-
- // Vision header layout
-visionRow: {
-  flexDirection: "row",
-  alignItems: "center",
-  justifyContent: "space-between",
-  marginBottom: 14,
-},
-
-  // Vision Assist heading
-visionTitle: {
-  color: tokens.text,
-  fontSize: 22,
-  fontWeight: "900",
-  letterSpacing: 0.8,
-},
-
-  // Vision toggle layout
-visionToggle: {
-  flexDirection: "row",
-  alignItems: "center",
-  gap: 10,
-},
-
-  // Toggle status text
-visionToggleText: {
-  color: tokens.text,
-  fontSize: 15,
-  fontWeight: "700",
-},
+  visionToggleText: {
+    color: tokens.muted,
+    fontSize: 12,
+    fontWeight: "700",
+  },
 
   visionCard: {
     width: "100%",

--- a/software_side/walkbuddy_reactNative/frontend_reactNative/src/components/MapPanel.tsx
+++ b/software_side/walkbuddy_reactNative/frontend_reactNative/src/components/MapPanel.tsx
@@ -10,6 +10,7 @@ interface MapPanelProps {
   routeGeometry?: number[][]; // Full route polyline [[lat, lng], ...]
   destination?: { lat: number; lng: number; name?: string };
   showMap: boolean;
+  routeColor?: string; // Color for the route polyline + destination marker
 }
 
 export default function MapPanel({
@@ -18,6 +19,7 @@ export default function MapPanel({
   routeGeometry,
   destination,
   showMap,
+  routeColor,
 }: MapPanelProps) {
   if (!showMap) {
     return <MinimalVisualPanel />;
@@ -26,7 +28,7 @@ export default function MapPanel({
   // For native platforms, use WebView
   return (
     <WebView
-      source={{ html: generateMapHTML(currentLocation, routeGeometry, destination) }}
+      source={{ html: generateMapHTML(currentLocation, routeGeometry, destination, routeColor) }}
       style={styles.webview}
       javaScriptEnabled
       domStorageEnabled
@@ -48,10 +50,12 @@ function MinimalVisualPanel() {
 function generateMapHTML(
   currentLocation?: Location,
   routeGeometry?: number[][],
-  destination?: { lat: number; lng: number; name?: string }
+  destination?: { lat: number; lng: number; name?: string },
+  routeColor?: string
 ): string {
   const lat = currentLocation?.latitude ?? (destination?.lat ?? 0);
   const lng = currentLocation?.longitude ?? (destination?.lng ?? 0);
+  const color = routeColor ?? '#f9b233';
 
   // Use route geometry if available, otherwise fall back to destination
   const hasRoute = routeGeometry && routeGeometry.length > 0;
@@ -67,6 +71,7 @@ function generateMapHTML(
   <style>
     body { margin: 0; padding: 0; overflow: hidden; }
     #map { width: 100%; height: 100vh; }
+    .leaflet-top.leaflet-left { top: 18px; left: 18px; }
   </style>
 </head>
 <body>
@@ -93,7 +98,7 @@ function generateMapHTML(
     const destMarker = L.marker([${destination.lat}, ${destination.lng}], {
       icon: L.divIcon({
         className: 'destination-marker',
-        html: '<div style="background-color: #f9b233; width: 20px; height: 20px; border-radius: 50%; border: 3px solid white; box-shadow: 0 2px 4px rgba(0,0,0,0.3);"></div>',
+        html: '<div style="background-color: ${color}; width: 20px; height: 20px; border-radius: 50%; border: 3px solid white; box-shadow: 0 2px 4px rgba(0,0,0,0.3);"></div>',
         iconSize: [20, 20],
         iconAnchor: [10, 10]
       })
@@ -103,8 +108,8 @@ function generateMapHTML(
 
     ${hasRoute ? `
     const routeCoords = ${JSON.stringify(routeGeometry)};
-    const polyline = L.polyline(routeCoords, { 
-      color: '#f9b233', 
+    const polyline = L.polyline(routeCoords, {
+      color: '${color}',
       weight: 5,
       opacity: 0.8,
       lineJoin: 'round',

--- a/software_side/walkbuddy_reactNative/frontend_reactNative/src/components/MapPanel.web.tsx
+++ b/software_side/walkbuddy_reactNative/frontend_reactNative/src/components/MapPanel.web.tsx
@@ -9,6 +9,7 @@ interface MapPanelProps {
   routeGeometry?: number[][]; // Full route polyline [[lat, lng], ...]
   destination?: { lat: number; lng: number; name?: string };
   showMap: boolean;
+  routeColor?: string; // Color for the route polyline + destination marker
 }
 
 export default function MapPanel({
@@ -17,6 +18,7 @@ export default function MapPanel({
   routeGeometry,
   destination,
   showMap,
+  routeColor,
 }: MapPanelProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -28,7 +30,7 @@ export default function MapPanel({
       return;
     }
 
-    const html = generateMapHTML(currentLocation, routeGeometry, destination);
+    const html = generateMapHTML(currentLocation, routeGeometry, destination, routeColor);
     
     if (containerRef.current) {
       containerRef.current.innerHTML = '';
@@ -41,7 +43,7 @@ export default function MapPanel({
       iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
       containerRef.current.appendChild(iframe);
     }
-  }, [currentLocation, routeGeometry, destination, showMap]);
+  }, [currentLocation, routeGeometry, destination, showMap, routeColor]);
 
   if (!showMap) {
     return <MinimalVisualPanel />;
@@ -67,10 +69,12 @@ function MinimalVisualPanel() {
 function generateMapHTML(
   currentLocation?: Location,
   routeGeometry?: number[][],
-  destination?: { lat: number; lng: number; name?: string }
+  destination?: { lat: number; lng: number; name?: string },
+  routeColor?: string
 ): string {
   const lat = currentLocation?.latitude ?? (destination?.lat ?? 0);
   const lng = currentLocation?.longitude ?? (destination?.lng ?? 0);
+  const color = routeColor ?? '#f9b233';
 
   // Use route geometry if available, otherwise fall back to destination
   const hasRoute = routeGeometry && routeGeometry.length > 0;
@@ -86,6 +90,7 @@ function generateMapHTML(
   <style>
     body { margin: 0; padding: 0; overflow: hidden; }
     #map { width: 100%; height: 100vh; }
+    .leaflet-top.leaflet-left { top: 18px; left: 18px; }
   </style>
 </head>
 <body>
@@ -112,7 +117,7 @@ function generateMapHTML(
     const destMarker = L.marker([${destination.lat}, ${destination.lng}], {
       icon: L.divIcon({
         className: 'destination-marker',
-        html: '<div style="background-color: #f9b233; width: 20px; height: 20px; border-radius: 50%; border: 3px solid white; box-shadow: 0 2px 4px rgba(0,0,0,0.3);"></div>',
+        html: '<div style="background-color: ${color}; width: 20px; height: 20px; border-radius: 50%; border: 3px solid white; box-shadow: 0 2px 4px rgba(0,0,0,0.3);"></div>',
         iconSize: [20, 20],
         iconAnchor: [10, 10]
       })
@@ -122,8 +127,8 @@ function generateMapHTML(
 
     ${hasRoute ? `
     const routeCoords = ${JSON.stringify(routeGeometry)};
-    const polyline = L.polyline(routeCoords, { 
-      color: '#f9b233', 
+    const polyline = L.polyline(routeCoords, {
+      color: '${color}',
       weight: 5,
       opacity: 0.8,
       lineJoin: 'round',


### PR DESCRIPTION
…on Assist camera error

- MapPanel: clear Leaflet's default zoom control from the rounded/clipped corner of the map preview, and source the route/marker color from a routeColor prop instead of a hardcoded hex value (native + web variants)
- exterior.tsx: pass routeColor=GOLD to MapPanel; replace the header's absolute-positioning hack with a plain flex row so the back button, title, and pin/edit-location icon are aligned
- index.tsx: Vision Assist tile now navigates to the working Camera screen in vision mode instead of loading a WebView pointed at a GET /vision route that does not exist on the backend; removed the now-dead preview state/effects